### PR TITLE
Multi-tab support with WinUI 2 TabView + DirectComposition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,10 @@ Release/
 .vs/
 *.vcxproj.user
 
+# NuGet
+packages/
+Generated Files/
+
 # Ghostty DLL and import library (build from source)
 ghostty/ghostty.dll
 ghostty/ghostty.lib

--- a/GhosttyBridge.cpp
+++ b/GhosttyBridge.cpp
@@ -246,6 +246,21 @@ LRESULT CALLBACK GhosttyBridge::glWndProc(HWND hwnd, UINT msg, WPARAM wParam, LP
     const bool hasSurface = sess && sess->surface;
 
     switch (msg) {
+    case WM_NCHITTEST: {
+        // Transparent at resize edges — let the parent handle resizing.
+        POINT pt = { GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam) };
+        HWND parent = GetParent(hwnd);
+        if (parent) {
+            RECT parentRc;
+            GetWindowRect(parent, &parentRc);
+            const int border = 6;
+            if (pt.x - parentRc.left < border || parentRc.right - pt.x < border ||
+                pt.y - parentRc.top < border || parentRc.bottom - pt.y < border) {
+                return HTTRANSPARENT;
+            }
+        }
+        break;
+    }
     case WM_CHAR: {
         if (!hasSurface || wParam < 0x20) return 0;
         // Handle UTF-16 surrogate pairs (emoji etc.)

--- a/GhosttyBridge.cpp
+++ b/GhosttyBridge.cpp
@@ -135,18 +135,27 @@ bool GhosttyBridge::initialize() {
 }
 
 void GhosttyBridge::shutdown() {
+    // Free all sessions before tearing down the app
+    for (auto& sess : m_sessions) {
+        if (sess->surface) {
+            ghostty_surface_free(sess->surface);
+            sess->surface = nullptr;
+        }
+        shutdownOpenGL(sess.get());
+    }
+    m_sessions.clear();
+
     if (m_app) {
         ghostty_app_free(m_app);
         m_app = nullptr;
     }
-    shutdownOpenGL();
     m_config = nullptr;
     m_initialized = false;
 }
 
-bool GhosttyBridge::initOpenGL(HWND hwnd) {
-    m_hdc = GetDC(hwnd);
-    if (!m_hdc) {
+bool GhosttyBridge::initOpenGL(TerminalSession* session) {
+    session->hdc = GetDC(session->hwnd);
+    if (!session->hdc) {
         DBG_LOG("ghostty: GetDC failed\n");
         return false;
     }
@@ -161,24 +170,24 @@ bool GhosttyBridge::initOpenGL(HWND hwnd) {
     pfd.cDepthBits = 24;
     pfd.cStencilBits = 8;
 
-    int pixelFormat = ChoosePixelFormat(m_hdc, &pfd);
+    int pixelFormat = ChoosePixelFormat(session->hdc, &pfd);
     if (pixelFormat == 0) {
         DBG_LOG("ghostty: ChoosePixelFormat failed\n");
         return false;
     }
 
-    if (!SetPixelFormat(m_hdc, pixelFormat, &pfd)) {
+    if (!SetPixelFormat(session->hdc, pixelFormat, &pfd)) {
         DBG_LOG("ghostty: SetPixelFormat failed\n");
         return false;
     }
 
-    m_hglrc = wglCreateContext(m_hdc);
-    if (!m_hglrc) {
+    session->hglrc = wglCreateContext(session->hdc);
+    if (!session->hglrc) {
         DBG_LOG("ghostty: wglCreateContext failed\n");
         return false;
     }
 
-    if (!wglMakeCurrent(m_hdc, m_hglrc)) {
+    if (!wglMakeCurrent(session->hdc, session->hglrc)) {
         DBG_LOG("ghostty: wglMakeCurrent failed\n");
         return false;
     }
@@ -190,7 +199,7 @@ bool GhosttyBridge::initOpenGL(HWND hwnd) {
     auto wglSwapIntervalEXT = (PFNWGLSWAPINTERVALEXTPROC)wglGetProcAddress("wglSwapIntervalEXT");
     if (wglSwapIntervalEXT) {
         wglSwapIntervalEXT(0); // V-Sync OFF for low latency
-        DBG_LOG(m_vsync ? "ghostty: V-Sync ON\n" : "ghostty: V-Sync OFF\n");
+        DBG_LOG("ghostty: V-Sync OFF\n");
     }
 
     const char* version = (const char*)glGetString(GL_VERSION);
@@ -203,23 +212,38 @@ bool GhosttyBridge::initOpenGL(HWND hwnd) {
     return true;
 }
 
-void GhosttyBridge::shutdownOpenGL() {
-    if (m_hglrc) {
+void GhosttyBridge::shutdownOpenGL(TerminalSession* session) {
+    if (session->hglrc) {
         wglMakeCurrent(nullptr, nullptr);
-        wglDeleteContext(m_hglrc);
-        m_hglrc = nullptr;
+        wglDeleteContext(session->hglrc);
+        session->hglrc = nullptr;
     }
     // HDC is released when window is destroyed
-    m_hdc = nullptr;
+    session->hdc = nullptr;
+}
+
+TerminalSession* GhosttyBridge::sessionFromSurface(ghostty_surface_t surface) {
+    if (!surface) return nullptr;
+    return static_cast<TerminalSession*>(ghostty_surface_userdata(surface));
 }
 
 LRESULT CALLBACK GhosttyBridge::glWndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
+    // Stash the TerminalSession* passed via CreateWindowEx lpParam
+    if (msg == WM_NCCREATE) {
+        auto* cs = reinterpret_cast<CREATESTRUCTW*>(lParam);
+        SetWindowLongPtrW(hwnd, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(cs->lpCreateParams));
+    }
+
+    auto* sess = reinterpret_cast<TerminalSession*>(GetWindowLongPtrW(hwnd, GWLP_USERDATA));
     auto& bridge = GhosttyBridge::instance();
+
+    // Helper that's true only when this window has a fully-initialized session
+    const bool hasSurface = sess && sess->surface;
 
     switch (msg) {
     case WM_NCCALCSIZE: {
         // When decorations are hidden, extend client area to cover the entire window
-        if (!bridge.m_decorations && wParam == TRUE) {
+        if (sess && !sess->decorations && wParam == TRUE) {
             // Return 0 to make client area = window area (no frame)
             return 0;
         }
@@ -227,7 +251,7 @@ LRESULT CALLBACK GhosttyBridge::glWndProc(HWND hwnd, UINT msg, WPARAM wParam, LP
     }
     case WM_NCHITTEST: {
         // Allow drag and resize when window decorations are hidden
-        if (!bridge.m_decorations) {
+        if (sess && !sess->decorations) {
             RECT rc;
             GetClientRect(hwnd, &rc);
             POINT pt = { GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam) };
@@ -255,7 +279,7 @@ LRESULT CALLBACK GhosttyBridge::glWndProc(HWND hwnd, UINT msg, WPARAM wParam, LP
         break;
     }
     case WM_CHAR: {
-        if (!bridge.m_surface || wParam < 0x20) return 0;
+        if (!hasSurface || wParam < 0x20) return 0;
         // Handle UTF-16 surrogate pairs (emoji etc.)
         static wchar_t highSurrogate = 0;
         if (IS_HIGH_SURROGATE(wParam)) {
@@ -276,15 +300,15 @@ LRESULT CALLBACK GhosttyBridge::glWndProc(HWND hwnd, UINT msg, WPARAM wParam, LP
         char utf8[8] = {};
         int len = WideCharToMultiByte(CP_UTF8, 0, utf16, utf16Len, utf8, sizeof(utf8), nullptr, nullptr);
         if (len > 0) {
-            ghostty_surface_text(bridge.m_surface, utf8, len);
+            ghostty_surface_text(sess->surface, utf8, len);
             if (bridge.m_app) ghostty_app_tick(bridge.m_app);
-            ghostty_surface_refresh(bridge.m_surface);
+            ghostty_surface_refresh(sess->surface);
         }
         return 0;
     }
     case WM_KEYDOWN:
     case WM_KEYUP: {
-        if (!bridge.m_surface) break;
+        if (!hasSurface) break;
 
         // Only handle keys that don't generate WM_CHAR
         bool isSpecialKey = false;
@@ -303,14 +327,14 @@ LRESULT CALLBACK GhosttyBridge::glWndProc(HWND hwnd, UINT msg, WPARAM wParam, LP
         }
         // Ctrl+C = copy selection or send SIGINT
         if ((GetKeyState(VK_CONTROL) & 0x8000) && wParam == 'C' && msg == WM_KEYDOWN) {
-            if (bridge.m_surface && ghostty_surface_has_selection(bridge.m_surface)) {
+            if (ghostty_surface_has_selection(sess->surface)) {
                 ghostty_text_s text = {};
-                if (ghostty_surface_read_selection(bridge.m_surface, &text) && text.text && text.text_len > 0) {
+                if (ghostty_surface_read_selection(sess->surface, &text) && text.text && text.text_len > 0) {
                     copyToClipboard(hwnd, text.text, text.text_len);
                 }
                 // Clear selection
-                ghostty_surface_mouse_button(bridge.m_surface, GHOSTTY_MOUSE_PRESS, GHOSTTY_MOUSE_LEFT, GHOSTTY_MODS_NONE);
-                ghostty_surface_mouse_button(bridge.m_surface, GHOSTTY_MOUSE_RELEASE, GHOSTTY_MOUSE_LEFT, GHOSTTY_MODS_NONE);
+                ghostty_surface_mouse_button(sess->surface, GHOSTTY_MOUSE_PRESS, GHOSTTY_MOUSE_LEFT, GHOSTTY_MODS_NONE);
+                ghostty_surface_mouse_button(sess->surface, GHOSTTY_MOUSE_RELEASE, GHOSTTY_MOUSE_LEFT, GHOSTTY_MODS_NONE);
 
                 return 0;
             }
@@ -318,7 +342,7 @@ LRESULT CALLBACK GhosttyBridge::glWndProc(HWND hwnd, UINT msg, WPARAM wParam, LP
         }
         // Ctrl+V = paste from clipboard directly
         if ((GetKeyState(VK_CONTROL) & 0x8000) && wParam == 'V' && msg == WM_KEYDOWN) {
-            if (bridge.m_surface && bridge.m_glWindow && OpenClipboard(bridge.m_glWindow)) {
+            if (OpenClipboard(hwnd)) {
                 HANDLE hData = GetClipboardData(CF_UNICODETEXT);
                 if (hData) {
                     wchar_t* wText = static_cast<wchar_t*>(GlobalLock(hData));
@@ -327,7 +351,7 @@ LRESULT CALLBACK GhosttyBridge::glWndProc(HWND hwnd, UINT msg, WPARAM wParam, LP
                         if (utf8Len > 0) {
                             std::vector<char> utf8(utf8Len);
                             WideCharToMultiByte(CP_UTF8, 0, wText, -1, utf8.data(), utf8Len, nullptr, nullptr);
-                            ghostty_surface_text(bridge.m_surface, utf8.data(), utf8Len - 1);
+                            ghostty_surface_text(sess->surface, utf8.data(), utf8Len - 1);
                         }
                         GlobalUnlock(hData);
                     }
@@ -360,7 +384,7 @@ LRESULT CALLBACK GhosttyBridge::glWndProc(HWND hwnd, UINT msg, WPARAM wParam, LP
         if (GetKeyState(VK_CONTROL) & 0x8000) keyEvent.mods = (ghostty_input_mods_e)(keyEvent.mods | GHOSTTY_MODS_CTRL);
         if (GetKeyState(VK_MENU) & 0x8000) keyEvent.mods = (ghostty_input_mods_e)(keyEvent.mods | GHOSTTY_MODS_ALT);
 
-        ghostty_surface_key(bridge.m_surface, keyEvent);
+        ghostty_surface_key(sess->surface, keyEvent);
 
         // When modifier keys change, re-send mouse position so ghostty
         // can update link detection (e.g. Ctrl+hover to highlight URLs)
@@ -369,7 +393,7 @@ LRESULT CALLBACK GhosttyBridge::glWndProc(HWND hwnd, UINT msg, WPARAM wParam, LP
             wParam == VK_MENU || wParam == VK_LMENU || wParam == VK_RMENU) {
             POINT pt;
             if (GetCursorPos(&pt) && ScreenToClient(hwnd, &pt)) {
-                ghostty_surface_mouse_pos(bridge.m_surface, (double)pt.x, (double)pt.y, keyEvent.mods);
+                ghostty_surface_mouse_pos(sess->surface, (double)pt.x, (double)pt.y, keyEvent.mods);
             }
         }
 
@@ -383,18 +407,20 @@ LRESULT CALLBACK GhosttyBridge::glWndProc(HWND hwnd, UINT msg, WPARAM wParam, LP
         return 0;
     }
     case WM_GETMINMAXINFO: {
-        auto* mmi = reinterpret_cast<MINMAXINFO*>(lParam);
-        if (bridge.m_minWidth > 0) mmi->ptMinTrackSize.x = bridge.m_minWidth;
-        if (bridge.m_minHeight > 0) mmi->ptMinTrackSize.y = bridge.m_minHeight;
-        if (bridge.m_maxWidth > 0) mmi->ptMaxTrackSize.x = bridge.m_maxWidth;
-        if (bridge.m_maxHeight > 0) mmi->ptMaxTrackSize.y = bridge.m_maxHeight;
+        if (sess) {
+            auto* mmi = reinterpret_cast<MINMAXINFO*>(lParam);
+            if (sess->minWidth > 0) mmi->ptMinTrackSize.x = sess->minWidth;
+            if (sess->minHeight > 0) mmi->ptMinTrackSize.y = sess->minHeight;
+            if (sess->maxWidth > 0) mmi->ptMaxTrackSize.x = sess->maxWidth;
+            if (sess->maxHeight > 0) mmi->ptMaxTrackSize.y = sess->maxHeight;
+        }
         return 0;
     }
     case WM_CLOSE:
-        // Clean up ghostty before destroying the window
-        if (bridge.m_surface) {
-            ghostty_surface_free(bridge.m_surface);
-            bridge.m_surface = nullptr;
+        // Clean up this session and quit the app when no sessions remain.
+        // (Phase 1 only ever creates one session, so this still terminates the app.)
+        if (sess) {
+            bridge.destroySession(sess);
         }
         bridge.shutdown();
         PostQuitMessage(0);
@@ -405,81 +431,81 @@ LRESULT CALLBACK GhosttyBridge::glWndProc(HWND hwnd, UINT msg, WPARAM wParam, LP
         if (width > 0 && height > 0) {
             // Notify DirectX renderer of new size (thread-safe atomic write)
             dx_notify_resize(width, height);
-            if (bridge.m_surface) {
-                ghostty_surface_set_size(bridge.m_surface, width, height);
-                ghostty_surface_refresh(bridge.m_surface);
+            if (hasSurface) {
+                ghostty_surface_set_size(sess->surface, width, height);
+                ghostty_surface_refresh(sess->surface);
             }
         }
         return 0;
     }
     case WM_MOUSEMOVE: {
-        if (bridge.m_surface) {
+        if (hasSurface) {
             double x = (double)GET_X_LPARAM(lParam);
             double y = (double)GET_Y_LPARAM(lParam);
             ghostty_input_mods_e mods = GHOSTTY_MODS_NONE;
             if (wParam & MK_SHIFT) mods = (ghostty_input_mods_e)(mods | GHOSTTY_MODS_SHIFT);
             if (wParam & MK_CONTROL) mods = (ghostty_input_mods_e)(mods | GHOSTTY_MODS_CTRL);
-            ghostty_surface_mouse_pos(bridge.m_surface, x, y, mods);
+            ghostty_surface_mouse_pos(sess->surface, x, y, mods);
         }
         return 0;
     }
     case WM_LBUTTONDOWN:
     case WM_LBUTTONUP: {
-        if (bridge.m_surface) {
+        if (hasSurface) {
             auto state = (msg == WM_LBUTTONDOWN) ? GHOSTTY_MOUSE_PRESS : GHOSTTY_MOUSE_RELEASE;
             ghostty_input_mods_e mods = GHOSTTY_MODS_NONE;
             if (wParam & MK_SHIFT) mods = (ghostty_input_mods_e)(mods | GHOSTTY_MODS_SHIFT);
             if (wParam & MK_CONTROL) mods = (ghostty_input_mods_e)(mods | GHOSTTY_MODS_CTRL);
-            ghostty_surface_mouse_button(bridge.m_surface, state, GHOSTTY_MOUSE_LEFT, mods);
+            ghostty_surface_mouse_button(sess->surface, state, GHOSTTY_MOUSE_LEFT, mods);
             if (msg == WM_LBUTTONDOWN) SetCapture(hwnd);
             else ReleaseCapture();
         }
         return 0;
     }
     case WM_RBUTTONDOWN: {
-        if (bridge.m_surface) {
-            if (ghostty_surface_has_selection(bridge.m_surface)) {
+        if (hasSurface) {
+            if (ghostty_surface_has_selection(sess->surface)) {
                 ghostty_text_s text = {};
-                if (ghostty_surface_read_selection(bridge.m_surface, &text) && text.text && text.text_len > 0) {
+                if (ghostty_surface_read_selection(sess->surface, &text) && text.text && text.text_len > 0) {
                     copyToClipboard(hwnd, text.text, text.text_len);
                 }
                 // Clear selection
-                ghostty_surface_mouse_button(bridge.m_surface, GHOSTTY_MOUSE_PRESS, GHOSTTY_MOUSE_LEFT, GHOSTTY_MODS_NONE);
-                ghostty_surface_mouse_button(bridge.m_surface, GHOSTTY_MOUSE_RELEASE, GHOSTTY_MOUSE_LEFT, GHOSTTY_MODS_NONE);
+                ghostty_surface_mouse_button(sess->surface, GHOSTTY_MOUSE_PRESS, GHOSTTY_MOUSE_LEFT, GHOSTTY_MODS_NONE);
+                ghostty_surface_mouse_button(sess->surface, GHOSTTY_MOUSE_RELEASE, GHOSTTY_MOUSE_LEFT, GHOSTTY_MODS_NONE);
 
             } else {
-                ghostty_surface_mouse_button(bridge.m_surface, GHOSTTY_MOUSE_PRESS, GHOSTTY_MOUSE_RIGHT, GHOSTTY_MODS_NONE);
+                ghostty_surface_mouse_button(sess->surface, GHOSTTY_MOUSE_PRESS, GHOSTTY_MOUSE_RIGHT, GHOSTTY_MODS_NONE);
             }
         }
         return 0;
     }
     case WM_RBUTTONUP: {
-        if (bridge.m_surface) {
-            ghostty_surface_mouse_button(bridge.m_surface, GHOSTTY_MOUSE_RELEASE, GHOSTTY_MOUSE_RIGHT, GHOSTTY_MODS_NONE);
+        if (hasSurface) {
+            ghostty_surface_mouse_button(sess->surface, GHOSTTY_MOUSE_RELEASE, GHOSTTY_MOUSE_RIGHT, GHOSTTY_MODS_NONE);
         }
         return 0;
     }
     case WM_MBUTTONDOWN:
     case WM_MBUTTONUP: {
-        if (bridge.m_surface) {
+        if (hasSurface) {
             auto state = (msg == WM_MBUTTONDOWN) ? GHOSTTY_MOUSE_PRESS : GHOSTTY_MOUSE_RELEASE;
-            ghostty_surface_mouse_button(bridge.m_surface, state, GHOSTTY_MOUSE_MIDDLE, GHOSTTY_MODS_NONE);
+            ghostty_surface_mouse_button(sess->surface, state, GHOSTTY_MOUSE_MIDDLE, GHOSTTY_MODS_NONE);
         }
         return 0;
     }
     case WM_MOUSEWHEEL: {
-        if (bridge.m_surface) {
+        if (hasSurface) {
             double delta = (double)GET_WHEEL_DELTA_WPARAM(wParam) / WHEEL_DELTA;
             ghostty_input_scroll_mods_t mods = GHOSTTY_MODS_NONE;
-            ghostty_surface_mouse_scroll(bridge.m_surface, 0, delta, mods);
+            ghostty_surface_mouse_scroll(sess->surface, 0, delta, mods);
         }
         return 0;
     }
     case WM_DPICHANGED: {
-        if (bridge.m_surface) {
+        if (hasSurface) {
             UINT dpi = HIWORD(wParam);
             double scale = (double)dpi / 96.0;
-            ghostty_surface_set_content_scale(bridge.m_surface, scale, scale);
+            ghostty_surface_set_content_scale(sess->surface, scale, scale);
             // Resize window to suggested rect
             RECT* suggested = (RECT*)lParam;
             SetWindowPos(hwnd, nullptr,
@@ -492,9 +518,9 @@ LRESULT CALLBACK GhosttyBridge::glWndProc(HWND hwnd, UINT msg, WPARAM wParam, LP
     }
     case WM_IME_STARTCOMPOSITION: {
         // Position the IME candidate window near the cursor
-        if (bridge.m_surface) {
+        if (hasSurface) {
             double x = 0, y = 0, w = 0, h = 0;
-            ghostty_surface_ime_point(bridge.m_surface, &x, &y, &w, &h);
+            ghostty_surface_ime_point(sess->surface, &x, &y, &w, &h);
             HIMC hImc = ImmGetContext(hwnd);
             if (hImc) {
                 // Position the composition window
@@ -516,7 +542,7 @@ LRESULT CALLBACK GhosttyBridge::glWndProc(HWND hwnd, UINT msg, WPARAM wParam, LP
         break;
     }
     case WM_IME_COMPOSITION: {
-        if (bridge.m_surface && (lParam & GCS_COMPSTR)) {
+        if (hasSurface && (lParam & GCS_COMPSTR)) {
             HIMC hImc = ImmGetContext(hwnd);
             if (hImc) {
                 int len = ImmGetCompositionStringW(hImc, GCS_COMPSTR, nullptr, 0);
@@ -528,11 +554,11 @@ LRESULT CALLBACK GhosttyBridge::glWndProc(HWND hwnd, UINT msg, WPARAM wParam, LP
                     if (utf8Len > 0) {
                         std::vector<char> utf8(utf8Len);
                         WideCharToMultiByte(CP_UTF8, 0, comp.data(), -1, utf8.data(), utf8Len, nullptr, nullptr);
-                        ghostty_surface_preedit(bridge.m_surface, utf8.data(), utf8Len - 1);
+                        ghostty_surface_preedit(sess->surface, utf8.data(), utf8Len - 1);
                     }
                 } else {
                     // Empty composition = cleared
-                    ghostty_surface_preedit(bridge.m_surface, nullptr, 0);
+                    ghostty_surface_preedit(sess->surface, nullptr, 0);
                 }
                 ImmReleaseContext(hwnd, hImc);
             }
@@ -547,17 +573,17 @@ LRESULT CALLBACK GhosttyBridge::glWndProc(HWND hwnd, UINT msg, WPARAM wParam, LP
         break;
     }
     case WM_IME_ENDCOMPOSITION:
-        if (bridge.m_surface) {
-            ghostty_surface_preedit(bridge.m_surface, nullptr, 0);
+        if (hasSurface) {
+            ghostty_surface_preedit(sess->surface, nullptr, 0);
         }
         break;
     case WM_SETFOCUS:
-        if (bridge.m_surface) ghostty_surface_set_focus(bridge.m_surface, true);
+        if (hasSurface) ghostty_surface_set_focus(sess->surface, true);
         return 0;
     case WM_KILLFOCUS:
-        if (bridge.m_surface) ghostty_surface_set_focus(bridge.m_surface, false);
+        if (hasSurface) ghostty_surface_set_focus(sess->surface, false);
         return 0;
-case WM_USER + 1:
+    case WM_USER + 1:
         // Wakeup from ghostty - process pending events on main thread
         if (bridge.m_app) ghostty_app_tick(bridge.m_app);
         return 0;
@@ -566,7 +592,7 @@ case WM_USER + 1:
     return DefWindowProcW(hwnd, msg, wParam, lParam);
 }
 
-HWND GhosttyBridge::createGLWindow(HWND parent) {
+HWND GhosttyBridge::createGLWindow(HWND parent, TerminalSession* session) {
     static bool registered = false;
     if (!registered) {
         WNDCLASSW wc = {};
@@ -588,14 +614,14 @@ HWND GhosttyBridge::createGLWindow(HWND parent) {
             0, L"GhosttyGLWindow", nullptr,
             WS_CHILD | WS_VISIBLE | WS_CLIPSIBLINGS | WS_CLIPCHILDREN,
             0, 0, rc.right - rc.left, rc.bottom - rc.top,
-            parent, nullptr, GetModuleHandleW(nullptr), nullptr);
+            parent, nullptr, GetModuleHandleW(nullptr), session);
     } else {
         // Standalone window mode (no WinUI parent)
         hwnd = CreateWindowExW(
             0, L"GhosttyGLWindow", L"Ghostty",
             WS_OVERLAPPEDWINDOW | WS_VISIBLE,
             CW_USEDEFAULT, CW_USEDEFAULT, 960, 640,
-            nullptr, nullptr, GetModuleHandleW(nullptr), nullptr);
+            nullptr, nullptr, GetModuleHandleW(nullptr), session);
     }
 
     if (hwnd) {
@@ -609,25 +635,28 @@ HWND GhosttyBridge::createGLWindow(HWND parent) {
     return hwnd;
 }
 
-ghostty_surface_t GhosttyBridge::createSurface(HWND parentHwnd) {
+TerminalSession* GhosttyBridge::createSurface(HWND parentHwnd) {
     if (!m_initialized || !m_app) return nullptr;
 
-    // Create a Win32 child window for OpenGL (WinUI overwrites GDI on main window)
-    m_glWindow = createGLWindow(parentHwnd);
-    if (!m_glWindow) return nullptr;
+    auto sessionOwned = std::make_unique<TerminalSession>();
+    TerminalSession* session = sessionOwned.get();
 
-    // Run on 4MB stack thread with OpenGL context
+    // Create the Win32 window — session pointer is plumbed through WM_NCCREATE
+    session->hwnd = createGLWindow(parentHwnd, session);
+    if (!session->hwnd) return nullptr;
+
+    // Run on 4MB stack thread with renderer context
     struct Args {
         GhosttyBridge* self;
-        HWND hwnd;
-        ghostty_surface_t result;
+        TerminalSession* session;
     };
-    Args args = { this, m_glWindow, nullptr };
+    Args args = { this, session };
 
     HANDLE hThread = CreateThread(
         nullptr, 4 * 1024 * 1024,
         [](LPVOID param) -> DWORD {
             auto* a = static_cast<Args*>(param);
+            TerminalSession* sess = a->session;
 
             // Default to DirectX, use GHOSTTY_RENDERER=opengl to override
             char rendererBuf[32] = {};
@@ -641,7 +670,7 @@ ghostty_surface_t GhosttyBridge::createSurface(HWND parentHwnd) {
 
             if (!useDirectX) {
                 // Create and activate OpenGL context on this thread
-                if (!a->self->initOpenGL(a->hwnd)) {
+                if (!initOpenGL(sess)) {
                     DBG_LOG("ghostty: OpenGL init failed\n");
                     return 1;
                 }
@@ -649,14 +678,17 @@ ghostty_surface_t GhosttyBridge::createSurface(HWND parentHwnd) {
 
             ghostty_surface_config_s surfConfig = ghostty_surface_config_new();
             surfConfig.platform_tag = GHOSTTY_PLATFORM_WINDOWS;
-            surfConfig.platform.windows.hwnd = a->hwnd;
-            surfConfig.platform.windows.hdc = useDirectX ? nullptr : a->self->m_hdc;
-            surfConfig.platform.windows.hglrc = useDirectX ? nullptr : a->self->m_hglrc;
+            surfConfig.platform.windows.hwnd = sess->hwnd;
+            surfConfig.platform.windows.hdc = useDirectX ? nullptr : sess->hdc;
+            surfConfig.platform.windows.hglrc = useDirectX ? nullptr : sess->hglrc;
+            // Stored on the surface so onAction can recover the session via
+            // ghostty_surface_userdata(target.surface).
+            surfConfig.userdata = sess;
             // Get DPI scale factor
-            UINT dpi = GetDpiForWindow(a->self->m_glWindow);
+            UINT dpi = GetDpiForWindow(sess->hwnd);
             surfConfig.scale_factor = (double)dpi / 96.0;
 
-            a->result = ghostty_surface_new(a->self->m_app, &surfConfig);
+            sess->surface = ghostty_surface_new(a->self->m_app, &surfConfig);
 
             // Release GL context BEFORE thread exits so renderer thread can acquire it
             if (!useDirectX) wglMakeCurrent(nullptr, nullptr);
@@ -669,47 +701,69 @@ ghostty_surface_t GhosttyBridge::createSurface(HWND parentHwnd) {
         CloseHandle(hThread);
     }
 
-    // Note: GL context remains on worker thread after it exits
-    // It will need to be made current again for rendering
-
-    if (args.result) {
-        DBG_LOG("ghostty: surface created!\n");
-        m_surface = args.result;
-
-    } else {
+    if (!session->surface) {
         DBG_LOG("ghostty: surface creation failed\n");
+        DestroyWindow(session->hwnd);
+        return nullptr;
     }
-    return args.result;
+
+    DBG_LOG("ghostty: surface created!\n");
+    m_sessions.push_back(std::move(sessionOwned));
+    return session;
 }
 
-void GhosttyBridge::destroySurface(ghostty_surface_t surface) {
-    if (surface) {
-        ghostty_surface_free(surface);
-        DBG_LOG("ghostty: surface destroyed\n");
+void GhosttyBridge::destroySession(TerminalSession* session) {
+    if (!session) return;
+    if (session->surface) {
+        ghostty_surface_free(session->surface);
+        session->surface = nullptr;
     }
+    shutdownOpenGL(session);
+    // Window destruction is the caller's responsibility (typically driven by WM_CLOSE).
+    // Clear the userdata so any pending messages on this hwnd see no session.
+    if (session->hwnd) {
+        SetWindowLongPtrW(session->hwnd, GWLP_USERDATA, 0);
+    }
+    for (auto it = m_sessions.begin(); it != m_sessions.end(); ++it) {
+        if (it->get() == session) {
+            m_sessions.erase(it);
+            break;
+        }
+    }
+    DBG_LOG("ghostty: session destroyed\n");
 }
 
 // --- Stub callbacks (TODO: implement properly) ---
 
 void GhosttyBridge::onWakeup(void* userdata) {
     auto* self = static_cast<GhosttyBridge*>(userdata);
-    // Post to main thread - onWakeup may be called from any thread
-    if (self && self->m_glWindow) {
-        PostMessageW(self->m_glWindow, WM_USER + 1, 0, 0);
+    if (!self) return;
+    // Post to main thread - onWakeup may be called from any thread.
+    // Any session's hwnd works since WM_USER+1 just dispatches ghostty_app_tick.
+    if (!self->m_sessions.empty()) {
+        PostMessageW(self->m_sessions.front()->hwnd, WM_USER + 1, 0, 0);
     }
 }
 
 bool GhosttyBridge::onAction(ghostty_app_t app, ghostty_target_s target, ghostty_action_s action) {
     auto& bridge = GhosttyBridge::instance();
 
+    // Resolve the target session for surface-targeted actions.
+    // App-targeted actions (NEW_WINDOW etc.) leave session=nullptr.
+    TerminalSession* sess = nullptr;
+    if (target.tag == GHOSTTY_TARGET_SURFACE) {
+        sess = sessionFromSurface(target.target.surface);
+    }
+    HWND hwnd = sess ? sess->hwnd : nullptr;
+
     switch (action.tag) {
     case GHOSTTY_ACTION_SET_TITLE:
-        if (action.action.set_title.title && bridge.m_glWindow) {
+        if (action.action.set_title.title && hwnd) {
             int wlen = MultiByteToWideChar(CP_UTF8, 0, action.action.set_title.title, -1, nullptr, 0);
             if (wlen > 0) {
                 std::vector<wchar_t> wTitle(wlen);
                 MultiByteToWideChar(CP_UTF8, 0, action.action.set_title.title, -1, wTitle.data(), wlen);
-                SetWindowTextW(bridge.m_glWindow, wTitle.data());
+                SetWindowTextW(hwnd, wTitle.data());
             }
         }
         return true;
@@ -765,82 +819,84 @@ bool GhosttyBridge::onAction(ghostty_app_t app, ghostty_target_s target, ghostty
         return true;
 
     case GHOSTTY_ACTION_RING_BELL:
-        if (bridge.m_glWindow)
-            FlashWindow(bridge.m_glWindow, TRUE);
+        if (hwnd)
+            FlashWindow(hwnd, TRUE);
         MessageBeep(MB_OK);
         return true;
 
     case GHOSTTY_ACTION_QUIT:
-        if (bridge.m_glWindow)
-            PostMessageW(bridge.m_glWindow, WM_CLOSE, 0, 0);
+        if (hwnd)
+            PostMessageW(hwnd, WM_CLOSE, 0, 0);
         return true;
 
     case GHOSTTY_ACTION_TOGGLE_FULLSCREEN: {
-        if (!bridge.m_glWindow) return true;
-        bridge.m_fullscreen = !bridge.m_fullscreen;
-        if (bridge.m_fullscreen) {
+        if (!sess || !hwnd) return true;
+        sess->fullscreen = !sess->fullscreen;
+        if (sess->fullscreen) {
             // Save current state
-            bridge.m_savedStyle = GetWindowLongW(bridge.m_glWindow, GWL_STYLE);
-            GetWindowRect(bridge.m_glWindow, &bridge.m_savedRect);
+            sess->savedStyle = GetWindowLongW(hwnd, GWL_STYLE);
+            GetWindowRect(hwnd, &sess->savedRect);
             // Go fullscreen
-            SetWindowLongW(bridge.m_glWindow, GWL_STYLE, bridge.m_savedStyle & ~(WS_OVERLAPPEDWINDOW));
+            SetWindowLongW(hwnd, GWL_STYLE, sess->savedStyle & ~(WS_OVERLAPPEDWINDOW));
             MONITORINFO mi = { sizeof(mi) };
-            GetMonitorInfoW(MonitorFromWindow(bridge.m_glWindow, MONITOR_DEFAULTTONEAREST), &mi);
-            SetWindowPos(bridge.m_glWindow, HWND_TOP,
+            GetMonitorInfoW(MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST), &mi);
+            SetWindowPos(hwnd, HWND_TOP,
                 mi.rcMonitor.left, mi.rcMonitor.top,
                 mi.rcMonitor.right - mi.rcMonitor.left,
                 mi.rcMonitor.bottom - mi.rcMonitor.top,
                 SWP_FRAMECHANGED);
         } else {
             // Restore
-            SetWindowLongW(bridge.m_glWindow, GWL_STYLE, bridge.m_savedStyle);
-            SetWindowPos(bridge.m_glWindow, nullptr,
-                bridge.m_savedRect.left, bridge.m_savedRect.top,
-                bridge.m_savedRect.right - bridge.m_savedRect.left,
-                bridge.m_savedRect.bottom - bridge.m_savedRect.top,
+            SetWindowLongW(hwnd, GWL_STYLE, sess->savedStyle);
+            SetWindowPos(hwnd, nullptr,
+                sess->savedRect.left, sess->savedRect.top,
+                sess->savedRect.right - sess->savedRect.left,
+                sess->savedRect.bottom - sess->savedRect.top,
                 SWP_FRAMECHANGED | SWP_NOZORDER);
         }
         return true;
     }
 
     case GHOSTTY_ACTION_TOGGLE_MAXIMIZE:
-        if (bridge.m_glWindow) {
-            if (IsZoomed(bridge.m_glWindow))
-                ShowWindow(bridge.m_glWindow, SW_RESTORE);
+        if (hwnd) {
+            if (IsZoomed(hwnd))
+                ShowWindow(hwnd, SW_RESTORE);
             else
-                ShowWindow(bridge.m_glWindow, SW_MAXIMIZE);
+                ShowWindow(hwnd, SW_MAXIMIZE);
         }
         return true;
 
     case GHOSTTY_ACTION_TOGGLE_WINDOW_DECORATIONS:
-        if (bridge.m_glWindow) {
-            bridge.m_decorations = !bridge.m_decorations;
-            DWORD style = GetWindowLongW(bridge.m_glWindow, GWL_STYLE);
-            if (bridge.m_decorations)
+        if (sess && hwnd) {
+            sess->decorations = !sess->decorations;
+            DWORD style = GetWindowLongW(hwnd, GWL_STYLE);
+            if (sess->decorations)
                 style |= WS_OVERLAPPEDWINDOW;
             else
                 style &= ~(WS_CAPTION | WS_THICKFRAME | WS_SYSMENU | WS_MINIMIZEBOX | WS_MAXIMIZEBOX);
-            SetWindowLongW(bridge.m_glWindow, GWL_STYLE, style);
-            SetWindowPos(bridge.m_glWindow, nullptr, 0, 0, 0, 0,
+            SetWindowLongW(hwnd, GWL_STYLE, style);
+            SetWindowPos(hwnd, nullptr, 0, 0, 0, 0,
                 SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_FRAMECHANGED);
         }
         return true;
 
     case GHOSTTY_ACTION_SIZE_LIMIT: {
-        bridge.m_minWidth = action.action.size_limit.min_width;
-        bridge.m_minHeight = action.action.size_limit.min_height;
-        bridge.m_maxWidth = action.action.size_limit.max_width;
-        bridge.m_maxHeight = action.action.size_limit.max_height;
-        char buf[128];
-        sprintf_s(buf, "ghostty: SIZE_LIMIT min=%ux%u max=%ux%u\n",
-            bridge.m_minWidth, bridge.m_minHeight, bridge.m_maxWidth, bridge.m_maxHeight);
-        OutputDebugStringA(buf);
+        if (sess) {
+            sess->minWidth = action.action.size_limit.min_width;
+            sess->minHeight = action.action.size_limit.min_height;
+            sess->maxWidth = action.action.size_limit.max_width;
+            sess->maxHeight = action.action.size_limit.max_height;
+            char buf[128];
+            sprintf_s(buf, "ghostty: SIZE_LIMIT min=%ux%u max=%ux%u\n",
+                sess->minWidth, sess->minHeight, sess->maxWidth, sess->maxHeight);
+            OutputDebugStringA(buf);
+        }
         return true;
     }
 
     case GHOSTTY_ACTION_INITIAL_SIZE:
-        if (bridge.m_glWindow && action.action.initial_size.width > 0 && action.action.initial_size.height > 0) {
-            SetWindowPos(bridge.m_glWindow, nullptr, 0, 0,
+        if (hwnd && action.action.initial_size.width > 0 && action.action.initial_size.height > 0) {
+            SetWindowPos(hwnd, nullptr, 0, 0,
                 action.action.initial_size.width,
                 action.action.initial_size.height,
                 SWP_NOMOVE | SWP_NOZORDER);
@@ -848,23 +904,23 @@ bool GhosttyBridge::onAction(ghostty_app_t app, ghostty_target_s target, ghostty
         return true;
 
     case GHOSTTY_ACTION_RESET_WINDOW_SIZE:
-        if (bridge.m_glWindow) {
-            SetWindowPos(bridge.m_glWindow, nullptr, 0, 0, 960, 640,
+        if (hwnd) {
+            SetWindowPos(hwnd, nullptr, 0, 0, 960, 640,
                 SWP_NOMOVE | SWP_NOZORDER);
         }
         return true;
 
     case GHOSTTY_ACTION_COLOR_CHANGE: {
         auto& cc = action.action.color_change;
-        if (cc.kind == GHOSTTY_ACTION_COLOR_KIND_BACKGROUND && bridge.m_glWindow) {
+        if (cc.kind == GHOSTTY_ACTION_COLOR_KIND_BACKGROUND && hwnd) {
             // Set title bar color to match terminal background (Windows 10/11)
             COLORREF color = RGB(cc.r, cc.g, cc.b);
-            DwmSetWindowAttribute(bridge.m_glWindow, DWMWA_CAPTION_COLOR, &color, sizeof(color));
+            DwmSetWindowAttribute(hwnd, DWMWA_CAPTION_COLOR, &color, sizeof(color));
 
             // Also set title bar text color: light text on dark bg, dark text on light bg
             float luminance = 0.299f * cc.r + 0.587f * cc.g + 0.114f * cc.b;
             COLORREF textColor = (luminance < 128) ? RGB(255, 255, 255) : RGB(0, 0, 0);
-            DwmSetWindowAttribute(bridge.m_glWindow, DWMWA_TEXT_COLOR, &textColor, sizeof(textColor));
+            DwmSetWindowAttribute(hwnd, DWMWA_TEXT_COLOR, &textColor, sizeof(textColor));
         }
         return true;
     }
@@ -874,7 +930,7 @@ bool GhosttyBridge::onAction(ghostty_app_t app, ghostty_target_s target, ghostty
             // Simple notification via balloon tooltip or message box
             // TODO: use proper Windows toast notifications
             MessageBeep(MB_ICONINFORMATION);
-            FlashWindow(bridge.m_glWindow, TRUE);
+            if (hwnd) FlashWindow(hwnd, TRUE);
         }
         return true;
 
@@ -885,9 +941,14 @@ bool GhosttyBridge::onAction(ghostty_app_t app, ghostty_target_s target, ghostty
 
 bool GhosttyBridge::onReadClipboard(void* userdata, ghostty_clipboard_e clipboard, void* state) {
     auto* self = static_cast<GhosttyBridge*>(userdata);
-    if (!self || !self->m_surface || !self->m_glWindow) return false;
+    // TODO(tabs): the runtime callback doesn't expose which surface requested
+    // the read. For Phase 1 (single session) we always use the front session;
+    // Phase 3 will need to track the focused session.
+    if (!self || self->m_sessions.empty()) return false;
+    TerminalSession* sess = self->m_sessions.front().get();
+    if (!sess->surface || !sess->hwnd) return false;
 
-    if (!OpenClipboard(self->m_glWindow)) return false;
+    if (!OpenClipboard(sess->hwnd)) return false;
 
     HANDLE hData = GetClipboardData(CF_UNICODETEXT);
     if (!hData) {
@@ -906,7 +967,7 @@ bool GhosttyBridge::onReadClipboard(void* userdata, ghostty_clipboard_e clipboar
     if (utf8Len > 0) {
         std::vector<char> utf8(utf8Len);
         WideCharToMultiByte(CP_UTF8, 0, wText, -1, utf8.data(), utf8Len, nullptr, nullptr);
-        ghostty_surface_complete_clipboard_request(self->m_surface, utf8.data(), state, false);
+        ghostty_surface_complete_clipboard_request(sess->surface, utf8.data(), state, false);
     }
 
     GlobalUnlock(hData);
@@ -920,7 +981,10 @@ void GhosttyBridge::onConfirmReadClipboard(void* userdata, const char* content, 
 
 void GhosttyBridge::onWriteClipboard(void* userdata, ghostty_clipboard_e clipboard, const ghostty_clipboard_content_s* content, size_t count, bool confirm) {
     auto* self = static_cast<GhosttyBridge*>(userdata);
-    if (!self || !self->m_glWindow || count == 0 || !content) return;
+    // TODO(tabs): same caveat as onReadClipboard — Phase 1 uses the front session's hwnd.
+    if (!self || self->m_sessions.empty() || count == 0 || !content) return;
+    HWND hwnd = self->m_sessions.front()->hwnd;
+    if (!hwnd) return;
 
     // Find text content
     const char* text = nullptr;
@@ -933,7 +997,7 @@ void GhosttyBridge::onWriteClipboard(void* userdata, ghostty_clipboard_e clipboa
     if (!text || !text[0]) return;
 
     int wlen = MultiByteToWideChar(CP_UTF8, 0, text, -1, nullptr, 0);
-    if (wlen <= 0 || !OpenClipboard(self->m_glWindow)) return;
+    if (wlen <= 0 || !OpenClipboard(hwnd)) return;
 
     EmptyClipboard();
     HGLOBAL hMem = GlobalAlloc(GMEM_MOVEABLE, (wlen + 1) * sizeof(wchar_t));

--- a/GhosttyBridge.cpp
+++ b/GhosttyBridge.cpp
@@ -573,7 +573,6 @@ LRESULT CALLBACK GhosttyBridge::mainWndProc(HWND hwnd, UINT msg, WPARAM wParam, 
         break;
     case WM_NCHITTEST: {
         // Manual hit-testing: resize edges → header drag region → client.
-        if (!sess) break;
         RECT rc;
         GetClientRect(hwnd, &rc);
         POINT pt = { GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam) };
@@ -593,7 +592,8 @@ LRESULT CALLBACK GhosttyBridge::mainWndProc(HWND hwnd, UINT msg, WPARAM wParam, 
         if (bottom) return HTBOTTOM;
         // Header area (tab bar strip): check if a XAML element is under
         // the cursor. If not (empty space), return HTCAPTION for drag.
-        if (sess->headerHeight > 0 && pt.y < sess->headerHeight) {
+        int headerHeight = sess ? sess->headerHeight : TerminalSession::kDefaultHeaderHeight;
+        if (headerHeight > 0 && pt.y < headerHeight) {
             // Ask the XAML Island's interop hwnd if it wants this point.
             // ChildWindowFromPoint skips the drag bar and checks the
             // XAML host; if the deepest child is the host itself (no
@@ -632,17 +632,23 @@ LRESULT CALLBACK GhosttyBridge::mainWndProc(HWND hwnd, UINT msg, WPARAM wParam, 
         return 0;
 
     case WM_SIZE: {
-        if (!sess) return 0;
         int width = LOWORD(lParam);
         int height = HIWORD(lParam);
-        int top = sess->headerHeight;
+        int top = sess ? sess->headerHeight : TerminalSession::kDefaultHeaderHeight;
         int childHeight = height - top;
         if (childHeight < 1) childHeight = 1;
-        if (sess->xamlHostWnd && top > 0) {
-            SetWindowPos(sess->xamlHostWnd, nullptr, 0, 0, width, top,
+        // Resize XAML host (use sess if available, otherwise find from sessions)
+        HWND xamlHost = sess ? sess->xamlHostWnd : nullptr;
+        HWND xamlIsland = sess ? sess->xamlIslandHwnd : nullptr;
+        if (!xamlHost && !bridge.m_sessions.empty()) {
+            xamlHost = bridge.m_sessions.front()->xamlHostWnd;
+            xamlIsland = bridge.m_sessions.front()->xamlIslandHwnd;
+        }
+        if (xamlHost && top > 0) {
+            SetWindowPos(xamlHost, nullptr, 0, 0, width, top,
                 SWP_NOZORDER | SWP_NOACTIVATE | SWP_SHOWWINDOW);
-            if (sess->xamlIslandHwnd) {
-                SetWindowPos(sess->xamlIslandHwnd, nullptr, 0, 0, width, top,
+            if (xamlIsland) {
+                SetWindowPos(xamlIsland, nullptr, 0, 0, width, top,
                     SWP_NOZORDER | SWP_NOACTIVATE | SWP_SHOWWINDOW);
             }
         }
@@ -1059,7 +1065,7 @@ bool GhosttyBridge::onAction(ghostty_app_t app, ghostty_target_s target, ghostty
         // hides the XAML header strip (and with it, tabs and the drag region).
         if (sess && hwnd) {
             sess->decorations = !sess->decorations;
-            sess->headerHeight = sess->decorations ? 32 : 0;
+            sess->headerHeight = sess->decorations ? TerminalSession::kDefaultHeaderHeight : 0;
             RECT rc;
             GetClientRect(hwnd, &rc);
             SendMessageW(hwnd, WM_SIZE, SIZE_RESTORED,

--- a/GhosttyBridge.cpp
+++ b/GhosttyBridge.cpp
@@ -22,6 +22,8 @@
 extern "C" void dx_notify_resize(void* dev, uint32_t w, uint32_t h);
 // Get the DxDevice pointer from a ghostty surface (returns the per-surface device)
 extern "C" void* ghostty_surface_dx_device(void* surface);
+// DirectComposition visibility control (safe while renderer is active)
+extern "C" void dx_set_surface_visible(void* dev, bool visible);
 
 GhosttyBridge::TitleChangedFn GhosttyBridge::s_titleChangedFn = nullptr;
 void* GhosttyBridge::s_titleChangedCtx = nullptr;
@@ -751,7 +753,7 @@ HWND GhosttyBridge::createGLWindow(HWND parent, TerminalSession* session) {
     GetClientRect(parent, &rc);
     int top = session ? session->headerHeight : 0;
     HWND hwnd = CreateWindowExW(
-        0, L"GhosttyGLWindow", nullptr,
+        WS_EX_NOREDIRECTIONBITMAP, L"GhosttyGLWindow", nullptr,
         WS_CHILD | WS_VISIBLE | WS_CLIPSIBLINGS | WS_CLIPCHILDREN,
         0, top, rc.right - rc.left, (rc.bottom - rc.top) - top,
         parent, nullptr, GetModuleHandleW(nullptr), session);

--- a/GhosttyBridge.cpp
+++ b/GhosttyBridge.cpp
@@ -509,9 +509,17 @@ LRESULT CALLBACK GhosttyBridge::glWndProc(HWND hwnd, UINT msg, WPARAM wParam, LP
     case WM_SETFOCUS:
         if (hasSurface) ghostty_surface_set_focus(sess->surface, true);
         return 0;
-    case WM_KILLFOCUS:
+    case WM_KILLFOCUS: {
         if (hasSurface) ghostty_surface_set_focus(sess->surface, false);
+        // If focus moved to the XAML Island (tab bar click), schedule a
+        // focus return. The PostMessage lets the click be processed first.
+        HWND newFocus = (HWND)wParam;
+        if (newFocus && sess && sess->parentHwnd &&
+            IsChild(sess->parentHwnd, newFocus) && newFocus != hwnd) {
+            PostMessageW(sess->parentHwnd, WM_APP, 0, 0);
+        }
         return 0;
+    }
     case WM_USER + 1:
         // Wakeup from ghostty - process pending events on main thread
         if (bridge.m_app) ghostty_app_tick(bridge.m_app);
@@ -602,6 +610,15 @@ LRESULT CALLBACK GhosttyBridge::mainWndProc(HWND hwnd, UINT msg, WPARAM wParam, 
         if (sess && sess->hwnd) SetFocus(sess->hwnd);
         return 0;
 
+    case WM_ACTIVATE:
+        // When the window is activated (clicked, alt-tabbed to), force focus
+        // to the Ghostty child. The XAML Island's internal windows tend to
+        // capture focus otherwise, preventing terminal keyboard input.
+        if (LOWORD(wParam) != WA_INACTIVE && sess && sess->hwnd) {
+            SetFocus(sess->hwnd);
+        }
+        return 0;
+
     case WM_DPICHANGED:
         if (sess && sess->surface) {
             UINT dpi = HIWORD(wParam);
@@ -614,6 +631,11 @@ LRESULT CALLBACK GhosttyBridge::mainWndProc(HWND hwnd, UINT msg, WPARAM wParam, 
                 suggested->bottom - suggested->top,
                 SWP_NOZORDER | SWP_NOACTIVATE);
         }
+        return 0;
+
+    case WM_APP:
+        // Posted by XAML Island's GotFocus handler — return focus to terminal.
+        if (sess && sess->hwnd) SetFocus(sess->hwnd);
         return 0;
 
     case WM_CLOSE:

--- a/GhosttyBridge.cpp
+++ b/GhosttyBridge.cpp
@@ -27,6 +27,8 @@ extern "C" void dx_set_surface_visible(void* dev, bool visible);
 
 GhosttyBridge::TitleChangedFn GhosttyBridge::s_titleChangedFn = nullptr;
 void* GhosttyBridge::s_titleChangedCtx = nullptr;
+GhosttyBridge::BgColorChangedFn GhosttyBridge::s_bgColorChangedFn = nullptr;
+void* GhosttyBridge::s_bgColorChangedCtx = nullptr;
 
 // Helper: copy UTF-8 text to Windows clipboard
 static bool copyToClipboard(HWND hwnd, const char* utf8, size_t utf8Len) {
@@ -1128,6 +1130,7 @@ bool GhosttyBridge::onAction(ghostty_app_t app, ghostty_target_s target, ghostty
             // Set title bar color to match terminal background (Windows 10/11)
             COLORREF color = RGB(cc.r, cc.g, cc.b);
             bridge.m_bgColor = color;
+            if (s_bgColorChangedFn) s_bgColorChangedFn(s_bgColorChangedCtx, cc.r, cc.g, cc.b);
             DwmSetWindowAttribute(hwnd, DWMWA_CAPTION_COLOR, &color, sizeof(color));
 
             // Also set title bar text color: light text on dark bg, dark text on light bg

--- a/GhosttyBridge.cpp
+++ b/GhosttyBridge.cpp
@@ -532,36 +532,36 @@ LRESULT CALLBACK GhosttyBridge::mainWndProc(HWND hwnd, UINT msg, WPARAM wParam, 
 
     switch (msg) {
     case WM_NCCALCSIZE:
-        if (sess && !sess->decorations && wParam == TRUE) {
-            // Extend client area to cover the entire window (no frame)
-            return 0;
-        }
+        // The window has WS_THICKFRAME but no WS_CAPTION. By default Windows
+        // would still leave a thin resize border in the NC area; we extend the
+        // client area to cover the entire window so our XAML header reaches
+        // the top edge. Resize edges are handled manually via WM_NCHITTEST.
+        if (wParam == TRUE) return 0;
         break;
-    case WM_NCHITTEST:
-        // Allow drag and resize when window decorations are hidden.
-        // The header area (headerHeight px at top) acts as the drag region
-        // since there's no native title bar.
-        if (sess && !sess->decorations) {
-            RECT rc;
-            GetClientRect(hwnd, &rc);
-            POINT pt = { GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam) };
-            ScreenToClient(hwnd, &pt);
-            const int border = 6;
-            bool left = pt.x < border;
-            bool right = pt.x >= rc.right - border;
-            bool top = pt.y < border;
-            bool bottom = pt.y >= rc.bottom - border;
-            if (top && left) return HTTOPLEFT;
-            if (top && right) return HTTOPRIGHT;
-            if (bottom && left) return HTBOTTOMLEFT;
-            if (bottom && right) return HTBOTTOMRIGHT;
-            if (left) return HTLEFT;
-            if (right) return HTRIGHT;
-            if (top) return HTTOP;
-            if (bottom) return HTBOTTOM;
-            if (pt.y < sess->headerHeight) return HTCAPTION;
-        }
-        break;
+    case WM_NCHITTEST: {
+        // Manual hit-testing: resize edges first (6px border), then the header
+        // strip is the drag region (HTCAPTION), then everything else is client.
+        if (!sess) break;
+        RECT rc;
+        GetClientRect(hwnd, &rc);
+        POINT pt = { GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam) };
+        ScreenToClient(hwnd, &pt);
+        const int border = 6;
+        bool left = pt.x < border;
+        bool right = pt.x >= rc.right - border;
+        bool top = pt.y < border;
+        bool bottom = pt.y >= rc.bottom - border;
+        if (top && left) return HTTOPLEFT;
+        if (top && right) return HTTOPRIGHT;
+        if (bottom && left) return HTBOTTOMLEFT;
+        if (bottom && right) return HTBOTTOMRIGHT;
+        if (left) return HTLEFT;
+        if (right) return HTRIGHT;
+        if (top) return HTTOP;
+        if (bottom) return HTBOTTOM;
+        if (pt.y < sess->headerHeight) return HTCAPTION;
+        return HTCLIENT;
+    }
 
     case WM_GETMINMAXINFO:
         if (sess) {
@@ -631,9 +631,13 @@ HWND GhosttyBridge::createMainWindow(TerminalSession* session) {
         registered = true;
     }
 
+    // No native caption — the XAML tab bar in the header area replaces it.
+    // Keep WS_THICKFRAME for resize, WS_SYSMENU/MIN/MAX for taskbar interaction.
+    const DWORD style = WS_OVERLAPPED | WS_THICKFRAME | WS_SYSMENU
+                      | WS_MINIMIZEBOX | WS_MAXIMIZEBOX | WS_VISIBLE;
     return CreateWindowExW(
         0, L"GhosttyMainWindow", L"Ghostty",
-        WS_OVERLAPPEDWINDOW | WS_VISIBLE,
+        style,
         CW_USEDEFAULT, CW_USEDEFAULT, 960, 640,
         nullptr, nullptr, GetModuleHandleW(nullptr), session);
 }
@@ -682,6 +686,11 @@ TerminalSession* GhosttyBridge::createSurface(HWND parentHwnd) {
     if (!parentHwnd) {
         session->parentHwnd = createMainWindow(session);
         if (!session->parentHwnd) return nullptr;
+        // Force the NC area recalculation so our WM_NCCALCSIZE (which extends
+        // the client area to cover the entire window) takes effect immediately.
+        // Without this, the first frame can flash a native caption remnant.
+        SetWindowPos(session->parentHwnd, nullptr, 0, 0, 0, 0,
+            SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_FRAMECHANGED);
         parentHwnd = session->parentHwnd;
     } else {
         session->parentHwnd = parentHwnd;
@@ -922,21 +931,11 @@ bool GhosttyBridge::onAction(ghostty_app_t app, ghostty_target_s target, ghostty
         return true;
 
     case GHOSTTY_ACTION_TOGGLE_WINDOW_DECORATIONS:
+        // The native caption is always absent — toggling decorations shows or
+        // hides the XAML header strip (and with it, tabs and the drag region).
         if (sess && hwnd) {
             sess->decorations = !sess->decorations;
-            DWORD style = GetWindowLongW(hwnd, GWL_STYLE);
-            if (sess->decorations) {
-                style |= WS_OVERLAPPEDWINDOW;
-                sess->headerHeight = 0;
-            } else {
-                // Keep WS_THICKFRAME so the user can still resize from edges.
-                style = (style & ~(WS_CAPTION | WS_SYSMENU | WS_MINIMIZEBOX | WS_MAXIMIZEBOX)) | WS_THICKFRAME;
-                sess->headerHeight = 32;
-            }
-            SetWindowLongW(hwnd, GWL_STYLE, style);
-            SetWindowPos(hwnd, nullptr, 0, 0, 0, 0,
-                SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_FRAMECHANGED);
-            // Force a relayout of the rendering child to honor the new header.
+            sess->headerHeight = sess->decorations ? 32 : 0;
             RECT rc;
             GetClientRect(hwnd, &rc);
             SendMessageW(hwnd, WM_SIZE, SIZE_RESTORED,

--- a/GhosttyBridge.cpp
+++ b/GhosttyBridge.cpp
@@ -637,13 +637,13 @@ LRESULT CALLBACK GhosttyBridge::mainWndProc(HWND hwnd, UINT msg, WPARAM wParam, 
         int top = sess ? sess->headerHeight : TerminalSession::kDefaultHeaderHeight;
         int childHeight = height - top;
         if (childHeight < 1) childHeight = 1;
-        // Resize XAML host (stored on bridge, persists across tab closes)
+        // Resize XAML host + island
         if (bridge.m_xamlHostWnd && top > 0) {
             SetWindowPos(bridge.m_xamlHostWnd, nullptr, 0, 0, width, top,
-                SWP_NOZORDER | SWP_NOACTIVATE | SWP_SHOWWINDOW);
+                SWP_NOZORDER | SWP_NOACTIVATE);
             if (bridge.m_xamlIslandHwnd) {
                 SetWindowPos(bridge.m_xamlIslandHwnd, nullptr, 0, 0, width, top,
-                    SWP_NOZORDER | SWP_NOACTIVATE | SWP_SHOWWINDOW);
+                    SWP_NOZORDER | SWP_NOACTIVATE);
             }
         }
         // Resize all rendering children (including hidden tabs)
@@ -653,6 +653,31 @@ LRESULT CALLBACK GhosttyBridge::mainWndProc(HWND hwnd, UINT msg, WPARAM wParam, 
                     SWP_NOZORDER | SWP_NOACTIVATE);
             }
         }
+        return 0;
+    }
+
+    case WM_PAINT: {
+        // Paint the client area with the title bar background color during resize.
+        // XAML Islands don't resize synchronously with the native window, so this
+        // hides the exposed gap with the expected color (same technique as Windows Terminal).
+        PAINTSTRUCT ps;
+        HDC hdc = BeginPaint(hwnd, &ps);
+        int top = sess ? sess->headerHeight : TerminalSession::kDefaultHeaderHeight;
+        // Title bar area: dark background matching the tab bar
+        if (ps.rcPaint.top < top) {
+            RECT rcHeader = ps.rcPaint;
+            rcHeader.bottom = min(rcHeader.bottom, (LONG)top);
+            FillRect(hdc, &rcHeader, (HBRUSH)GetStockObject(BLACK_BRUSH));
+        }
+        // Terminal area: fill with the terminal background color
+        if (ps.rcPaint.bottom > top) {
+            RECT rcContent = ps.rcPaint;
+            rcContent.top = max(rcContent.top, (LONG)top);
+            HBRUSH bgBrush = CreateSolidBrush(bridge.m_bgColor);
+            FillRect(hdc, &rcContent, bgBrush);
+            DeleteObject(bgBrush);
+        }
+        EndPaint(hwnd, &ps);
         return 0;
     }
 
@@ -1102,6 +1127,7 @@ bool GhosttyBridge::onAction(ghostty_app_t app, ghostty_target_s target, ghostty
         if (cc.kind == GHOSTTY_ACTION_COLOR_KIND_BACKGROUND && hwnd) {
             // Set title bar color to match terminal background (Windows 10/11)
             COLORREF color = RGB(cc.r, cc.g, cc.b);
+            bridge.m_bgColor = color;
             DwmSetWindowAttribute(hwnd, DWMWA_CAPTION_COLOR, &color, sizeof(color));
 
             // Also set title bar text color: light text on dark bg, dark text on light bg

--- a/GhosttyBridge.cpp
+++ b/GhosttyBridge.cpp
@@ -21,6 +21,9 @@
 // DirectX renderer: notify resize from main thread (exported from ghostty.dll)
 extern "C" void dx_notify_resize(uint32_t w, uint32_t h);
 
+GhosttyBridge::TitleChangedFn GhosttyBridge::s_titleChangedFn = nullptr;
+void* GhosttyBridge::s_titleChangedCtx = nullptr;
+
 // Helper: copy UTF-8 text to Windows clipboard
 static bool copyToClipboard(HWND hwnd, const char* utf8, size_t utf8Len) {
     int wlen = MultiByteToWideChar(CP_UTF8, 0, utf8, (int)utf8Len, nullptr, 0);
@@ -865,6 +868,11 @@ bool GhosttyBridge::onAction(ghostty_app_t app, ghostty_target_s target, ghostty
                 std::vector<wchar_t> wTitle(wlen);
                 MultiByteToWideChar(CP_UTF8, 0, action.action.set_title.title, -1, wTitle.data(), wlen);
                 SetWindowTextW(hwnd, wTitle.data());
+                // Update the matching TabViewItem header
+                HWND sessHwnd = sess ? sess->hwnd : nullptr;
+                if (sessHwnd && s_titleChangedFn) {
+                    s_titleChangedFn(s_titleChangedCtx, sessHwnd, wTitle.data());
+                }
             }
         }
         return true;

--- a/GhosttyBridge.cpp
+++ b/GhosttyBridge.cpp
@@ -634,8 +634,14 @@ LRESULT CALLBACK GhosttyBridge::mainWndProc(HWND hwnd, UINT msg, WPARAM wParam, 
         return 0;
 
     case WM_APP:
-        // Posted by XAML Island's GotFocus handler — return focus to terminal.
-        if (sess && sess->hwnd) SetFocus(sess->hwnd);
+        // Posted by XAML Island's GotFocus / SelectionChanged — return focus
+        // to whichever terminal session is currently visible.
+        for (auto& s : bridge.m_sessions) {
+            if (s->hwnd && IsWindowVisible(s->hwnd)) {
+                SetFocus(s->hwnd);
+                break;
+            }
+        }
         return 0;
 
     case WM_CLOSE:

--- a/GhosttyBridge.cpp
+++ b/GhosttyBridge.cpp
@@ -19,7 +19,9 @@
 #pragma comment(lib, "gdi32.lib")
 
 // DirectX renderer: notify resize from main thread (exported from ghostty.dll)
-extern "C" void dx_notify_resize(uint32_t w, uint32_t h);
+extern "C" void dx_notify_resize(void* dev, uint32_t w, uint32_t h);
+// Get the DxDevice pointer from a ghostty surface (returns the per-surface device)
+extern "C" void* ghostty_surface_dx_device(void* surface);
 
 GhosttyBridge::TitleChangedFn GhosttyBridge::s_titleChangedFn = nullptr;
 void* GhosttyBridge::s_titleChangedCtx = nullptr;
@@ -376,8 +378,11 @@ LRESULT CALLBACK GhosttyBridge::glWndProc(HWND hwnd, UINT msg, WPARAM wParam, LP
         UINT width = LOWORD(lParam);
         UINT height = HIWORD(lParam);
         if (width > 0 && height > 0) {
-            // Notify DirectX renderer of new size (thread-safe atomic write)
-            dx_notify_resize(width, height);
+            // Notify the per-surface DirectX device of the new size
+            if (hasSurface) {
+                void* dxDev = ghostty_surface_dx_device(sess->surface);
+                dx_notify_resize(dxDev, width, height);
+            }
             if (hasSurface) {
                 ghostty_surface_set_size(sess->surface, width, height);
                 ghostty_surface_refresh(sess->surface);
@@ -550,8 +555,7 @@ LRESULT CALLBACK GhosttyBridge::mainWndProc(HWND hwnd, UINT msg, WPARAM wParam, 
         if (wParam == TRUE) return 0;
         break;
     case WM_NCHITTEST: {
-        // Manual hit-testing: resize edges first (6px border), then the header
-        // strip is the drag region (HTCAPTION), then everything else is client.
+        // Manual hit-testing: resize edges → header drag region → client.
         if (!sess) break;
         RECT rc;
         GetClientRect(hwnd, &rc);
@@ -570,9 +574,33 @@ LRESULT CALLBACK GhosttyBridge::mainWndProc(HWND hwnd, UINT msg, WPARAM wParam, 
         if (right) return HTRIGHT;
         if (top) return HTTOP;
         if (bottom) return HTBOTTOM;
-        // Header area: HTCLIENT so XAML can receive clicks when the
-        // drag bar overlay returns HTTRANSPARENT. The drag bar itself
-        // returns HTCAPTION for empty areas (handled by its WndProc).
+        // Header area (tab bar strip): check if a XAML element is under
+        // the cursor. If not (empty space), return HTCAPTION for drag.
+        if (sess->headerHeight > 0 && pt.y < sess->headerHeight) {
+            // Ask the XAML Island's interop hwnd if it wants this point.
+            // ChildWindowFromPoint skips the drag bar and checks the
+            // XAML host; if the deepest child is the host itself (no
+            // interactive element), treat it as draggable empty space.
+            POINT screenPt = { GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam) };
+            HWND hit = WindowFromPoint(screenPt);
+            // If the hit window is the main window itself or a non-XAML
+            // child, it's empty header space — allow dragging.
+            if (hit == hwnd) return HTCAPTION;
+            // Check if the hit window is an interactive XAML element by
+            // walking up to see if it's a child of our main window.
+            // The XAML Island's internal windows handle their own clicks.
+            // For the gap between TabView and buttons (drag area column),
+            // the XAML host window receives the hit but has no interactive
+            // content → we detect this by checking the class name.
+            wchar_t cls[64] = {};
+            GetClassNameW(hit, cls, 64);
+            // "Windows.UI.Input.InputSite.WindowClass" is the XAML
+            // Island's top-level input window. If it's hit directly
+            // (not a button or tab inside it), treat as drag area.
+            if (wcsstr(cls, L"InputSite") || wcsstr(cls, L"XamlHost")) {
+                return HTCAPTION;
+            }
+        }
         return HTCLIENT;
     }
 
@@ -646,6 +674,12 @@ LRESULT CALLBACK GhosttyBridge::mainWndProc(HWND hwnd, UINT msg, WPARAM wParam, 
                 break;
             }
         }
+        return 0;
+
+    case WM_USER + 1:
+        // Wakeup from ghostty — process pending events on main thread.
+        // Posted by onWakeup() which targets m_wakeupHwnd (this window).
+        if (bridge.m_app) ghostty_app_tick(bridge.m_app);
         return 0;
 
     case WM_CLOSE:
@@ -737,6 +771,11 @@ TerminalSession* GhosttyBridge::createSurface(HWND parentHwnd) {
         session->parentHwnd = parentHwnd;
     }
 
+    // Store main window HWND for thread-safe wakeup (set once, never changes)
+    if (!m_wakeupHwnd) {
+        m_wakeupHwnd = session->parentHwnd;
+    }
+
     // Create the rendering child — session pointer is plumbed through WM_NCCREATE
     session->hwnd = createGLWindow(parentHwnd, session);
     if (!session->hwnd) {
@@ -787,7 +826,22 @@ TerminalSession* GhosttyBridge::createSurface(HWND parentHwnd) {
             UINT dpi = GetDpiForWindow(sess->hwnd);
             surfConfig.scale_factor = (double)dpi / 96.0;
 
-            sess->surface = ghostty_surface_new(a->self->m_app, &surfConfig);
+            {
+                char buf[256];
+                sprintf_s(buf, "ghostty: calling ghostty_surface_new app=%p hwnd=%p sessions=%zu\n",
+                    a->self->m_app, sess->hwnd, a->self->m_sessions.size());
+                OutputDebugStringA(buf);
+            }
+
+            __try {
+                sess->surface = ghostty_surface_new(a->self->m_app, &surfConfig);
+            } __except(EXCEPTION_EXECUTE_HANDLER) {
+                char buf[128];
+                sprintf_s(buf, "ghostty: CRASH in ghostty_surface_new! code=0x%08X\n",
+                    GetExceptionCode());
+                OutputDebugStringA(buf);
+                sess->surface = nullptr;
+            }
 
             // Release GL context BEFORE thread exits so renderer thread can acquire it
             if (!useDirectX) wglMakeCurrent(nullptr, nullptr);
@@ -819,13 +873,14 @@ void GhosttyBridge::destroySession(TerminalSession* session) {
     }
     shutdownOpenGL(session);
     // Clear userdata so pending messages on these hwnds see no session.
-    // Window destruction is driven by WM_CLOSE on the parent — we don't
-    // DestroyWindow here, we just detach.
     if (session->hwnd) {
         SetWindowLongPtrW(session->hwnd, GWLP_USERDATA, 0);
+        DestroyWindow(session->hwnd);
+        session->hwnd = nullptr;
     }
     if (session->parentHwnd) {
         SetWindowLongPtrW(session->parentHwnd, GWLP_USERDATA, 0);
+        // Don't destroy parentHwnd — it's the shared main window for all tabs.
     }
     for (auto it = m_sessions.begin(); it != m_sessions.end(); ++it) {
         if (it->get() == session) {
@@ -840,12 +895,10 @@ void GhosttyBridge::destroySession(TerminalSession* session) {
 
 void GhosttyBridge::onWakeup(void* userdata) {
     auto* self = static_cast<GhosttyBridge*>(userdata);
-    if (!self) return;
-    // Post to main thread - onWakeup may be called from any thread.
-    // Any session's hwnd works since WM_USER+1 just dispatches ghostty_app_tick.
-    if (!self->m_sessions.empty()) {
-        PostMessageW(self->m_sessions.front()->hwnd, WM_USER + 1, 0, 0);
-    }
+    if (!self || !self->m_wakeupHwnd) return;
+    // Post to the main window — avoids accessing m_sessions which can be
+    // reallocated on the main thread while renderer threads call this.
+    PostMessageW(self->m_wakeupHwnd, WM_USER + 1, 0, 0);
 }
 
 bool GhosttyBridge::onAction(ghostty_app_t app, ghostty_target_s target, ghostty_action_s action) {

--- a/GhosttyBridge.cpp
+++ b/GhosttyBridge.cpp
@@ -644,10 +644,12 @@ LRESULT CALLBACK GhosttyBridge::mainWndProc(HWND hwnd, UINT msg, WPARAM wParam, 
                     SWP_NOZORDER | SWP_NOACTIVATE | SWP_SHOWWINDOW);
             }
         }
-        // Resize the rendering child below the header.
-        if (sess->hwnd) {
-            SetWindowPos(sess->hwnd, nullptr, 0, top, width, childHeight,
-                SWP_NOZORDER | SWP_NOACTIVATE);
+        // Resize all rendering children (including hidden tabs)
+        for (auto& s : bridge.m_sessions) {
+            if (s->hwnd) {
+                SetWindowPos(s->hwnd, nullptr, 0, top, width, childHeight,
+                    SWP_NOZORDER | SWP_NOACTIVATE);
+            }
         }
         return 0;
     }

--- a/GhosttyBridge.cpp
+++ b/GhosttyBridge.cpp
@@ -538,7 +538,9 @@ LRESULT CALLBACK GhosttyBridge::mainWndProc(HWND hwnd, UINT msg, WPARAM wParam, 
         }
         break;
     case WM_NCHITTEST:
-        // Allow drag and resize when window decorations are hidden
+        // Allow drag and resize when window decorations are hidden.
+        // The header area (headerHeight px at top) acts as the drag region
+        // since there's no native title bar.
         if (sess && !sess->decorations) {
             RECT rc;
             GetClientRect(hwnd, &rc);
@@ -557,7 +559,7 @@ LRESULT CALLBACK GhosttyBridge::mainWndProc(HWND hwnd, UINT msg, WPARAM wParam, 
             if (right) return HTRIGHT;
             if (top) return HTTOP;
             if (bottom) return HTBOTTOM;
-            if (pt.y < 30) return HTCAPTION;
+            if (pt.y < sess->headerHeight) return HTCAPTION;
         }
         break;
 
@@ -572,12 +574,15 @@ LRESULT CALLBACK GhosttyBridge::mainWndProc(HWND hwnd, UINT msg, WPARAM wParam, 
         return 0;
 
     case WM_SIZE: {
-        // Resize the rendering child to fill our client area.
+        // Resize the rendering child to fill our client area below the header.
         // The child's WM_SIZE handler notifies the renderer + ghostty surface.
         if (sess && sess->hwnd) {
-            UINT width = LOWORD(lParam);
-            UINT height = HIWORD(lParam);
-            SetWindowPos(sess->hwnd, nullptr, 0, 0, width, height,
+            int width = LOWORD(lParam);
+            int height = HIWORD(lParam);
+            int top = sess->headerHeight;
+            int childHeight = height - top;
+            if (childHeight < 1) childHeight = 1;
+            SetWindowPos(sess->hwnd, nullptr, 0, top, width, childHeight,
                 SWP_NOZORDER | SWP_NOACTIVATE);
         }
         return 0;
@@ -648,10 +653,11 @@ HWND GhosttyBridge::createGLWindow(HWND parent, TerminalSession* session) {
 
     RECT rc;
     GetClientRect(parent, &rc);
+    int top = session ? session->headerHeight : 0;
     HWND hwnd = CreateWindowExW(
         0, L"GhosttyGLWindow", nullptr,
         WS_CHILD | WS_VISIBLE | WS_CLIPSIBLINGS | WS_CLIPCHILDREN,
-        0, 0, rc.right - rc.left, rc.bottom - rc.top,
+        0, top, rc.right - rc.left, (rc.bottom - rc.top) - top,
         parent, nullptr, GetModuleHandleW(nullptr), session);
 
     if (hwnd) {
@@ -919,13 +925,22 @@ bool GhosttyBridge::onAction(ghostty_app_t app, ghostty_target_s target, ghostty
         if (sess && hwnd) {
             sess->decorations = !sess->decorations;
             DWORD style = GetWindowLongW(hwnd, GWL_STYLE);
-            if (sess->decorations)
+            if (sess->decorations) {
                 style |= WS_OVERLAPPEDWINDOW;
-            else
-                style &= ~(WS_CAPTION | WS_THICKFRAME | WS_SYSMENU | WS_MINIMIZEBOX | WS_MAXIMIZEBOX);
+                sess->headerHeight = 0;
+            } else {
+                // Keep WS_THICKFRAME so the user can still resize from edges.
+                style = (style & ~(WS_CAPTION | WS_SYSMENU | WS_MINIMIZEBOX | WS_MAXIMIZEBOX)) | WS_THICKFRAME;
+                sess->headerHeight = 32;
+            }
             SetWindowLongW(hwnd, GWL_STYLE, style);
             SetWindowPos(hwnd, nullptr, 0, 0, 0, 0,
                 SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_FRAMECHANGED);
+            // Force a relayout of the rendering child to honor the new header.
+            RECT rc;
+            GetClientRect(hwnd, &rc);
+            SendMessageW(hwnd, WM_SIZE, SIZE_RESTORED,
+                MAKELPARAM(rc.right - rc.left, rc.bottom - rc.top));
         }
         return true;
 

--- a/GhosttyBridge.cpp
+++ b/GhosttyBridge.cpp
@@ -580,10 +580,14 @@ LRESULT CALLBACK GhosttyBridge::mainWndProc(HWND hwnd, UINT msg, WPARAM wParam, 
         int top = sess->headerHeight;
         int childHeight = height - top;
         if (childHeight < 1) childHeight = 1;
-        // Resize the XAML Island to fill the header area.
-        if (sess->xamlIslandHwnd && top > 0) {
-            SetWindowPos(sess->xamlIslandHwnd, nullptr, 0, 0, width, top,
+        // Resize the XAML host and its island child to fill the header area.
+        if (sess->xamlHostWnd && top > 0) {
+            SetWindowPos(sess->xamlHostWnd, nullptr, 0, 0, width, top,
                 SWP_NOZORDER | SWP_NOACTIVATE | SWP_SHOWWINDOW);
+            if (sess->xamlIslandHwnd) {
+                SetWindowPos(sess->xamlIslandHwnd, nullptr, 0, 0, width, top,
+                    SWP_NOZORDER | SWP_NOACTIVATE | SWP_SHOWWINDOW);
+            }
         }
         // Resize the rendering child below the header.
         if (sess->hwnd) {

--- a/GhosttyBridge.cpp
+++ b/GhosttyBridge.cpp
@@ -570,11 +570,9 @@ LRESULT CALLBACK GhosttyBridge::mainWndProc(HWND hwnd, UINT msg, WPARAM wParam, 
         if (right) return HTRIGHT;
         if (top) return HTTOP;
         if (bottom) return HTBOTTOM;
-        // Header area: HTCAPTION for drag. Currently the XAML Island
-        // absorbs mouse events so drag only works outside the island.
-        // Proper tab-bar drag requires DwmExtendFrameIntoClientArea
-        // integration — tracked as a future improvement.
-        if (sess->headerHeight > 0 && pt.y < sess->headerHeight) return HTCAPTION;
+        // Header area: HTCLIENT so XAML can receive clicks when the
+        // drag bar overlay returns HTTRANSPARENT. The drag bar itself
+        // returns HTCAPTION for empty areas (handled by its WndProc).
         return HTCLIENT;
     }
 
@@ -595,7 +593,6 @@ LRESULT CALLBACK GhosttyBridge::mainWndProc(HWND hwnd, UINT msg, WPARAM wParam, 
         int top = sess->headerHeight;
         int childHeight = height - top;
         if (childHeight < 1) childHeight = 1;
-        // Resize the XAML host to fill the header area.
         if (sess->xamlHostWnd && top > 0) {
             SetWindowPos(sess->xamlHostWnd, nullptr, 0, 0, width, top,
                 SWP_NOZORDER | SWP_NOACTIVATE | SWP_SHOWWINDOW);

--- a/GhosttyBridge.cpp
+++ b/GhosttyBridge.cpp
@@ -241,43 +241,6 @@ LRESULT CALLBACK GhosttyBridge::glWndProc(HWND hwnd, UINT msg, WPARAM wParam, LP
     const bool hasSurface = sess && sess->surface;
 
     switch (msg) {
-    case WM_NCCALCSIZE: {
-        // When decorations are hidden, extend client area to cover the entire window
-        if (sess && !sess->decorations && wParam == TRUE) {
-            // Return 0 to make client area = window area (no frame)
-            return 0;
-        }
-        break;
-    }
-    case WM_NCHITTEST: {
-        // Allow drag and resize when window decorations are hidden
-        if (sess && !sess->decorations) {
-            RECT rc;
-            GetClientRect(hwnd, &rc);
-            POINT pt = { GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam) };
-            ScreenToClient(hwnd, &pt);
-            const int border = 6; // resize border width in pixels
-
-            // Edges and corners for resize
-            bool left = pt.x < border;
-            bool right = pt.x >= rc.right - border;
-            bool top = pt.y < border;
-            bool bottom = pt.y >= rc.bottom - border;
-
-            if (top && left) return HTTOPLEFT;
-            if (top && right) return HTTOPRIGHT;
-            if (bottom && left) return HTBOTTOMLEFT;
-            if (bottom && right) return HTBOTTOMRIGHT;
-            if (left) return HTLEFT;
-            if (right) return HTRIGHT;
-            if (top) return HTTOP;
-            if (bottom) return HTBOTTOM;
-
-            // Top 30px = draggable title bar area
-            if (pt.y < 30) return HTCAPTION;
-        }
-        break;
-    }
     case WM_CHAR: {
         if (!hasSurface || wParam < 0x20) return 0;
         // Handle UTF-16 surrogate pairs (emoji etc.)
@@ -402,29 +365,10 @@ LRESULT CALLBACK GhosttyBridge::glWndProc(HWND hwnd, UINT msg, WPARAM wParam, LP
     case WM_ERASEBKGND:
         return 1; // Skip background erase to prevent flicker
     case WM_PAINT: {
-        // Validate the region without drawing - OpenGL renderer handles all drawing
+        // Validate the region without drawing - renderer handles all drawing
         ValidateRect(hwnd, nullptr);
         return 0;
     }
-    case WM_GETMINMAXINFO: {
-        if (sess) {
-            auto* mmi = reinterpret_cast<MINMAXINFO*>(lParam);
-            if (sess->minWidth > 0) mmi->ptMinTrackSize.x = sess->minWidth;
-            if (sess->minHeight > 0) mmi->ptMinTrackSize.y = sess->minHeight;
-            if (sess->maxWidth > 0) mmi->ptMaxTrackSize.x = sess->maxWidth;
-            if (sess->maxHeight > 0) mmi->ptMaxTrackSize.y = sess->maxHeight;
-        }
-        return 0;
-    }
-    case WM_CLOSE:
-        // Clean up this session and quit the app when no sessions remain.
-        // (Phase 1 only ever creates one session, so this still terminates the app.)
-        if (sess) {
-            bridge.destroySession(sess);
-        }
-        bridge.shutdown();
-        PostQuitMessage(0);
-        return 0;
     case WM_SIZE: {
         UINT width = LOWORD(lParam);
         UINT height = HIWORD(lParam);
@@ -498,21 +442,6 @@ LRESULT CALLBACK GhosttyBridge::glWndProc(HWND hwnd, UINT msg, WPARAM wParam, LP
             double delta = (double)GET_WHEEL_DELTA_WPARAM(wParam) / WHEEL_DELTA;
             ghostty_input_scroll_mods_t mods = GHOSTTY_MODS_NONE;
             ghostty_surface_mouse_scroll(sess->surface, 0, delta, mods);
-        }
-        return 0;
-    }
-    case WM_DPICHANGED: {
-        if (hasSurface) {
-            UINT dpi = HIWORD(wParam);
-            double scale = (double)dpi / 96.0;
-            ghostty_surface_set_content_scale(sess->surface, scale, scale);
-            // Resize window to suggested rect
-            RECT* suggested = (RECT*)lParam;
-            SetWindowPos(hwnd, nullptr,
-                suggested->left, suggested->top,
-                suggested->right - suggested->left,
-                suggested->bottom - suggested->top,
-                SWP_NOZORDER | SWP_NOACTIVATE);
         }
         return 0;
     }
@@ -592,6 +521,118 @@ LRESULT CALLBACK GhosttyBridge::glWndProc(HWND hwnd, UINT msg, WPARAM wParam, LP
     return DefWindowProcW(hwnd, msg, wParam, lParam);
 }
 
+LRESULT CALLBACK GhosttyBridge::mainWndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
+    if (msg == WM_NCCREATE) {
+        auto* cs = reinterpret_cast<CREATESTRUCTW*>(lParam);
+        SetWindowLongPtrW(hwnd, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(cs->lpCreateParams));
+    }
+
+    auto* sess = reinterpret_cast<TerminalSession*>(GetWindowLongPtrW(hwnd, GWLP_USERDATA));
+    auto& bridge = GhosttyBridge::instance();
+
+    switch (msg) {
+    case WM_NCCALCSIZE:
+        if (sess && !sess->decorations && wParam == TRUE) {
+            // Extend client area to cover the entire window (no frame)
+            return 0;
+        }
+        break;
+    case WM_NCHITTEST:
+        // Allow drag and resize when window decorations are hidden
+        if (sess && !sess->decorations) {
+            RECT rc;
+            GetClientRect(hwnd, &rc);
+            POINT pt = { GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam) };
+            ScreenToClient(hwnd, &pt);
+            const int border = 6;
+            bool left = pt.x < border;
+            bool right = pt.x >= rc.right - border;
+            bool top = pt.y < border;
+            bool bottom = pt.y >= rc.bottom - border;
+            if (top && left) return HTTOPLEFT;
+            if (top && right) return HTTOPRIGHT;
+            if (bottom && left) return HTBOTTOMLEFT;
+            if (bottom && right) return HTBOTTOMRIGHT;
+            if (left) return HTLEFT;
+            if (right) return HTRIGHT;
+            if (top) return HTTOP;
+            if (bottom) return HTBOTTOM;
+            if (pt.y < 30) return HTCAPTION;
+        }
+        break;
+
+    case WM_GETMINMAXINFO:
+        if (sess) {
+            auto* mmi = reinterpret_cast<MINMAXINFO*>(lParam);
+            if (sess->minWidth > 0) mmi->ptMinTrackSize.x = sess->minWidth;
+            if (sess->minHeight > 0) mmi->ptMinTrackSize.y = sess->minHeight;
+            if (sess->maxWidth > 0) mmi->ptMaxTrackSize.x = sess->maxWidth;
+            if (sess->maxHeight > 0) mmi->ptMaxTrackSize.y = sess->maxHeight;
+        }
+        return 0;
+
+    case WM_SIZE: {
+        // Resize the rendering child to fill our client area.
+        // The child's WM_SIZE handler notifies the renderer + ghostty surface.
+        if (sess && sess->hwnd) {
+            UINT width = LOWORD(lParam);
+            UINT height = HIWORD(lParam);
+            SetWindowPos(sess->hwnd, nullptr, 0, 0, width, height,
+                SWP_NOZORDER | SWP_NOACTIVATE);
+        }
+        return 0;
+    }
+
+    case WM_SETFOCUS:
+        // Forward focus to the rendering child so it receives keyboard input.
+        if (sess && sess->hwnd) SetFocus(sess->hwnd);
+        return 0;
+
+    case WM_DPICHANGED:
+        if (sess && sess->surface) {
+            UINT dpi = HIWORD(wParam);
+            double scale = (double)dpi / 96.0;
+            ghostty_surface_set_content_scale(sess->surface, scale, scale);
+            RECT* suggested = (RECT*)lParam;
+            SetWindowPos(hwnd, nullptr,
+                suggested->left, suggested->top,
+                suggested->right - suggested->left,
+                suggested->bottom - suggested->top,
+                SWP_NOZORDER | SWP_NOACTIVATE);
+        }
+        return 0;
+
+    case WM_CLOSE:
+        // Phase 2-A: still single-session, so closing the main window quits the app.
+        if (sess) bridge.destroySession(sess);
+        bridge.shutdown();
+        PostQuitMessage(0);
+        return 0;
+    }
+
+    return DefWindowProcW(hwnd, msg, wParam, lParam);
+}
+
+HWND GhosttyBridge::createMainWindow(TerminalSession* session) {
+    static bool registered = false;
+    if (!registered) {
+        WNDCLASSW wc = {};
+        wc.lpfnWndProc = mainWndProc;
+        wc.hInstance = GetModuleHandleW(nullptr);
+        wc.lpszClassName = L"GhosttyMainWindow";
+        wc.hCursor = LoadCursorW(nullptr, IDC_ARROW);
+        wc.hbrBackground = (HBRUSH)(COLOR_WINDOW + 1);
+        RegisterClassW(&wc);
+        registered = true;
+    }
+
+    return CreateWindowExW(
+        0, L"GhosttyMainWindow", L"Ghostty",
+        WS_OVERLAPPEDWINDOW | WS_VISIBLE,
+        CW_USEDEFAULT, CW_USEDEFAULT, 960, 640,
+        nullptr, nullptr, GetModuleHandleW(nullptr), session);
+}
+
 HWND GhosttyBridge::createGLWindow(HWND parent, TerminalSession* session) {
     static bool registered = false;
     if (!registered) {
@@ -605,24 +646,13 @@ HWND GhosttyBridge::createGLWindow(HWND parent, TerminalSession* session) {
         registered = true;
     }
 
-    HWND hwnd;
-    if (parent) {
-        // Child window mode
-        RECT rc;
-        GetClientRect(parent, &rc);
-        hwnd = CreateWindowExW(
-            0, L"GhosttyGLWindow", nullptr,
-            WS_CHILD | WS_VISIBLE | WS_CLIPSIBLINGS | WS_CLIPCHILDREN,
-            0, 0, rc.right - rc.left, rc.bottom - rc.top,
-            parent, nullptr, GetModuleHandleW(nullptr), session);
-    } else {
-        // Standalone window mode (no WinUI parent)
-        hwnd = CreateWindowExW(
-            0, L"GhosttyGLWindow", L"Ghostty",
-            WS_OVERLAPPEDWINDOW | WS_VISIBLE,
-            CW_USEDEFAULT, CW_USEDEFAULT, 960, 640,
-            nullptr, nullptr, GetModuleHandleW(nullptr), session);
-    }
+    RECT rc;
+    GetClientRect(parent, &rc);
+    HWND hwnd = CreateWindowExW(
+        0, L"GhosttyGLWindow", nullptr,
+        WS_CHILD | WS_VISIBLE | WS_CLIPSIBLINGS | WS_CLIPCHILDREN,
+        0, 0, rc.right - rc.left, rc.bottom - rc.top,
+        parent, nullptr, GetModuleHandleW(nullptr), session);
 
     if (hwnd) {
         char buf[128];
@@ -641,9 +671,22 @@ TerminalSession* GhosttyBridge::createSurface(HWND parentHwnd) {
     auto sessionOwned = std::make_unique<TerminalSession>();
     TerminalSession* session = sessionOwned.get();
 
-    // Create the Win32 window — session pointer is plumbed through WM_NCCREATE
+    // If no parent was supplied, host the rendering child inside our own
+    // top-level main window (Phase 2-A: always one main window per session).
+    if (!parentHwnd) {
+        session->parentHwnd = createMainWindow(session);
+        if (!session->parentHwnd) return nullptr;
+        parentHwnd = session->parentHwnd;
+    } else {
+        session->parentHwnd = parentHwnd;
+    }
+
+    // Create the rendering child — session pointer is plumbed through WM_NCCREATE
     session->hwnd = createGLWindow(parentHwnd, session);
-    if (!session->hwnd) return nullptr;
+    if (!session->hwnd) {
+        if (session->parentHwnd) DestroyWindow(session->parentHwnd);
+        return nullptr;
+    }
 
     // Run on 4MB stack thread with renderer context
     struct Args {
@@ -719,10 +762,14 @@ void GhosttyBridge::destroySession(TerminalSession* session) {
         session->surface = nullptr;
     }
     shutdownOpenGL(session);
-    // Window destruction is the caller's responsibility (typically driven by WM_CLOSE).
-    // Clear the userdata so any pending messages on this hwnd see no session.
+    // Clear userdata so pending messages on these hwnds see no session.
+    // Window destruction is driven by WM_CLOSE on the parent — we don't
+    // DestroyWindow here, we just detach.
     if (session->hwnd) {
         SetWindowLongPtrW(session->hwnd, GWLP_USERDATA, 0);
+    }
+    if (session->parentHwnd) {
+        SetWindowLongPtrW(session->parentHwnd, GWLP_USERDATA, 0);
     }
     for (auto it = m_sessions.begin(); it != m_sessions.end(); ++it) {
         if (it->get() == session) {
@@ -754,7 +801,9 @@ bool GhosttyBridge::onAction(ghostty_app_t app, ghostty_target_s target, ghostty
     if (target.tag == GHOSTTY_TARGET_SURFACE) {
         sess = sessionFromSurface(target.target.surface);
     }
-    HWND hwnd = sess ? sess->hwnd : nullptr;
+    // Window-level actions (title, fullscreen, decorations, color, ...) target
+    // the top-level main window. The rendering child does not own a frame.
+    HWND hwnd = sess ? sess->parentHwnd : nullptr;
 
     switch (action.tag) {
     case GHOSTTY_ACTION_SET_TITLE:
@@ -946,9 +995,9 @@ bool GhosttyBridge::onReadClipboard(void* userdata, ghostty_clipboard_e clipboar
     // Phase 3 will need to track the focused session.
     if (!self || self->m_sessions.empty()) return false;
     TerminalSession* sess = self->m_sessions.front().get();
-    if (!sess->surface || !sess->hwnd) return false;
+    if (!sess->surface || !sess->parentHwnd) return false;
 
-    if (!OpenClipboard(sess->hwnd)) return false;
+    if (!OpenClipboard(sess->parentHwnd)) return false;
 
     HANDLE hData = GetClipboardData(CF_UNICODETEXT);
     if (!hData) {
@@ -983,7 +1032,7 @@ void GhosttyBridge::onWriteClipboard(void* userdata, ghostty_clipboard_e clipboa
     auto* self = static_cast<GhosttyBridge*>(userdata);
     // TODO(tabs): same caveat as onReadClipboard — Phase 1 uses the front session's hwnd.
     if (!self || self->m_sessions.empty() || count == 0 || !content) return;
-    HWND hwnd = self->m_sessions.front()->hwnd;
+    HWND hwnd = self->m_sessions.front()->parentHwnd;
     if (!hwnd) return;
 
     // Find text content

--- a/GhosttyBridge.cpp
+++ b/GhosttyBridge.cpp
@@ -557,7 +557,7 @@ LRESULT CALLBACK GhosttyBridge::mainWndProc(HWND hwnd, UINT msg, WPARAM wParam, 
         GetClientRect(hwnd, &rc);
         POINT pt = { GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam) };
         ScreenToClient(hwnd, &pt);
-        const int border = 6;
+        const int border = 4;  // thin resize border (sides + bottom)
         bool left = pt.x < border;
         bool right = pt.x >= rc.right - border;
         bool top = pt.y < border;
@@ -568,9 +568,10 @@ LRESULT CALLBACK GhosttyBridge::mainWndProc(HWND hwnd, UINT msg, WPARAM wParam, 
         if (bottom && right) return HTBOTTOMRIGHT;
         if (left) return HTLEFT;
         if (right) return HTRIGHT;
+        // Top 4px = resize, 4-8px = drag caption (above XAML Island)
         if (top) return HTTOP;
         if (bottom) return HTBOTTOM;
-        if (pt.y < sess->headerHeight) return HTCAPTION;
+        if (pt.y < 8) return HTCAPTION;
         return HTCLIENT;
     }
 
@@ -591,12 +592,16 @@ LRESULT CALLBACK GhosttyBridge::mainWndProc(HWND hwnd, UINT msg, WPARAM wParam, 
         int top = sess->headerHeight;
         int childHeight = height - top;
         if (childHeight < 1) childHeight = 1;
-        // Resize the XAML host and its island child to fill the header area.
-        if (sess->xamlHostWnd && top > 0) {
-            SetWindowPos(sess->xamlHostWnd, nullptr, 0, 0, width, top,
+        // Resize the XAML host below a thin drag strip at the very top.
+        // The top 6px remain as the parent's HTCAPTION area for window drag.
+        const int dragStrip = 8;
+        int xamlTop = (top > dragStrip) ? dragStrip : 0;
+        int xamlHeight = top - xamlTop;
+        if (sess->xamlHostWnd && xamlHeight > 0) {
+            SetWindowPos(sess->xamlHostWnd, nullptr, 0, xamlTop, width, xamlHeight,
                 SWP_NOZORDER | SWP_NOACTIVATE | SWP_SHOWWINDOW);
             if (sess->xamlIslandHwnd) {
-                SetWindowPos(sess->xamlIslandHwnd, nullptr, 0, 0, width, top,
+                SetWindowPos(sess->xamlIslandHwnd, nullptr, 0, 0, width, xamlHeight,
                     SWP_NOZORDER | SWP_NOACTIVATE | SWP_SHOWWINDOW);
             }
         }
@@ -666,7 +671,7 @@ HWND GhosttyBridge::createMainWindow(TerminalSession* session) {
         wc.hInstance = GetModuleHandleW(nullptr);
         wc.lpszClassName = L"GhosttyMainWindow";
         wc.hCursor = LoadCursorW(nullptr, IDC_ARROW);
-        wc.hbrBackground = (HBRUSH)(COLOR_WINDOW + 1);
+        wc.hbrBackground = CreateSolidBrush(RGB(30, 30, 30));
         RegisterClassW(&wc);
         registered = true;
     }

--- a/GhosttyBridge.cpp
+++ b/GhosttyBridge.cpp
@@ -10,11 +10,6 @@
 #pragma comment(lib, "dwmapi.lib")
 #include "GhosttyBridge.h"
 
-#ifdef _DEBUG
-#define DBG_LOG(msg) OutputDebugStringA(msg)
-#else
-#define DBG_LOG(msg) ((void)0)
-#endif
 #pragma comment(lib, "opengl32.lib")
 #pragma comment(lib, "gdi32.lib")
 
@@ -105,16 +100,10 @@ bool GhosttyBridge::initialize() {
     // Check config diagnostics
     uint32_t diagCount = ghostty_config_diagnostics_count(m_config);
     if (diagCount > 0) {
-        char buf[128];
-        sprintf_s(buf, "ghostty: config has %u diagnostics\n", diagCount);
-        OutputDebugStringA(buf);
+        DBG_LOG("ghostty: config has diagnostics\n");
         for (uint32_t i = 0; i < diagCount; i++) {
             ghostty_diagnostic_s diag = ghostty_config_get_diagnostic(m_config, i);
-            if (diag.message) {
-                OutputDebugStringA("ghostty: config diag: ");
-                OutputDebugStringA(diag.message);
-                OutputDebugStringA("\n");
-            }
+            if (diag.message) DBG_LOG(diag.message);
         }
     }
     DBG_LOG("ghostty: config finalized\n");
@@ -852,11 +841,6 @@ TerminalSession* GhosttyBridge::createSurface(HWND parentHwnd) {
             char rendererBuf[32] = {};
             GetEnvironmentVariableA("GHOSTTY_RENDERER", rendererBuf, sizeof(rendererBuf));
             bool useDirectX = (strcmp(rendererBuf, "opengl") != 0);
-            {
-                char logBuf[128];
-                sprintf_s(logBuf, "ghostty: GHOSTTY_RENDERER=%s useDirectX=%d\n", rendererBuf, useDirectX);
-                OutputDebugStringA(logBuf);
-            }
 
             if (!useDirectX) {
                 // Create and activate OpenGL context on this thread
@@ -878,22 +862,7 @@ TerminalSession* GhosttyBridge::createSurface(HWND parentHwnd) {
             UINT dpi = GetDpiForWindow(sess->hwnd);
             surfConfig.scale_factor = (double)dpi / 96.0;
 
-            {
-                char buf[256];
-                sprintf_s(buf, "ghostty: calling ghostty_surface_new app=%p hwnd=%p sessions=%zu\n",
-                    a->self->m_app, sess->hwnd, a->self->m_sessions.size());
-                OutputDebugStringA(buf);
-            }
-
-            __try {
-                sess->surface = ghostty_surface_new(a->self->m_app, &surfConfig);
-            } __except(EXCEPTION_EXECUTE_HANDLER) {
-                char buf[128];
-                sprintf_s(buf, "ghostty: CRASH in ghostty_surface_new! code=0x%08X\n",
-                    GetExceptionCode());
-                OutputDebugStringA(buf);
-                sess->surface = nullptr;
-            }
+            sess->surface = ghostty_surface_new(a->self->m_app, &surfConfig);
 
             // Release GL context BEFORE thread exits so renderer thread can acquire it
             if (!useDirectX) wglMakeCurrent(nullptr, nullptr);
@@ -1100,10 +1069,6 @@ bool GhosttyBridge::onAction(ghostty_app_t app, ghostty_target_s target, ghostty
             sess->minHeight = action.action.size_limit.min_height;
             sess->maxWidth = action.action.size_limit.max_width;
             sess->maxHeight = action.action.size_limit.max_height;
-            char buf[128];
-            sprintf_s(buf, "ghostty: SIZE_LIMIT min=%ux%u max=%ux%u\n",
-                sess->minWidth, sess->minHeight, sess->maxWidth, sess->maxHeight);
-            OutputDebugStringA(buf);
         }
         return true;
     }

--- a/GhosttyBridge.cpp
+++ b/GhosttyBridge.cpp
@@ -612,15 +612,20 @@ LRESULT CALLBACK GhosttyBridge::mainWndProc(HWND hwnd, UINT msg, WPARAM wParam, 
         return HTCLIENT;
     }
 
-    case WM_GETMINMAXINFO:
-        if (sess) {
+    case WM_GETMINMAXINFO: {
+        // Use sess if available, otherwise find any active session for size limits
+        TerminalSession* limSess = sess;
+        if (!limSess && !bridge.m_sessions.empty())
+            limSess = bridge.m_sessions.front().get();
+        if (limSess) {
             auto* mmi = reinterpret_cast<MINMAXINFO*>(lParam);
-            if (sess->minWidth > 0) mmi->ptMinTrackSize.x = sess->minWidth;
-            if (sess->minHeight > 0) mmi->ptMinTrackSize.y = sess->minHeight;
-            if (sess->maxWidth > 0) mmi->ptMaxTrackSize.x = sess->maxWidth;
-            if (sess->maxHeight > 0) mmi->ptMaxTrackSize.y = sess->maxHeight;
+            if (limSess->minWidth > 0) mmi->ptMinTrackSize.x = limSess->minWidth;
+            if (limSess->minHeight > 0) mmi->ptMinTrackSize.y = limSess->minHeight;
+            if (limSess->maxWidth > 0) mmi->ptMaxTrackSize.x = limSess->maxWidth;
+            if (limSess->maxHeight > 0) mmi->ptMaxTrackSize.y = limSess->maxHeight;
         }
         return 0;
+    }
 
     case WM_SIZE: {
         int width = LOWORD(lParam);
@@ -673,31 +678,32 @@ LRESULT CALLBACK GhosttyBridge::mainWndProc(HWND hwnd, UINT msg, WPARAM wParam, 
     }
 
     case WM_SETFOCUS:
-        // Forward focus to the rendering child so it receives keyboard input.
-        if (sess && sess->hwnd) SetFocus(sess->hwnd);
+        // Forward focus to the topmost rendering child.
+        PostMessageW(hwnd, WM_APP, 0, 0);
         return 0;
 
     case WM_ACTIVATE:
-        // When the window is activated (clicked, alt-tabbed to), force focus
-        // to the Ghostty child. The XAML Island's internal windows tend to
-        // capture focus otherwise, preventing terminal keyboard input.
-        if (LOWORD(wParam) != WA_INACTIVE && sess && sess->hwnd) {
-            SetFocus(sess->hwnd);
+        // When the window is activated, return focus to the active tab.
+        if (LOWORD(wParam) != WA_INACTIVE) {
+            PostMessageW(hwnd, WM_APP, 0, 0);
         }
         return 0;
 
-    case WM_DPICHANGED:
-        if (sess && sess->surface) {
-            UINT dpi = HIWORD(wParam);
-            double scale = (double)dpi / 96.0;
-            ghostty_surface_set_content_scale(sess->surface, scale, scale);
-            RECT* suggested = (RECT*)lParam;
-            SetWindowPos(hwnd, nullptr,
-                suggested->left, suggested->top,
-                suggested->right - suggested->left,
-                suggested->bottom - suggested->top,
-                SWP_NOZORDER | SWP_NOACTIVATE);
+    case WM_DPICHANGED: {
+        UINT dpi = HIWORD(wParam);
+        double scale = (double)dpi / 96.0;
+        // Apply DPI to all surfaces
+        for (auto& s : bridge.m_sessions) {
+            if (s->surface)
+                ghostty_surface_set_content_scale(s->surface, scale, scale);
         }
+        RECT* suggested = (RECT*)lParam;
+        SetWindowPos(hwnd, nullptr,
+            suggested->left, suggested->top,
+            suggested->right - suggested->left,
+            suggested->bottom - suggested->top,
+            SWP_NOZORDER | SWP_NOACTIVATE);
+    }
         return 0;
 
     case WM_APP: {

--- a/GhosttyBridge.cpp
+++ b/GhosttyBridge.cpp
@@ -574,14 +574,19 @@ LRESULT CALLBACK GhosttyBridge::mainWndProc(HWND hwnd, UINT msg, WPARAM wParam, 
         return 0;
 
     case WM_SIZE: {
-        // Resize the rendering child to fill our client area below the header.
-        // The child's WM_SIZE handler notifies the renderer + ghostty surface.
-        if (sess && sess->hwnd) {
-            int width = LOWORD(lParam);
-            int height = HIWORD(lParam);
-            int top = sess->headerHeight;
-            int childHeight = height - top;
-            if (childHeight < 1) childHeight = 1;
+        if (!sess) return 0;
+        int width = LOWORD(lParam);
+        int height = HIWORD(lParam);
+        int top = sess->headerHeight;
+        int childHeight = height - top;
+        if (childHeight < 1) childHeight = 1;
+        // Resize the XAML Island to fill the header area.
+        if (sess->xamlIslandHwnd && top > 0) {
+            SetWindowPos(sess->xamlIslandHwnd, nullptr, 0, 0, width, top,
+                SWP_NOZORDER | SWP_NOACTIVATE | SWP_SHOWWINDOW);
+        }
+        // Resize the rendering child below the header.
+        if (sess->hwnd) {
             SetWindowPos(sess->hwnd, nullptr, 0, top, width, childHeight,
                 SWP_NOZORDER | SWP_NOACTIVATE);
         }

--- a/GhosttyBridge.cpp
+++ b/GhosttyBridge.cpp
@@ -568,10 +568,13 @@ LRESULT CALLBACK GhosttyBridge::mainWndProc(HWND hwnd, UINT msg, WPARAM wParam, 
         if (bottom && right) return HTBOTTOMRIGHT;
         if (left) return HTLEFT;
         if (right) return HTRIGHT;
-        // Top 4px = resize, 4-8px = drag caption (above XAML Island)
         if (top) return HTTOP;
         if (bottom) return HTBOTTOM;
-        if (pt.y < 8) return HTCAPTION;
+        // Header area: HTCAPTION for drag. Currently the XAML Island
+        // absorbs mouse events so drag only works outside the island.
+        // Proper tab-bar drag requires DwmExtendFrameIntoClientArea
+        // integration — tracked as a future improvement.
+        if (sess->headerHeight > 0 && pt.y < sess->headerHeight) return HTCAPTION;
         return HTCLIENT;
     }
 
@@ -592,16 +595,12 @@ LRESULT CALLBACK GhosttyBridge::mainWndProc(HWND hwnd, UINT msg, WPARAM wParam, 
         int top = sess->headerHeight;
         int childHeight = height - top;
         if (childHeight < 1) childHeight = 1;
-        // Resize the XAML host below a thin drag strip at the very top.
-        // The top 6px remain as the parent's HTCAPTION area for window drag.
-        const int dragStrip = 8;
-        int xamlTop = (top > dragStrip) ? dragStrip : 0;
-        int xamlHeight = top - xamlTop;
-        if (sess->xamlHostWnd && xamlHeight > 0) {
-            SetWindowPos(sess->xamlHostWnd, nullptr, 0, xamlTop, width, xamlHeight,
+        // Resize the XAML host to fill the header area.
+        if (sess->xamlHostWnd && top > 0) {
+            SetWindowPos(sess->xamlHostWnd, nullptr, 0, 0, width, top,
                 SWP_NOZORDER | SWP_NOACTIVATE | SWP_SHOWWINDOW);
             if (sess->xamlIslandHwnd) {
-                SetWindowPos(sess->xamlIslandHwnd, nullptr, 0, 0, width, xamlHeight,
+                SetWindowPos(sess->xamlIslandHwnd, nullptr, 0, 0, width, top,
                     SWP_NOZORDER | SWP_NOACTIVATE | SWP_SHOWWINDOW);
             }
         }

--- a/GhosttyBridge.cpp
+++ b/GhosttyBridge.cpp
@@ -637,18 +637,12 @@ LRESULT CALLBACK GhosttyBridge::mainWndProc(HWND hwnd, UINT msg, WPARAM wParam, 
         int top = sess ? sess->headerHeight : TerminalSession::kDefaultHeaderHeight;
         int childHeight = height - top;
         if (childHeight < 1) childHeight = 1;
-        // Resize XAML host (use sess if available, otherwise find from sessions)
-        HWND xamlHost = sess ? sess->xamlHostWnd : nullptr;
-        HWND xamlIsland = sess ? sess->xamlIslandHwnd : nullptr;
-        if (!xamlHost && !bridge.m_sessions.empty()) {
-            xamlHost = bridge.m_sessions.front()->xamlHostWnd;
-            xamlIsland = bridge.m_sessions.front()->xamlIslandHwnd;
-        }
-        if (xamlHost && top > 0) {
-            SetWindowPos(xamlHost, nullptr, 0, 0, width, top,
+        // Resize XAML host (stored on bridge, persists across tab closes)
+        if (bridge.m_xamlHostWnd && top > 0) {
+            SetWindowPos(bridge.m_xamlHostWnd, nullptr, 0, 0, width, top,
                 SWP_NOZORDER | SWP_NOACTIVATE | SWP_SHOWWINDOW);
-            if (xamlIsland) {
-                SetWindowPos(xamlIsland, nullptr, 0, 0, width, top,
+            if (bridge.m_xamlIslandHwnd) {
+                SetWindowPos(bridge.m_xamlIslandHwnd, nullptr, 0, 0, width, top,
                     SWP_NOZORDER | SWP_NOACTIVATE | SWP_SHOWWINDOW);
             }
         }

--- a/GhosttyBridge.cpp
+++ b/GhosttyBridge.cpp
@@ -684,16 +684,22 @@ LRESULT CALLBACK GhosttyBridge::mainWndProc(HWND hwnd, UINT msg, WPARAM wParam, 
         }
         return 0;
 
-    case WM_APP:
+    case WM_APP: {
         // Posted by XAML Island's GotFocus / SelectionChanged — return focus
-        // to whichever terminal session is currently visible.
-        for (auto& s : bridge.m_sessions) {
-            if (s->hwnd && IsWindowVisible(s->hwnd)) {
-                SetFocus(s->hwnd);
-                break;
+        // to the topmost (active) terminal session child window.
+        HWND topChild = GetTopWindow(hwnd);
+        // Walk down to find the first session child (skip XAML host etc.)
+        while (topChild) {
+            for (auto& s : bridge.m_sessions) {
+                if (s->hwnd == topChild) {
+                    SetFocus(topChild);
+                    return 0;
+                }
             }
+            topChild = GetNextWindow(topChild, GW_HWNDNEXT);
         }
         return 0;
+    }
 
     case WM_USER + 1:
         // Wakeup from ghostty — process pending events on main thread.

--- a/GhosttyBridge.h
+++ b/GhosttyBridge.h
@@ -96,6 +96,13 @@ private:
     // Look up the session associated with a ghostty_surface_t (via surface userdata).
     static TerminalSession* sessionFromSurface(ghostty_surface_t surface);
 
+public:
+    // Callback for tab title updates (set by wWinMain, called from onAction).
+    // sessionHwnd identifies which tab to update.
+    using TitleChangedFn = void(*)(void* ctx, HWND sessionHwnd, const wchar_t* title);
+    static TitleChangedFn s_titleChangedFn;
+    static void* s_titleChangedCtx;
+
     ghostty_app_t m_app = nullptr;
     ghostty_config_t m_config = nullptr;
     bool m_initialized = false;

--- a/GhosttyBridge.h
+++ b/GhosttyBridge.h
@@ -13,19 +13,24 @@
 // Stored in HWND GWLP_USERDATA and in ghostty_surface userdata for fast lookup.
 struct TerminalSession {
     ghostty_surface_t surface = nullptr;
+
+    // Top-level window that hosts the rendering child. Owns title, frame,
+    // fullscreen state, size limits, and receives close/dpi events.
+    HWND parentHwnd = nullptr;
+    // Child window the renderer draws into and that receives input events.
     HWND hwnd = nullptr;
 
     // OpenGL renderer state (unused in DirectX mode)
     HDC hdc = nullptr;
     HGLRC hglrc = nullptr;
 
-    // Window state for fullscreen/decorations toggle
+    // Window state for fullscreen/decorations toggle (apply to parentHwnd)
     bool fullscreen = false;
     bool decorations = true;
     RECT savedRect = {};
     DWORD savedStyle = 0;
 
-    // Size limits from ghostty config
+    // Size limits from ghostty config (enforced on parentHwnd via WM_GETMINMAXINFO)
     uint32_t minWidth = 0, minHeight = 0;
     uint32_t maxWidth = 0, maxHeight = 0;
 };
@@ -65,6 +70,10 @@ private:
     static void onConfirmReadClipboard(void* userdata, const char* content, void* state, ghostty_clipboard_request_e req);
     static void onWriteClipboard(void* userdata, ghostty_clipboard_e clipboard, const ghostty_clipboard_content_s* content, size_t count, bool confirm);
     static void onCloseSurface(void* userdata, bool process_exited);
+
+    // Top-level window that hosts the rendering child window.
+    static LRESULT CALLBACK mainWndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam);
+    HWND createMainWindow(TerminalSession* session);
 
     // Win32 child window for OpenGL/DirectX rendering
     static LRESULT CALLBACK glWndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam);

--- a/GhosttyBridge.h
+++ b/GhosttyBridge.h
@@ -35,9 +35,10 @@ struct TerminalSession {
     // when window-decoration=false to give the chromeless terminal-only look.
     int headerHeight = 32;
 
-    // XAML Islands: the child HWND created by DesktopWindowXamlSource.
-    // Positioned in the header area, hosts WinUI 2 controls (TabView).
-    HWND xamlIslandHwnd = nullptr;
+    // XAML Islands: a dedicated host child window and the island HWND inside it.
+    // Kept separate from the rendering child to avoid DXGI swap chain conflicts.
+    HWND xamlHostWnd = nullptr;   // our child of parentHwnd, hosts the island
+    HWND xamlIslandHwnd = nullptr; // child of xamlHostWnd, created by XAML
 
     // Size limits from ghostty config (enforced on parentHwnd via WM_GETMINMAXINFO)
     uint32_t minWidth = 0, minHeight = 0;

--- a/GhosttyBridge.h
+++ b/GhosttyBridge.h
@@ -30,6 +30,12 @@ struct TerminalSession {
     RECT savedRect = {};
     DWORD savedStyle = 0;
 
+    // Reserved area at the top of the main window for tabs / drag region.
+    // Zero when the native caption is visible (decorations=true); set to 32px
+    // when decorations=false so the user still has somewhere to drag the
+    // window from. Step 2-D will host XAML controls in this area.
+    int headerHeight = 0;
+
     // Size limits from ghostty config (enforced on parentHwnd via WM_GETMINMAXINFO)
     uint32_t minWidth = 0, minHeight = 0;
     uint32_t maxWidth = 0, maxHeight = 0;

--- a/GhosttyBridge.h
+++ b/GhosttyBridge.h
@@ -3,9 +3,32 @@
 #include <Windows.h>
 #include <GL/gl.h>
 #include <cstdint>
+#include <vector>
+#include <memory>
 
 // Bridge between libghostty and Win32
 // Equivalent to the Swift AppDelegate on macOS
+
+// Per-surface state. One instance per terminal tab/window.
+// Stored in HWND GWLP_USERDATA and in ghostty_surface userdata for fast lookup.
+struct TerminalSession {
+    ghostty_surface_t surface = nullptr;
+    HWND hwnd = nullptr;
+
+    // OpenGL renderer state (unused in DirectX mode)
+    HDC hdc = nullptr;
+    HGLRC hglrc = nullptr;
+
+    // Window state for fullscreen/decorations toggle
+    bool fullscreen = false;
+    bool decorations = true;
+    RECT savedRect = {};
+    DWORD savedStyle = 0;
+
+    // Size limits from ghostty config
+    uint32_t minWidth = 0, minHeight = 0;
+    uint32_t maxWidth = 0, maxHeight = 0;
+};
 
 class GhosttyBridge {
 public:
@@ -21,12 +44,13 @@ public:
     ghostty_config_t config() const { return m_config; }
     bool isInitialized() const { return m_initialized; }
 
-    // Surface creation/destruction
-    // Creates a Win32 child window inside parentHwnd for OpenGL rendering
-    ghostty_surface_t createSurface(HWND parentHwnd);
-    void destroySurface(ghostty_surface_t surface);
-    HWND glWindow() const { return m_glWindow; }
-    void setDecorations(bool enabled) { m_decorations = enabled; }
+    // Creates a new TerminalSession with its own child window and ghostty surface.
+    // If parentHwnd is null, creates a top-level window.
+    // Returned pointer is owned by GhosttyBridge.
+    TerminalSession* createSurface(HWND parentHwnd);
+    void destroySession(TerminalSession* session);
+
+    const std::vector<std::unique_ptr<TerminalSession>>& sessions() const { return m_sessions; }
 
 private:
     GhosttyBridge() = default;
@@ -42,29 +66,20 @@ private:
     static void onWriteClipboard(void* userdata, ghostty_clipboard_e clipboard, const ghostty_clipboard_content_s* content, size_t count, bool confirm);
     static void onCloseSurface(void* userdata, bool process_exited);
 
-    // Win32 child window for OpenGL rendering
+    // Win32 child window for OpenGL/DirectX rendering
     static LRESULT CALLBACK glWndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam);
-    HWND createGLWindow(HWND parent);
+    HWND createGLWindow(HWND parent, TerminalSession* session);
 
-    // OpenGL context for WGL
-    bool initOpenGL(HWND hwnd);
-    void shutdownOpenGL();
+    // OpenGL context for WGL (per-session)
+    static bool initOpenGL(TerminalSession* session);
+    static void shutdownOpenGL(TerminalSession* session);
+
+    // Look up the session associated with a ghostty_surface_t (via surface userdata).
+    static TerminalSession* sessionFromSurface(ghostty_surface_t surface);
 
     ghostty_app_t m_app = nullptr;
     ghostty_config_t m_config = nullptr;
-    ghostty_surface_t m_surface = nullptr;
-    HWND m_glWindow = nullptr;
-    HDC m_hdc = nullptr;
-    HGLRC m_hglrc = nullptr;
-    bool m_vsync = false;
     bool m_initialized = false;
 
-    // Window state for fullscreen/decorations toggle
-    bool m_fullscreen = false;
-    bool m_decorations = true;
-    RECT m_savedRect = {};        // Window rect before fullscreen
-    DWORD m_savedStyle = 0;       // Window style before fullscreen
-    uint32_t m_minWidth = 0, m_minHeight = 0;
-    uint32_t m_maxWidth = 0, m_maxHeight = 0;
-
+    std::vector<std::unique_ptr<TerminalSession>> m_sessions;
 };

--- a/GhosttyBridge.h
+++ b/GhosttyBridge.h
@@ -30,11 +30,10 @@ struct TerminalSession {
     RECT savedRect = {};
     DWORD savedStyle = 0;
 
-    // Reserved area at the top of the main window for tabs / drag region.
-    // Zero when the native caption is visible (decorations=true); set to 32px
-    // when decorations=false so the user still has somewhere to drag the
-    // window from. Step 2-D will host XAML controls in this area.
-    int headerHeight = 0;
+    // Reserved area at the top of the main window for the XAML tab bar (which
+    // also serves as the drag region, since there is no native caption). Zero
+    // when window-decoration=false to give the chromeless terminal-only look.
+    int headerHeight = 32;
 
     // Size limits from ghostty config (enforced on parentHwnd via WM_GETMINMAXINFO)
     uint32_t minWidth = 0, minHeight = 0;

--- a/GhosttyBridge.h
+++ b/GhosttyBridge.h
@@ -106,5 +106,10 @@ public:
     ghostty_config_t m_config = nullptr;
     bool m_initialized = false;
 
+    // Main window HWND for thread-safe wakeup posting.
+    // Set once during first createSurface, never changes after.
+    // onWakeup uses this instead of m_sessions to avoid data races.
+    HWND m_wakeupHwnd = nullptr;
+
     std::vector<std::unique_ptr<TerminalSession>> m_sessions;
 };

--- a/GhosttyBridge.h
+++ b/GhosttyBridge.h
@@ -116,5 +116,9 @@ public:
     HWND m_xamlHostWnd = nullptr;
     HWND m_xamlIslandHwnd = nullptr;
 
+    // Terminal background color — updated by COLOR_CHANGE action,
+    // used to fill exposed areas during resize.
+    COLORREF m_bgColor = RGB(30, 30, 30);
+
     std::vector<std::unique_ptr<TerminalSession>> m_sessions;
 };

--- a/GhosttyBridge.h
+++ b/GhosttyBridge.h
@@ -101,6 +101,10 @@ public:
     // sessionHwnd identifies which tab to update.
     using TitleChangedFn = void(*)(void* ctx, HWND sessionHwnd, const wchar_t* title);
     static TitleChangedFn s_titleChangedFn;
+
+    using BgColorChangedFn = void(*)(void* ctx, uint8_t r, uint8_t g, uint8_t b);
+    static BgColorChangedFn s_bgColorChangedFn;
+    static void* s_bgColorChangedCtx;
     static void* s_titleChangedCtx;
 
     ghostty_app_t m_app = nullptr;

--- a/GhosttyBridge.h
+++ b/GhosttyBridge.h
@@ -33,7 +33,7 @@ struct TerminalSession {
     // Reserved area at the top of the main window for the XAML tab bar (which
     // also serves as the drag region, since there is no native caption). Zero
     // when window-decoration=false to give the chromeless terminal-only look.
-    int headerHeight = 32;
+    int headerHeight = 40;
 
     // XAML Islands: a dedicated host child window and the island HWND inside it.
     // Kept separate from the rendering child to avoid DXGI swap chain conflicts.

--- a/GhosttyBridge.h
+++ b/GhosttyBridge.h
@@ -36,8 +36,7 @@ struct TerminalSession {
     int headerHeight = 40;
 
     // XAML Islands: a dedicated host child window and the island HWND inside it.
-    // Kept separate from the rendering child to avoid DXGI swap chain conflicts.
-    HWND xamlHostWnd = nullptr;   // our child of parentHwnd, hosts the island
+    HWND xamlHostWnd = nullptr;    // our child of parentHwnd, hosts the island
     HWND xamlIslandHwnd = nullptr; // child of xamlHostWnd, created by XAML
 
     // Size limits from ghostty config (enforced on parentHwnd via WM_GETMINMAXINFO)

--- a/GhosttyBridge.h
+++ b/GhosttyBridge.h
@@ -6,6 +6,12 @@
 #include <vector>
 #include <memory>
 
+#ifdef _DEBUG
+#define DBG_LOG(msg) OutputDebugStringA(msg)
+#else
+#define DBG_LOG(msg) ((void)0)
+#endif
+
 // Bridge between libghostty and Win32
 // Equivalent to the Swift AppDelegate on macOS
 

--- a/GhosttyBridge.h
+++ b/GhosttyBridge.h
@@ -35,6 +35,10 @@ struct TerminalSession {
     // when window-decoration=false to give the chromeless terminal-only look.
     int headerHeight = 32;
 
+    // XAML Islands: the child HWND created by DesktopWindowXamlSource.
+    // Positioned in the header area, hosts WinUI 2 controls (TabView).
+    HWND xamlIslandHwnd = nullptr;
+
     // Size limits from ghostty config (enforced on parentHwnd via WM_GETMINMAXINFO)
     uint32_t minWidth = 0, minHeight = 0;
     uint32_t maxWidth = 0, maxHeight = 0;

--- a/GhosttyBridge.h
+++ b/GhosttyBridge.h
@@ -33,7 +33,8 @@ struct TerminalSession {
     // Reserved area at the top of the main window for the XAML tab bar (which
     // also serves as the drag region, since there is no native caption). Zero
     // when window-decoration=false to give the chromeless terminal-only look.
-    int headerHeight = 40;
+    static constexpr int kDefaultHeaderHeight = 40;
+    int headerHeight = kDefaultHeaderHeight;
 
     // XAML Islands: a dedicated host child window and the island HWND inside it.
     HWND xamlHostWnd = nullptr;    // our child of parentHwnd, hosts the island

--- a/GhosttyBridge.h
+++ b/GhosttyBridge.h
@@ -112,5 +112,9 @@ public:
     // onWakeup uses this instead of m_sessions to avoid data races.
     HWND m_wakeupHwnd = nullptr;
 
+    // XAML Island HWNDs — shared across all tabs, created once.
+    HWND m_xamlHostWnd = nullptr;
+    HWND m_xamlIslandHwnd = nullptr;
+
     std::vector<std::unique_ptr<TerminalSession>> m_sessions;
 };

--- a/GhosttyWin32.cpp
+++ b/GhosttyWin32.cpp
@@ -163,6 +163,7 @@ int APIENTRY wWinMain(
                     hwnd, nullptr, GetModuleHandleW(nullptr), nullptr);
 
                 session->xamlHostWnd = xamlHostWnd;
+                bridge.m_xamlHostWnd = xamlHostWnd;
 
                 xamlSource = DesktopWindowXamlSource();
                 auto interop = xamlSource.as<IDesktopWindowXamlSourceNative>();
@@ -171,6 +172,7 @@ int APIENTRY wWinMain(
                 HWND islandHwnd = nullptr;
                 winrt::check_hresult(interop->get_WindowHandle(&islandHwnd));
                 session->xamlIslandHwnd = islandHwnd;
+                bridge.m_xamlIslandHwnd = islandHwnd;
 
                 // Fill the host window.
                 SetWindowPos(islandHwnd, nullptr, 0, 0,
@@ -319,10 +321,8 @@ int APIENTRY wWinMain(
                     [parentHwnd, &bridge](muxc::TabView const& tv, auto&&) {
                         auto* newSess = bridge.createSurface(parentHwnd);
                         if (!newSess) return;
-                        // TODO: reduce flicker on new tab creation
-                        ShowWindow(newSess->hwnd, SW_SHOW);
-                        SetFocus(newSess->hwnd);
-                        // Add a new tab
+                        // Add tab and select — SelectionChanged handles
+                        // DirectComposition visibility and focus.
                         auto newTab = muxc::TabViewItem();
                         newTab.Header(winrt::box_value(L"Terminal"));
                         newTab.Tag(winrt::box_value(reinterpret_cast<uint64_t>(newSess->hwnd)));

--- a/GhosttyWin32.cpp
+++ b/GhosttyWin32.cpp
@@ -160,6 +160,7 @@ int APIENTRY wWinMain(
                 tabView.VerticalAlignment(xaml::VerticalAlignment::Stretch);
                 tabView.IsAddTabButtonVisible(true);
                 tabView.TabWidthMode(muxc::TabViewWidthMode::Equal);
+                tabView.RequestedTheme(xaml::ElementTheme::Dark);
 
                 // First tab — associate with the initial session via Tag
                 auto tab1 = muxc::TabViewItem();

--- a/GhosttyWin32.cpp
+++ b/GhosttyWin32.cpp
@@ -29,10 +29,10 @@ int APIENTRY wWinMain(
     }
 
     // Create surface (standalone Win32 window)
-    bridge.createSurface(nullptr);
+    TerminalSession* session = bridge.createSurface(nullptr);
 
     // Apply config-driven window settings
-    if (HWND hwnd = bridge.glWindow()) {
+    if (HWND hwnd = session ? session->hwnd : nullptr) {
         // window-decoration
         const char* decorVal = nullptr;
         if (ghostty_config_get(bridge.config(), &decorVal, "window-decoration", 17) && decorVal) {
@@ -40,7 +40,7 @@ int APIENTRY wWinMain(
                 DWORD style = GetWindowLongW(hwnd, GWL_STYLE);
                 // Keep WS_THICKFRAME for smooth DWM resize, hide caption visually
                 style = (style & ~(WS_CAPTION | WS_SYSMENU | WS_MINIMIZEBOX | WS_MAXIMIZEBOX)) | WS_THICKFRAME;
-                bridge.setDecorations(false);
+                session->decorations = false;
                 SetWindowLongW(hwnd, GWL_STYLE, style);
                 SetWindowPos(hwnd, nullptr, 0, 0, 0, 0,
                     SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_FRAMECHANGED);

--- a/GhosttyWin32.cpp
+++ b/GhosttyWin32.cpp
@@ -23,6 +23,7 @@ int APIENTRY wWinMain(
     // identity needed (unlike WinUI 3, see issue #18).
     winrt::init_apartment(winrt::apartment_type::single_threaded);
     WindowsXamlManager xamlManager{ nullptr };
+    DesktopWindowXamlSource xamlSource{ nullptr }; // Must outlive the message loop
     bool xamlReady = false;
     try {
         // No XamlApplication needed — built-in WinUI 2 controls (TabView etc.)
@@ -77,30 +78,54 @@ int APIENTRY wWinMain(
         DwmSetWindowAttribute(hwnd, 33 /*DWMWA_WINDOW_CORNER_PREFERENCE*/, &cornerPref, sizeof(cornerPref));
 
         // Host a XAML Island in the header area (will become TabView in Step 2-E).
+        // The island is attached to a dedicated host child window (not the main
+        // window directly) so its DirectComposition surface doesn't conflict
+        // with ghostty's D3D11 swap chain on the rendering child.
         if (session->headerHeight > 0 && xamlReady) {
             try {
-                auto xamlSource = DesktopWindowXamlSource();
+                // Create a thin child window solely for hosting the XAML Island.
+                static bool xamlHostRegistered = false;
+                if (!xamlHostRegistered) {
+                    WNDCLASSW wc = {};
+                    wc.lpfnWndProc = DefWindowProcW;
+                    wc.hInstance = GetModuleHandleW(nullptr);
+                    wc.lpszClassName = L"GhosttyXamlHost";
+                    RegisterClassW(&wc);
+                    xamlHostRegistered = true;
+                }
+                RECT rc;
+                GetClientRect(hwnd, &rc);
+                HWND xamlHostWnd = CreateWindowExW(
+                    0, L"GhosttyXamlHost", nullptr,
+                    WS_CHILD | WS_VISIBLE,
+                    0, 0, rc.right - rc.left, session->headerHeight,
+                    hwnd, nullptr, GetModuleHandleW(nullptr), nullptr);
+
+                session->xamlHostWnd = xamlHostWnd;
+
+                xamlSource = DesktopWindowXamlSource();
                 auto interop = xamlSource.as<IDesktopWindowXamlSourceNative>();
-                winrt::check_hresult(interop->AttachToWindow(hwnd));
+                winrt::check_hresult(interop->AttachToWindow(xamlHostWnd));
 
                 HWND islandHwnd = nullptr;
                 winrt::check_hresult(interop->get_WindowHandle(&islandHwnd));
                 session->xamlIslandHwnd = islandHwnd;
 
-                // Position the island in the header area.
-                RECT rc;
-                GetClientRect(hwnd, &rc);
+                // Fill the host window.
                 SetWindowPos(islandHwnd, nullptr, 0, 0,
                     rc.right - rc.left, session->headerHeight,
                     SWP_SHOWWINDOW);
 
-                // Placeholder: a dark border matching the terminal background.
-                namespace controls = winrt::Windows::UI::Xaml::Controls;
-                namespace media = winrt::Windows::UI::Xaml::Media;
-                auto border = controls::Border();
-                border.Background(media::SolidColorBrush(
+                // Placeholder: a dark panel matching the terminal background.
+                namespace xaml = winrt::Windows::UI::Xaml;
+                namespace controls = xaml::Controls;
+                namespace media = xaml::Media;
+                auto grid = controls::Grid();
+                grid.Background(media::SolidColorBrush(
                     winrt::Windows::UI::ColorHelper::FromArgb(255, 30, 30, 30)));
-                xamlSource.Content(border);
+                grid.HorizontalAlignment(xaml::HorizontalAlignment::Stretch);
+                grid.VerticalAlignment(xaml::VerticalAlignment::Stretch);
+                xamlSource.Content(grid);
 
                 OutputDebugStringA("ghostty: XAML Island attached to header\n");
             } catch (winrt::hresult_error const& e) {

--- a/GhosttyWin32.cpp
+++ b/GhosttyWin32.cpp
@@ -316,10 +316,7 @@ int APIENTRY wWinMain(
                     [parentHwnd, &bridge](muxc::TabView const& tv, auto&&) {
                         auto* newSess = bridge.createSurface(parentHwnd);
                         if (!newSess) return;
-                        // Hide all other session windows, show the new one
-                        for (auto& s : bridge.sessions()) {
-                            if (s.get() != newSess) ShowWindow(s->hwnd, SW_HIDE);
-                        }
+                        // TODO: reduce flicker on new tab creation
                         ShowWindow(newSess->hwnd, SW_SHOW);
                         SetFocus(newSess->hwnd);
                         // Add a new tab
@@ -330,7 +327,7 @@ int APIENTRY wWinMain(
                         tv.SelectedItem(newTab);
                     });
 
-                // Tab selection changed: show/hide child windows
+                // Tab selection changed: bring selected surface to top
                 tabView.SelectionChanged(
                     [parentHwnd, &bridge](auto&& sender, auto&&) {
                         auto tv = sender.template as<muxc::TabView>();
@@ -339,10 +336,9 @@ int APIENTRY wWinMain(
                         auto selItem = sel.template as<muxc::TabViewItem>();
                         uint64_t selTag = winrt::unbox_value<uint64_t>(selItem.Tag());
                         HWND selHwnd = reinterpret_cast<HWND>(selTag);
-                        for (auto& s : bridge.sessions()) {
-                            ShowWindow(s->hwnd, (s->hwnd == selHwnd) ? SW_SHOW : SW_HIDE);
-                        }
-                        PostMessageW(parentHwnd, WM_APP, 0, 0);
+                        SetWindowPos(selHwnd, HWND_TOP, 0, 0, 0, 0,
+                            SWP_NOMOVE | SWP_NOSIZE | SWP_SHOWWINDOW);
+                        SetFocus(selHwnd);
                     });
 
                 // Tab close requested: destroy the session
@@ -374,14 +370,13 @@ int APIENTRY wWinMain(
                             return;
                         }
 
-                        // Show the newly selected tab's session
+                        // Bring the newly selected tab's session to top
                         if (auto sel = tv.SelectedItem()) {
                             auto selItem = sel.as<muxc::TabViewItem>();
                             uint64_t selTag = winrt::unbox_value<uint64_t>(selItem.Tag());
                             HWND selHwnd = reinterpret_cast<HWND>(selTag);
-                            for (auto& s : bridge.sessions()) {
-                                ShowWindow(s->hwnd, (s->hwnd == selHwnd) ? SW_SHOW : SW_HIDE);
-                            }
+                            SetWindowPos(selHwnd, HWND_TOP, 0, 0, 0, 0,
+                                SWP_NOMOVE | SWP_NOSIZE | SWP_SHOWWINDOW);
                             SetFocus(selHwnd);
                         }
                     });

--- a/GhosttyWin32.cpp
+++ b/GhosttyWin32.cpp
@@ -327,7 +327,7 @@ int APIENTRY wWinMain(
                         tv.SelectedItem(newTab);
                     });
 
-                // Tab selection changed: bring selected surface to top
+                // Tab selection changed: show selected, hide others, set focus
                 tabView.SelectionChanged(
                     [parentHwnd, &bridge](auto&& sender, auto&&) {
                         auto tv = sender.template as<muxc::TabView>();
@@ -338,6 +338,11 @@ int APIENTRY wWinMain(
                         HWND selHwnd = reinterpret_cast<HWND>(selTag);
                         SetWindowPos(selHwnd, HWND_TOP, 0, 0, 0, 0,
                             SWP_NOMOVE | SWP_NOSIZE | SWP_SHOWWINDOW);
+                        for (auto& s : bridge.sessions()) {
+                            if (s->hwnd && s->hwnd != selHwnd) {
+                                ShowWindow(s->hwnd, SW_HIDE);
+                            }
+                        }
                         SetFocus(selHwnd);
                     });
 
@@ -370,13 +375,18 @@ int APIENTRY wWinMain(
                             return;
                         }
 
-                        // Bring the newly selected tab's session to top
+                        // Show selected, hide others, set focus
                         if (auto sel = tv.SelectedItem()) {
                             auto selItem = sel.as<muxc::TabViewItem>();
                             uint64_t selTag = winrt::unbox_value<uint64_t>(selItem.Tag());
                             HWND selHwnd = reinterpret_cast<HWND>(selTag);
                             SetWindowPos(selHwnd, HWND_TOP, 0, 0, 0, 0,
                                 SWP_NOMOVE | SWP_NOSIZE | SWP_SHOWWINDOW);
+                            for (auto& s : bridge.sessions()) {
+                                if (s->hwnd && s->hwnd != selHwnd) {
+                                    ShowWindow(s->hwnd, SW_HIDE);
+                                }
+                            }
                             SetFocus(selHwnd);
                         }
                     });

--- a/GhosttyWin32.cpp
+++ b/GhosttyWin32.cpp
@@ -161,18 +161,96 @@ int APIENTRY wWinMain(
                 tabView.IsAddTabButtonVisible(true);
                 tabView.TabWidthMode(muxc::TabViewWidthMode::Equal);
 
+                // First tab — associate with the initial session via Tag
                 auto tab1 = muxc::TabViewItem();
                 tab1.Header(winrt::box_value(L"Terminal"));
                 tab1.IsClosable(false);
+                tab1.Tag(winrt::box_value(reinterpret_cast<uint64_t>(session->hwnd)));
                 tabView.TabItems().Append(tab1);
                 tabView.SelectedItem(tab1);
 
                 xamlSource.Content(tabView);
 
-                // When the XAML Island gets focus (user clicked the tab bar),
-                // asynchronously return focus to the terminal. PostMessage
-                // lets the click be processed first, then focus moves back.
+                // --- Tab event handlers ---
                 HWND parentHwnd = session->parentHwnd;
+
+                // [+] button: create a new terminal session + tab
+                tabView.AddTabButtonClick(
+                    [parentHwnd, &bridge](muxc::TabView const& tv, auto&&) {
+                        auto* newSess = bridge.createSurface(parentHwnd);
+                        if (!newSess) return;
+                        // Hide all other session windows, show the new one
+                        for (auto& s : bridge.sessions()) {
+                            if (s.get() != newSess) ShowWindow(s->hwnd, SW_HIDE);
+                        }
+                        ShowWindow(newSess->hwnd, SW_SHOW);
+                        SetFocus(newSess->hwnd);
+                        // Add a new tab
+                        auto newTab = muxc::TabViewItem();
+                        newTab.Header(winrt::box_value(L"Terminal"));
+                        newTab.Tag(winrt::box_value(reinterpret_cast<uint64_t>(newSess->hwnd)));
+                        tv.TabItems().Append(newTab);
+                        tv.SelectedItem(newTab);
+                    });
+
+                // Tab selection changed: show/hide child windows
+                tabView.SelectionChanged(
+                    [parentHwnd, &bridge](auto&& sender, auto&&) {
+                        auto tv = sender.template as<muxc::TabView>();
+                        auto sel = tv.SelectedItem();
+                        if (!sel) return;
+                        auto selItem = sel.template as<muxc::TabViewItem>();
+                        uint64_t selTag = winrt::unbox_value<uint64_t>(selItem.Tag());
+                        HWND selHwnd = reinterpret_cast<HWND>(selTag);
+                        for (auto& s : bridge.sessions()) {
+                            ShowWindow(s->hwnd, (s->hwnd == selHwnd) ? SW_SHOW : SW_HIDE);
+                        }
+                        PostMessageW(parentHwnd, WM_APP, 0, 0);
+                    });
+
+                // Tab close requested: destroy the session
+                tabView.TabCloseRequested(
+                    [parentHwnd, &bridge](muxc::TabView const& tv,
+                                          muxc::TabViewTabCloseRequestedEventArgs const& args) {
+                        auto item = args.Tab();
+                        uint64_t tag = winrt::unbox_value<uint64_t>(item.Tag());
+                        HWND targetHwnd = reinterpret_cast<HWND>(tag);
+
+                        // Find and destroy the session
+                        for (auto& s : bridge.sessions()) {
+                            if (s->hwnd == targetHwnd) {
+                                bridge.destroySession(s.get());
+                                break;
+                            }
+                        }
+
+                        // Remove the tab
+                        uint32_t idx = 0;
+                        if (tv.TabItems().IndexOf(item, idx)) {
+                            tv.TabItems().RemoveAt(idx);
+                        }
+
+                        // If no tabs left, quit
+                        if (tv.TabItems().Size() == 0) {
+                            bridge.shutdown();
+                            PostQuitMessage(0);
+                            return;
+                        }
+
+                        // Show the newly selected tab's session
+                        if (auto sel = tv.SelectedItem()) {
+                            auto selItem = sel.as<muxc::TabViewItem>();
+                            uint64_t selTag = winrt::unbox_value<uint64_t>(selItem.Tag());
+                            HWND selHwnd = reinterpret_cast<HWND>(selTag);
+                            for (auto& s : bridge.sessions()) {
+                                ShowWindow(s->hwnd, (s->hwnd == selHwnd) ? SW_SHOW : SW_HIDE);
+                            }
+                            SetFocus(selHwnd);
+                        }
+                    });
+
+                // When the XAML Island gets focus (user clicked the tab bar),
+                // asynchronously return focus to the terminal.
                 xamlSource.GotFocus(
                     [parentHwnd](DesktopWindowXamlSource const&,
                                  winrt::Windows::UI::Xaml::Hosting::DesktopWindowXamlSourceGotFocusEventArgs const&) {

--- a/GhosttyWin32.cpp
+++ b/GhosttyWin32.cpp
@@ -5,6 +5,37 @@
 using namespace winrt;
 using namespace winrt::Windows::UI::Xaml::Hosting;
 
+// Custom Application subclass that provides WinUI 2 metadata.
+// WindowsXamlManager needs an Application with IXamlMetadataProvider
+// so it can resolve WinUI 2 types (TabView etc.) at runtime.
+// The actual metadata provider (XamlControlsXamlMetaDataProvider) is
+// created lazily to avoid the circular dependency: the Application
+// must exist before the provider can be instantiated.
+struct GhosttyApp : winrt::Windows::UI::Xaml::ApplicationT<GhosttyApp,
+    winrt::Windows::UI::Xaml::Markup::IXamlMetadataProvider>
+{
+    winrt::Microsoft::UI::Xaml::XamlTypeInfo::XamlControlsXamlMetaDataProvider m_provider{ nullptr };
+
+    winrt::Windows::UI::Xaml::Markup::IXamlType GetXamlType(
+        winrt::Windows::UI::Xaml::Interop::TypeName const& type)
+    {
+        if (!m_provider) m_provider = winrt::Microsoft::UI::Xaml::XamlTypeInfo::XamlControlsXamlMetaDataProvider();
+        return m_provider.GetXamlType(type);
+    }
+
+    winrt::Windows::UI::Xaml::Markup::IXamlType GetXamlType(winrt::hstring const& fullName)
+    {
+        if (!m_provider) m_provider = winrt::Microsoft::UI::Xaml::XamlTypeInfo::XamlControlsXamlMetaDataProvider();
+        return m_provider.GetXamlType(fullName);
+    }
+
+    winrt::com_array<winrt::Windows::UI::Xaml::Markup::XmlnsDefinition> GetXmlnsDefinitions()
+    {
+        if (!m_provider) m_provider = winrt::Microsoft::UI::Xaml::XamlTypeInfo::XamlControlsXamlMetaDataProvider();
+        return m_provider.GetXmlnsDefinitions();
+    }
+};
+
 int APIENTRY wWinMain(
     _In_ HINSTANCE hInstance,
     _In_opt_ HINSTANCE hPrevInstance,
@@ -26,14 +57,24 @@ int APIENTRY wWinMain(
     DesktopWindowXamlSource xamlSource{ nullptr }; // Must outlive the message loop
     bool xamlReady = false;
     try {
-        // No XamlApplication needed — built-in WinUI 2 controls (TabView etc.)
-        // register their own metadata. Just initialize the XAML framework.
+        OutputDebugStringA("ghostty: step 1 — creating custom App...\n");
+        auto app = winrt::make<GhosttyApp>();
+        OutputDebugStringA("ghostty: step 2 — App created, calling InitializeForCurrentThread...\n");
         xamlManager = WindowsXamlManager::InitializeForCurrentThread();
+        // Step 3: try merging WinUI 2 theme resources (optional — TabView
+        // may work unstyled even if this fails).
+        try {
+            auto muxResources = winrt::Microsoft::UI::Xaml::Controls::XamlControlsResources();
+            winrt::Windows::UI::Xaml::Application::Current().Resources().MergedDictionaries().Append(muxResources);
+            OutputDebugStringA("ghostty: step 3 — WinUI 2 resources merged\n");
+        } catch (...) {
+            OutputDebugStringA("ghostty: step 3 — WinUI 2 resources skipped (non-fatal)\n");
+        }
         xamlReady = true;
-        OutputDebugStringA("ghostty: WinUI 2 XAML hosting initialized\n");
+        OutputDebugStringA("ghostty: XAML initialized OK\n");
     } catch (winrt::hresult_error const& e) {
         char buf[256];
-        sprintf_s(buf, "ghostty: XAML init failed hr=0x%08x\n", (unsigned)e.code());
+        sprintf_s(buf, "ghostty: XAML init failed at hr=0x%08x\n", (unsigned)e.code());
         OutputDebugStringA(buf);
     }
 
@@ -116,16 +157,23 @@ int APIENTRY wWinMain(
                     rc.right - rc.left, session->headerHeight,
                     SWP_SHOWWINDOW);
 
-                // Placeholder: a dark panel matching the terminal background.
-                namespace xaml = winrt::Windows::UI::Xaml;
-                namespace controls = xaml::Controls;
-                namespace media = xaml::Media;
-                auto grid = controls::Grid();
-                grid.Background(media::SolidColorBrush(
-                    winrt::Windows::UI::ColorHelper::FromArgb(255, 30, 30, 30)));
-                grid.HorizontalAlignment(xaml::HorizontalAlignment::Stretch);
-                grid.VerticalAlignment(xaml::VerticalAlignment::Stretch);
-                xamlSource.Content(grid);
+                // Create TabView via XAML markup so the type is resolved
+                // through our IXamlMetadataProvider (GhosttyApp), not via
+                // direct RoGetActivationFactory (which fails for WinUI 2).
+                auto tabViewXaml = winrt::Windows::UI::Xaml::Markup::XamlReader::Load(
+                    LR"(<muxc:TabView
+                        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                        xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+                        HorizontalAlignment="Stretch"
+                        VerticalAlignment="Stretch"
+                        IsAddTabButtonVisible="True"
+                        TabWidthMode="Equal">
+                        <muxc:TabView.TabItems>
+                            <muxc:TabViewItem Header="Terminal" IsClosable="False"/>
+                        </muxc:TabView.TabItems>
+                    </muxc:TabView>)");
+
+                xamlSource.Content(tabViewXaml.as<winrt::Windows::UI::Xaml::UIElement>());
 
                 OutputDebugStringA("ghostty: XAML Island attached to header\n");
             } catch (winrt::hresult_error const& e) {

--- a/GhosttyWin32.cpp
+++ b/GhosttyWin32.cpp
@@ -53,32 +53,29 @@ int APIENTRY wWinMain(
     // Create surface (standalone Win32 window)
     TerminalSession* session = bridge.createSurface(nullptr);
 
-    // Apply config-driven window settings to the top-level main window
+    // Apply config-driven window settings to the top-level main window.
+    // The main window is always created without a native caption — the XAML
+    // tab bar in the header strip replaces it. window-decoration only controls
+    // whether that header strip is shown:
+    //   - true  (default) → 32px header (tab bar visible, drag region present)
+    //   - false           → no header   (chromeless terminal-only look)
     if (HWND hwnd = session ? session->parentHwnd : nullptr) {
-        // window-decoration
         const char* decorVal = nullptr;
         if (ghostty_config_get(bridge.config(), &decorVal, "window-decoration", 17) && decorVal) {
             if (strcmp(decorVal, "false") == 0 || strcmp(decorVal, "none") == 0) {
-                DWORD style = GetWindowLongW(hwnd, GWL_STYLE);
-                // Keep WS_THICKFRAME for smooth DWM resize, hide caption visually
-                style = (style & ~(WS_CAPTION | WS_SYSMENU | WS_MINIMIZEBOX | WS_MAXIMIZEBOX)) | WS_THICKFRAME;
                 session->decorations = false;
-                // Reserve a 32px header at the top so the user can drag the
-                // window even though the native caption is hidden. The drag
-                // region is delivered via WM_NCHITTEST → HTCAPTION.
-                session->headerHeight = 32;
-                SetWindowLongW(hwnd, GWL_STYLE, style);
-                SetWindowPos(hwnd, nullptr, 0, 0, 0, 0,
-                    SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_FRAMECHANGED);
+                session->headerHeight = 0;
+                // Re-fire WM_SIZE so the rendering child reclaims the header area.
+                RECT rc;
+                GetClientRect(hwnd, &rc);
+                SendMessageW(hwnd, WM_SIZE, SIZE_RESTORED,
+                    MAKELPARAM(rc.right - rc.left, rc.bottom - rc.top));
             }
         }
 
         // Windows 11 rounded corners
         INT cornerPref = 2; // DWMWCP_ROUND
         DwmSetWindowAttribute(hwnd, 33 /*DWMWA_WINDOW_CORNER_PREFERENCE*/, &cornerPref, sizeof(cornerPref));
-
-        // background-opacity is handled by ghostty's renderer internally.
-        // No Win32-level transparency needed (DWM compositing is expensive).
     }
 
     // Move focus to the rendering child so keyboard/IME input works on first

--- a/GhosttyWin32.cpp
+++ b/GhosttyWin32.cpp
@@ -169,6 +169,16 @@ int APIENTRY wWinMain(
 
                 xamlSource.Content(tabView);
 
+                // When the XAML Island gets focus (user clicked the tab bar),
+                // asynchronously return focus to the terminal. PostMessage
+                // lets the click be processed first, then focus moves back.
+                HWND parentHwnd = session->parentHwnd;
+                xamlSource.GotFocus(
+                    [parentHwnd](DesktopWindowXamlSource const&,
+                                 winrt::Windows::UI::Xaml::Hosting::DesktopWindowXamlSourceGotFocusEventArgs const&) {
+                        PostMessageW(parentHwnd, WM_APP, 0, 0);
+                    });
+
                 OutputDebugStringA("ghostty: XAML Island attached to header\n");
             } catch (winrt::hresult_error const& e) {
                 char buf[256];

--- a/GhosttyWin32.cpp
+++ b/GhosttyWin32.cpp
@@ -354,15 +354,7 @@ int APIENTRY wWinMain(
                         uint64_t tag = winrt::unbox_value<uint64_t>(item.Tag());
                         HWND targetHwnd = reinterpret_cast<HWND>(tag);
 
-                        // Find and destroy the session
-                        for (auto& s : bridge.sessions()) {
-                            if (s->hwnd == targetHwnd) {
-                                bridge.destroySession(s.get());
-                                break;
-                            }
-                        }
-
-                        // Remove the tab
+                        // Remove the tab from TabView first
                         uint32_t idx = 0;
                         if (tv.TabItems().IndexOf(item, idx)) {
                             tv.TabItems().RemoveAt(idx);
@@ -370,24 +362,33 @@ int APIENTRY wWinMain(
 
                         // If no tabs left, quit
                         if (tv.TabItems().Size() == 0) {
+                            bridge.destroySession(
+                                [&]() -> TerminalSession* {
+                                    for (auto& s : bridge.sessions())
+                                        if (s->hwnd == targetHwnd) return s.get();
+                                    return nullptr;
+                                }());
                             bridge.shutdown();
                             PostQuitMessage(0);
                             return;
                         }
 
-                        // Show selected, hide others, set focus
+                        // Switch to next tab FIRST (surface is already the right size)
                         if (auto sel = tv.SelectedItem()) {
                             auto selItem = sel.as<muxc::TabViewItem>();
                             uint64_t selTag = winrt::unbox_value<uint64_t>(selItem.Tag());
                             HWND selHwnd = reinterpret_cast<HWND>(selTag);
                             SetWindowPos(selHwnd, HWND_TOP, 0, 0, 0, 0,
                                 SWP_NOMOVE | SWP_NOSIZE | SWP_SHOWWINDOW);
-                            for (auto& s : bridge.sessions()) {
-                                if (s->hwnd && s->hwnd != selHwnd) {
-                                    ShowWindow(s->hwnd, SW_HIDE);
-                                }
-                            }
                             SetFocus(selHwnd);
+                        }
+
+                        // NOW destroy the old session (new tab is already visible)
+                        for (auto& s : bridge.sessions()) {
+                            if (s->hwnd == targetHwnd) {
+                                bridge.destroySession(s.get());
+                                break;
+                            }
                         }
                     });
 

--- a/GhosttyWin32.cpp
+++ b/GhosttyWin32.cpp
@@ -31,8 +31,8 @@ int APIENTRY wWinMain(
     // Create surface (standalone Win32 window)
     TerminalSession* session = bridge.createSurface(nullptr);
 
-    // Apply config-driven window settings
-    if (HWND hwnd = session ? session->hwnd : nullptr) {
+    // Apply config-driven window settings to the top-level main window
+    if (HWND hwnd = session ? session->parentHwnd : nullptr) {
         // window-decoration
         const char* decorVal = nullptr;
         if (ghostty_config_get(bridge.config(), &decorVal, "window-decoration", 17) && decorVal) {
@@ -53,6 +53,12 @@ int APIENTRY wWinMain(
 
         // background-opacity is handled by ghostty's renderer internally.
         // No Win32-level transparency needed (DWM compositing is expensive).
+    }
+
+    // Move focus to the rendering child so keyboard/IME input works on first
+    // activation (otherwise the user has to alt-tab away and back).
+    if (session && session->hwnd) {
+        SetFocus(session->hwnd);
     }
 
     // Message loop

--- a/GhosttyWin32.cpp
+++ b/GhosttyWin32.cpp
@@ -257,6 +257,23 @@ int APIENTRY wWinMain(
                         PostMessageW(parentHwnd, WM_APP, 0, 0);
                     });
 
+                // Title sync: when ghostty sets a surface title, update the
+                // matching TabViewItem header.
+                static winrt::Microsoft::UI::Xaml::Controls::TabView s_tabView{ nullptr };
+                s_tabView = tabView;
+                GhosttyBridge::s_titleChangedFn = [](void*, HWND sessHwnd, const wchar_t* title) {
+                    if (!s_tabView) return;
+                    namespace muxc = winrt::Microsoft::UI::Xaml::Controls;
+                    for (uint32_t i = 0; i < s_tabView.TabItems().Size(); i++) {
+                        auto item = s_tabView.TabItems().GetAt(i).as<muxc::TabViewItem>();
+                        uint64_t tag = winrt::unbox_value<uint64_t>(item.Tag());
+                        if (reinterpret_cast<HWND>(tag) == sessHwnd) {
+                            item.Header(winrt::box_value(title));
+                            break;
+                        }
+                    }
+                };
+
                 OutputDebugStringA("ghostty: XAML Island attached to header\n");
             } catch (winrt::hresult_error const& e) {
                 char buf[256];

--- a/GhosttyWin32.cpp
+++ b/GhosttyWin32.cpp
@@ -36,50 +36,10 @@ struct GhosttyApp : winrt::Windows::UI::Xaml::ApplicationT<GhosttyApp,
     }
 };
 
-// Subclass proc for the XAML Island's own HWND (child of xamlHostWnd).
-// Intercepts WM_NCHITTEST to check if the mouse is over interactive XAML
-// content. If not → HTTRANSPARENT so the parent can return HTCAPTION.
-#include <commctrl.h>
-#pragma comment(lib, "comctl32.lib")
-
-static winrt::Windows::UI::Xaml::Hosting::DesktopWindowXamlSource* g_xamlSourceForHitTest = nullptr;
-
-static LRESULT CALLBACK islandSubclassProc(
-    HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam,
-    UINT_PTR /*subclassId*/, DWORD_PTR /*refData*/)
-{
-    if (msg == WM_NCHITTEST && g_xamlSourceForHitTest && *g_xamlSourceForHitTest) {
-        auto content = g_xamlSourceForHitTest->Content();
-        if (content) {
-            POINT pt;
-            pt.x = (short)LOWORD(lParam);
-            pt.y = (short)HIWORD(lParam);
-            ScreenToClient(hwnd, &pt);
-            namespace xaml = winrt::Windows::UI::Xaml;
-            auto point = winrt::Windows::Foundation::Point(
-                static_cast<float>(pt.x), static_cast<float>(pt.y));
-            auto elements = xaml::Media::VisualTreeHelper::FindElementsInHostCoordinates(
-                point, content);
-            for (auto const& elem : elements) {
-                auto name = winrt::get_class_name(elem);
-                std::wstring_view sv{ name };
-                if (sv.find(L"Button") != std::wstring_view::npos ||
-                    sv.find(L"TabViewItem") != std::wstring_view::npos ||
-                    sv.find(L"ListViewItem") != std::wstring_view::npos) {
-                    return DefSubclassProc(hwnd, msg, wParam, lParam);
-                }
-            }
-            return HTTRANSPARENT;
-        }
-    }
-    return DefSubclassProc(hwnd, msg, wParam, lParam);
-}
-
-static LRESULT CALLBACK xamlHostWndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
-    if (msg == WM_NCHITTEST) return HTTRANSPARENT;
-    return DefWindowProcW(hwnd, msg, wParam, lParam);
-}
-
+// Transparent drag bar overlay — sits ON TOP of the XAML Island in z-order.
+// Intercepts WM_NCHITTEST: if the mouse is over interactive XAML content
+// (tabs, buttons) → HTTRANSPARENT (pass to XAML below). If over empty
+// space → HTCAPTION (window drag). This is the Windows Terminal approach.
 int APIENTRY wWinMain(
     _In_ HINSTANCE hInstance,
     _In_opt_ HINSTANCE hPrevInstance,
@@ -166,10 +126,11 @@ int APIENTRY wWinMain(
                 static bool xamlHostRegistered = false;
                 if (!xamlHostRegistered) {
                     WNDCLASSW wc = {};
-                    wc.lpfnWndProc = xamlHostWndProc;
+                    wc.lpfnWndProc = DefWindowProcW; // NOT HTTRANSPARENT — must be HTCLIENT for XAML passthrough
                     wc.hInstance = GetModuleHandleW(nullptr);
                     wc.lpszClassName = L"GhosttyXamlHost";
                     RegisterClassW(&wc);
+
                     xamlHostRegistered = true;
                 }
                 RECT rc;
@@ -190,11 +151,6 @@ int APIENTRY wWinMain(
                 winrt::check_hresult(interop->get_WindowHandle(&islandHwnd));
                 session->xamlIslandHwnd = islandHwnd;
 
-                // Subclass the island HWND so we can intercept WM_NCHITTEST
-                // and return HTTRANSPARENT for empty tab bar areas (drag).
-                g_xamlSourceForHitTest = &xamlSource;
-                SetWindowSubclass(islandHwnd, islandSubclassProc, 0, 0);
-
                 // Fill the host window.
                 SetWindowPos(islandHwnd, nullptr, 0, 0,
                     rc.right - rc.left, session->headerHeight,
@@ -213,13 +169,16 @@ int APIENTRY wWinMain(
                 root.HorizontalAlignment(xaml::HorizontalAlignment::Stretch);
                 root.VerticalAlignment(xaml::VerticalAlignment::Stretch);
 
-                // Two columns: TabView (star) + system buttons (auto)
+                // Three columns: TabView (auto) + drag area (star) + buttons (auto)
                 auto col1 = controls::ColumnDefinition();
-                col1.Width(xaml::GridLengthHelper::FromValueAndType(1, xaml::GridUnitType::Star));
+                col1.Width(xaml::GridLengthHelper::Auto());
                 root.ColumnDefinitions().Append(col1);
                 auto col2 = controls::ColumnDefinition();
-                col2.Width(xaml::GridLengthHelper::Auto());
+                col2.Width(xaml::GridLengthHelper::FromValueAndType(1, xaml::GridUnitType::Star));
                 root.ColumnDefinitions().Append(col2);
+                auto col3 = controls::ColumnDefinition();
+                col3.Width(xaml::GridLengthHelper::Auto());
+                root.ColumnDefinitions().Append(col3);
 
                 // TabView
                 auto tabView = muxc::TabView();
@@ -239,11 +198,48 @@ int APIENTRY wWinMain(
 
                 HWND mainWnd = session->parentHwnd;
 
+                // Drag area — fills the gap between tabs and system buttons.
+                // Has a background so it's hittable, PointerPressed starts drag.
+                auto dragArea = controls::Border();
+                dragArea.Background(media::SolidColorBrush(
+                    winrt::Windows::UI::ColorHelper::FromArgb(1, 30, 30, 30))); // nearly transparent but hittable
+                dragArea.HorizontalAlignment(xaml::HorizontalAlignment::Stretch);
+                dragArea.VerticalAlignment(xaml::VerticalAlignment::Stretch);
+                controls::Grid::SetColumn(dragArea, 1);
+                // Manual window drag via XAML pointer events.
+                struct DragState { POINT start; bool active = false; };
+                static DragState drag;
+                dragArea.PointerPressed([mainWnd](auto&& sender, xaml::Input::PointerRoutedEventArgs const& args) {
+                    GetCursorPos(&drag.start);
+                    drag.active = true;
+                    sender.as<xaml::UIElement>().CapturePointer(args.Pointer());
+                    args.Handled(true);
+                });
+                dragArea.PointerMoved([mainWnd](auto&&, xaml::Input::PointerRoutedEventArgs const& args) {
+                    if (!drag.active) return;
+                    POINT now;
+                    GetCursorPos(&now);
+                    RECT rc;
+                    GetWindowRect(mainWnd, &rc);
+                    SetWindowPos(mainWnd, nullptr,
+                        rc.left + (now.x - drag.start.x),
+                        rc.top + (now.y - drag.start.y),
+                        0, 0, SWP_NOSIZE | SWP_NOZORDER);
+                    drag.start = now;
+                    args.Handled(true);
+                });
+                dragArea.PointerReleased([](auto&& sender, xaml::Input::PointerRoutedEventArgs const& args) {
+                    drag.active = false;
+                    sender.as<xaml::UIElement>().ReleasePointerCapture(args.Pointer());
+                    args.Handled(true);
+                });
+                root.Children().Append(dragArea);
+
                 // System buttons (─ □ ×)
                 auto sysButtons = controls::StackPanel();
                 sysButtons.Orientation(controls::Orientation::Horizontal);
                 sysButtons.VerticalAlignment(xaml::VerticalAlignment::Top);
-                controls::Grid::SetColumn(sysButtons, 1);
+                controls::Grid::SetColumn(sysButtons, 2);
 
                 auto makeBtn = [&](const wchar_t* text, double w) {
                     auto btn = controls::Button();
@@ -390,7 +386,16 @@ int APIENTRY wWinMain(
                     }
                 };
 
-                OutputDebugStringA("ghostty: XAML Island attached to header\n");
+                // Transparent drag bar overlay — sits on top of the XAML Island
+                // to intercept WM_NCHITTEST for window dragging.
+                HWND dragBarHwnd = CreateWindowExW(
+                    WS_EX_LAYERED | WS_EX_NOREDIRECTIONBITMAP,
+                    L"GhosttyDragBar", nullptr,
+                    WS_CHILD | WS_VISIBLE,
+                    0, 0, rc.right - rc.left, session->headerHeight,
+                    hwnd, nullptr, GetModuleHandleW(nullptr), nullptr);
+
+                OutputDebugStringA("ghostty: XAML Island + drag bar attached\n");
             } catch (winrt::hresult_error const& e) {
                 char buf[256];
                 sprintf_s(buf, "ghostty: XAML Island failed hr=0x%08x\n", (unsigned)e.code());

--- a/GhosttyWin32.cpp
+++ b/GhosttyWin32.cpp
@@ -189,6 +189,11 @@ int APIENTRY wWinMain(
                 // Root layout: TabView on the left, system buttons on the right
                 auto root = controls::Grid();
                 root.RequestedTheme(xaml::ElementTheme::Dark);
+                root.Background(media::SolidColorBrush(
+                    winrt::Windows::UI::ColorHelper::FromArgb(255,
+                        GetRValue(bridge.m_bgColor),
+                        GetGValue(bridge.m_bgColor),
+                        GetBValue(bridge.m_bgColor))));
                 root.HorizontalAlignment(xaml::HorizontalAlignment::Stretch);
                 root.VerticalAlignment(xaml::VerticalAlignment::Stretch);
 
@@ -282,26 +287,27 @@ int APIENTRY wWinMain(
                     btn.Background(media::SolidColorBrush(
                         winrt::Windows::UI::ColorHelper::FromArgb(0, 0, 0, 0)));
                     btn.Width(w);
-                    btn.Height(32);
+                    btn.Height(TerminalSession::kDefaultHeaderHeight);
                     btn.Padding(xaml::ThicknessHelper::FromUniformLength(0));
                     btn.BorderThickness(xaml::ThicknessHelper::FromUniformLength(0));
                     btn.VerticalAlignment(xaml::VerticalAlignment::Top);
                     return btn;
                 };
 
-                auto minBtn = makeBtn(L"\xE949", 46);  // Minimize icon
+                auto minBtn = makeBtn(L"\xE949", 46);  // ChromeMinimize
                 minBtn.FontFamily(media::FontFamily(L"Segoe MDL2 Assets"));
                 minBtn.Click([mainWnd](auto&&, auto&&) {
                     ShowWindow(mainWnd, SW_MINIMIZE);
                 });
 
-                auto maxBtn = makeBtn(L"\xE739", 46);  // Maximize icon
+                auto maxBtn = makeBtn(L"\xE922", 46);  // ChromeMaximize
                 maxBtn.FontFamily(media::FontFamily(L"Segoe MDL2 Assets"));
                 maxBtn.Click([mainWnd](auto&&, auto&&) {
                     ShowWindow(mainWnd, IsZoomed(mainWnd) ? SW_RESTORE : SW_MAXIMIZE);
                 });
 
-                auto closeBtn = makeBtn(L"\xE106", 46);  // Close icon
+                auto closeBtn = makeBtn(L"\xE8BB", 46);  // ChromeClose
+                closeBtn.FontFamily(media::FontFamily(L"Segoe MDL2 Assets"));
                 closeBtn.Click([mainWnd](auto&&, auto&&) {
                     PostMessageW(mainWnd, WM_CLOSE, 0, 0);
                 });
@@ -415,7 +421,17 @@ int APIENTRY wWinMain(
                 // Title sync: when ghostty sets a surface title, update the
                 // matching TabViewItem header.
                 static winrt::Microsoft::UI::Xaml::Controls::TabView s_tabView{ nullptr };
+                static winrt::Windows::UI::Xaml::Controls::Grid s_rootGrid{ nullptr };
                 s_tabView = tabView;
+                s_rootGrid = root;
+
+                // Update tab bar background when terminal bg color changes
+                GhosttyBridge::s_bgColorChangedFn = [](void*, uint8_t r, uint8_t g, uint8_t b) {
+                    if (!s_rootGrid) return;
+                    namespace media = winrt::Windows::UI::Xaml::Media;
+                    s_rootGrid.Background(media::SolidColorBrush(
+                        winrt::Windows::UI::ColorHelper::FromArgb(255, r, g, b)));
+                };
                 GhosttyBridge::s_titleChangedFn = [](void*, HWND sessHwnd, const wchar_t* title) {
                     if (!s_tabView) return;
                     namespace muxc = winrt::Microsoft::UI::Xaml::Controls;

--- a/GhosttyWin32.cpp
+++ b/GhosttyWin32.cpp
@@ -1,5 +1,6 @@
 #include "framework.h"
 #include <dwmapi.h>
+#include <windowsx.h>
 #include "GhosttyBridge.h"
 
 using namespace winrt;
@@ -126,7 +127,24 @@ int APIENTRY wWinMain(
                 static bool xamlHostRegistered = false;
                 if (!xamlHostRegistered) {
                     WNDCLASSW wc = {};
-                    wc.lpfnWndProc = DefWindowProcW; // NOT HTTRANSPARENT — must be HTCLIENT for XAML passthrough
+                    // Forward resize edge hits to the parent main window
+                    // so the user can grab the resize border over the XAML area.
+                    wc.lpfnWndProc = [](HWND h, UINT m, WPARAM w, LPARAM l) -> LRESULT {
+                        if (m == WM_NCHITTEST) {
+                            HWND parent = GetParent(h);
+                            if (parent) {
+                                POINT pt = { GET_X_LPARAM(l), GET_Y_LPARAM(l) };
+                                RECT parentRc;
+                                GetWindowRect(parent, &parentRc);
+                                const int border = 6;
+                                if (pt.x - parentRc.left < border || parentRc.right - pt.x < border ||
+                                    pt.y - parentRc.top < border || parentRc.bottom - pt.y < border) {
+                                    return HTTRANSPARENT;
+                                }
+                            }
+                        }
+                        return DefWindowProcW(h, m, w, l);
+                    };
                     wc.hInstance = GetModuleHandleW(nullptr);
                     wc.lpszClassName = L"GhosttyXamlHost";
                     RegisterClassW(&wc);

--- a/GhosttyWin32.cpp
+++ b/GhosttyWin32.cpp
@@ -169,28 +169,35 @@ int APIENTRY wWinMain(
                 root.HorizontalAlignment(xaml::HorizontalAlignment::Stretch);
                 root.VerticalAlignment(xaml::VerticalAlignment::Stretch);
 
-                // Three columns: TabView (auto) + drag area (star) + buttons (auto)
+                // Three columns: TabView (auto, max 70%) + drag area (star) + buttons (auto)
                 auto col1 = controls::ColumnDefinition();
                 col1.Width(xaml::GridLengthHelper::Auto());
                 root.ColumnDefinitions().Append(col1);
                 auto col2 = controls::ColumnDefinition();
                 col2.Width(xaml::GridLengthHelper::FromValueAndType(1, xaml::GridUnitType::Star));
+                col2.MinWidth(100); // Always keep at least 100px for dragging
                 root.ColumnDefinitions().Append(col2);
                 auto col3 = controls::ColumnDefinition();
                 col3.Width(xaml::GridLengthHelper::Auto());
                 root.ColumnDefinitions().Append(col3);
 
-                // TabView
+                // TabView — capped at 70% of window width so drag area is always reachable
                 auto tabView = muxc::TabView();
-                tabView.HorizontalAlignment(xaml::HorizontalAlignment::Stretch);
+                tabView.HorizontalAlignment(xaml::HorizontalAlignment::Left);
                 tabView.VerticalAlignment(xaml::VerticalAlignment::Stretch);
                 tabView.IsAddTabButtonVisible(true);
                 tabView.TabWidthMode(muxc::TabViewWidthMode::Equal);
+                tabView.MaxWidth(static_cast<double>(rc.right - rc.left) * 0.7);
                 controls::Grid::SetColumn(tabView, 0);
+
+                // Update MaxWidth when window resizes
+                root.SizeChanged([tabView](auto&&, xaml::SizeChangedEventArgs const& args) {
+                    tabView.MaxWidth(args.NewSize().Width * 0.7);
+                });
 
                 auto tab1 = muxc::TabViewItem();
                 tab1.Header(winrt::box_value(L"Terminal"));
-                tab1.IsClosable(false);
+                tab1.IsClosable(true);
                 tab1.Tag(winrt::box_value(reinterpret_cast<uint64_t>(session->hwnd)));
                 tabView.TabItems().Append(tab1);
                 tabView.SelectedItem(tab1);
@@ -385,15 +392,6 @@ int APIENTRY wWinMain(
                         }
                     }
                 };
-
-                // Transparent drag bar overlay — sits on top of the XAML Island
-                // to intercept WM_NCHITTEST for window dragging.
-                HWND dragBarHwnd = CreateWindowExW(
-                    WS_EX_LAYERED | WS_EX_NOREDIRECTIONBITMAP,
-                    L"GhosttyDragBar", nullptr,
-                    WS_CHILD | WS_VISIBLE,
-                    0, 0, rc.right - rc.left, session->headerHeight,
-                    hwnd, nullptr, GetModuleHandleW(nullptr), nullptr);
 
                 OutputDebugStringA("ghostty: XAML Island + drag bar attached\n");
             } catch (winrt::hresult_error const& e) {

--- a/GhosttyWin32.cpp
+++ b/GhosttyWin32.cpp
@@ -63,6 +63,10 @@ int APIENTRY wWinMain(
                 // Keep WS_THICKFRAME for smooth DWM resize, hide caption visually
                 style = (style & ~(WS_CAPTION | WS_SYSMENU | WS_MINIMIZEBOX | WS_MAXIMIZEBOX)) | WS_THICKFRAME;
                 session->decorations = false;
+                // Reserve a 32px header at the top so the user can drag the
+                // window even though the native caption is hidden. The drag
+                // region is delivered via WM_NCHITTEST → HTCAPTION.
+                session->headerHeight = 32;
                 SetWindowLongW(hwnd, GWL_STYLE, style);
                 SetWindowPos(hwnd, nullptr, 0, 0, 0, 0,
                     SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_FRAMECHANGED);

--- a/GhosttyWin32.cpp
+++ b/GhosttyWin32.cpp
@@ -3,6 +3,9 @@
 #include <windowsx.h>
 #include "GhosttyBridge.h"
 
+extern "C" void dx_set_surface_visible(void* dev, bool visible);
+extern "C" void* ghostty_surface_dx_device(void* surface);
+
 using namespace winrt;
 using namespace winrt::Windows::UI::Xaml::Hosting;
 
@@ -327,7 +330,7 @@ int APIENTRY wWinMain(
                         tv.SelectedItem(newTab);
                     });
 
-                // Tab selection changed: show selected, hide others, set focus
+                // Tab selection changed: show/hide via DirectComposition + set focus
                 tabView.SelectionChanged(
                     [parentHwnd, &bridge](auto&& sender, auto&&) {
                         auto tv = sender.template as<muxc::TabView>();
@@ -336,13 +339,15 @@ int APIENTRY wWinMain(
                         auto selItem = sel.template as<muxc::TabViewItem>();
                         uint64_t selTag = winrt::unbox_value<uint64_t>(selItem.Tag());
                         HWND selHwnd = reinterpret_cast<HWND>(selTag);
-                        SetWindowPos(selHwnd, HWND_TOP, 0, 0, 0, 0,
-                            SWP_NOMOVE | SWP_NOSIZE | SWP_SHOWWINDOW);
+                        // Show/hide via DirectComposition (safe while renderers are active)
                         for (auto& s : bridge.sessions()) {
-                            if (s->hwnd && s->hwnd != selHwnd) {
-                                ShowWindow(s->hwnd, SW_HIDE);
+                            if (s->hwnd && s->surface) {
+                                void* dxDev = ghostty_surface_dx_device(s->surface);
+                                if (dxDev) dx_set_surface_visible(dxDev, s->hwnd == selHwnd);
                             }
                         }
+                        SetWindowPos(selHwnd, HWND_TOP, 0, 0, 0, 0,
+                            SWP_NOMOVE | SWP_NOSIZE);
                         SetFocus(selHwnd);
                     });
 
@@ -373,13 +378,19 @@ int APIENTRY wWinMain(
                             return;
                         }
 
-                        // Switch to next tab FIRST (surface is already the right size)
+                        // Switch to next tab FIRST via DirectComposition
                         if (auto sel = tv.SelectedItem()) {
                             auto selItem = sel.as<muxc::TabViewItem>();
                             uint64_t selTag = winrt::unbox_value<uint64_t>(selItem.Tag());
                             HWND selHwnd = reinterpret_cast<HWND>(selTag);
+                            for (auto& s : bridge.sessions()) {
+                                if (s->hwnd && s->surface) {
+                                    void* dxDev = ghostty_surface_dx_device(s->surface);
+                                    if (dxDev) dx_set_surface_visible(dxDev, s->hwnd == selHwnd);
+                                }
+                            }
                             SetWindowPos(selHwnd, HWND_TOP, 0, 0, 0, 0,
-                                SWP_NOMOVE | SWP_NOSIZE | SWP_SHOWWINDOW);
+                                SWP_NOMOVE | SWP_NOSIZE);
                             SetFocus(selHwnd);
                         }
 

--- a/GhosttyWin32.cpp
+++ b/GhosttyWin32.cpp
@@ -23,10 +23,12 @@ int APIENTRY wWinMain(
     // identity needed (unlike WinUI 3, see issue #18).
     winrt::init_apartment(winrt::apartment_type::single_threaded);
     WindowsXamlManager xamlManager{ nullptr };
+    bool xamlReady = false;
     try {
-        auto providers = winrt::single_threaded_vector<winrt::Windows::UI::Xaml::Markup::IXamlMetadataProvider>();
-        winrt::Microsoft::Toolkit::Win32::UI::XamlHost::XamlApplication xamlApp{ providers };
+        // No XamlApplication needed — built-in WinUI 2 controls (TabView etc.)
+        // register their own metadata. Just initialize the XAML framework.
         xamlManager = WindowsXamlManager::InitializeForCurrentThread();
+        xamlReady = true;
         OutputDebugStringA("ghostty: WinUI 2 XAML hosting initialized\n");
     } catch (winrt::hresult_error const& e) {
         char buf[256];
@@ -73,6 +75,40 @@ int APIENTRY wWinMain(
         // Windows 11 rounded corners
         INT cornerPref = 2; // DWMWCP_ROUND
         DwmSetWindowAttribute(hwnd, 33 /*DWMWA_WINDOW_CORNER_PREFERENCE*/, &cornerPref, sizeof(cornerPref));
+
+        // Host a XAML Island in the header area (will become TabView in Step 2-E).
+        if (session->headerHeight > 0 && xamlReady) {
+            try {
+                auto xamlSource = DesktopWindowXamlSource();
+                auto interop = xamlSource.as<IDesktopWindowXamlSourceNative>();
+                winrt::check_hresult(interop->AttachToWindow(hwnd));
+
+                HWND islandHwnd = nullptr;
+                winrt::check_hresult(interop->get_WindowHandle(&islandHwnd));
+                session->xamlIslandHwnd = islandHwnd;
+
+                // Position the island in the header area.
+                RECT rc;
+                GetClientRect(hwnd, &rc);
+                SetWindowPos(islandHwnd, nullptr, 0, 0,
+                    rc.right - rc.left, session->headerHeight,
+                    SWP_SHOWWINDOW);
+
+                // Placeholder: a dark border matching the terminal background.
+                namespace controls = winrt::Windows::UI::Xaml::Controls;
+                namespace media = winrt::Windows::UI::Xaml::Media;
+                auto border = controls::Border();
+                border.Background(media::SolidColorBrush(
+                    winrt::Windows::UI::ColorHelper::FromArgb(255, 30, 30, 30)));
+                xamlSource.Content(border);
+
+                OutputDebugStringA("ghostty: XAML Island attached to header\n");
+            } catch (winrt::hresult_error const& e) {
+                char buf[256];
+                sprintf_s(buf, "ghostty: XAML Island failed hr=0x%08x\n", (unsigned)e.code());
+                OutputDebugStringA(buf);
+            }
+        }
     }
 
     // Move focus to the rendering child so keyboard/IME input works on first

--- a/GhosttyWin32.cpp
+++ b/GhosttyWin32.cpp
@@ -73,11 +73,10 @@ int APIENTRY wWinMain(
         auto muxResources = winrt::Microsoft::UI::Xaml::Controls::XamlControlsResources();
         winrt::Windows::UI::Xaml::Application::Current().Resources().MergedDictionaries().Append(muxResources);
         xamlReady = true;
-        OutputDebugStringA("ghostty: XAML + WinUI 2 initialized\n");
+        DBG_LOG("ghostty: XAML + WinUI 2 initialized\n");
     } catch (winrt::hresult_error const& e) {
-        char buf[256];
-        sprintf_s(buf, "ghostty: XAML init failed at hr=0x%08x\n", (unsigned)e.code());
-        OutputDebugStringA(buf);
+        (void)e;
+        DBG_LOG("ghostty: XAML init failed\n");
     }
 
     // Default to Mesa Zink (GL→Vulkan) for flicker-free rendering.
@@ -445,11 +444,10 @@ int APIENTRY wWinMain(
                     }
                 };
 
-                OutputDebugStringA("ghostty: XAML Island + drag bar attached\n");
+                DBG_LOG("ghostty: XAML Island attached\n");
             } catch (winrt::hresult_error const& e) {
-                char buf[256];
-                sprintf_s(buf, "ghostty: XAML Island failed hr=0x%08x\n", (unsigned)e.code());
-                OutputDebugStringA(buf);
+                (void)e;
+                DBG_LOG("ghostty: XAML Island failed\n");
             }
         }
     }

--- a/GhosttyWin32.cpp
+++ b/GhosttyWin32.cpp
@@ -2,6 +2,9 @@
 #include <dwmapi.h>
 #include "GhosttyBridge.h"
 
+using namespace winrt;
+using namespace winrt::Windows::UI::Xaml::Hosting;
+
 int APIENTRY wWinMain(
     _In_ HINSTANCE hInstance,
     _In_opt_ HINSTANCE hPrevInstance,
@@ -14,6 +17,25 @@ int APIENTRY wWinMain(
 
     // Enable Per-Monitor DPI awareness
     SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
+
+    // Initialize C++/WinRT and the XAML hosting framework. The XamlApplication
+    // base class from Microsoft.Toolkit.Win32.UI.XamlApplication provides the
+    // metadata providers WinUI 2 controls need. Failing to initialize is not
+    // fatal — the app falls back to a plain Win32 host.
+    winrt::init_apartment(winrt::apartment_type::single_threaded);
+    WindowsXamlManager xamlManager{ nullptr };
+    winrt::Microsoft::Toolkit::Win32::UI::XamlHost::XamlApplication xamlApp{ nullptr };
+    try {
+        // Empty metadata providers list — WinUI 2 controls register themselves.
+        auto providers = winrt::single_threaded_vector<winrt::Windows::UI::Xaml::Markup::IXamlMetadataProvider>();
+        xamlApp = winrt::Microsoft::Toolkit::Win32::UI::XamlHost::XamlApplication{ providers };
+        xamlManager = WindowsXamlManager::InitializeForCurrentThread();
+        OutputDebugStringA("ghostty: XAML hosting initialized\n");
+    } catch (winrt::hresult_error const& e) {
+        char buf[256];
+        sprintf_s(buf, "ghostty: XAML init failed hr=0x%08x\n", (unsigned)e.code());
+        OutputDebugStringA(buf);
+    }
 
     // Default to Mesa Zink (GL→Vulkan) for flicker-free rendering.
     // Set before any OpenGL calls. Users can override with GALLIUM_DRIVER env var.

--- a/GhosttyWin32.cpp
+++ b/GhosttyWin32.cpp
@@ -348,7 +348,8 @@ int APIENTRY wWinMain(
                         }
                         SetWindowPos(selHwnd, HWND_TOP, 0, 0, 0, 0,
                             SWP_NOMOVE | SWP_NOSIZE);
-                        SetFocus(selHwnd);
+                        // Defer focus — XAML may steal it during event dispatch
+                        PostMessageW(parentHwnd, WM_APP, 0, 0);
                     });
 
                 // Tab close requested: destroy the session

--- a/GhosttyWin32.cpp
+++ b/GhosttyWin32.cpp
@@ -130,10 +130,11 @@ int APIENTRY wWinMain(
                 }
                 RECT rc;
                 GetClientRect(hwnd, &rc);
+                const int dragStrip = 8;
                 HWND xamlHostWnd = CreateWindowExW(
                     0, L"GhosttyXamlHost", nullptr,
                     WS_CHILD | WS_VISIBLE,
-                    0, 0, rc.right - rc.left, session->headerHeight,
+                    0, dragStrip, rc.right - rc.left, session->headerHeight - dragStrip,
                     hwnd, nullptr, GetModuleHandleW(nullptr), nullptr);
 
                 session->xamlHostWnd = xamlHostWnd;
@@ -148,32 +149,98 @@ int APIENTRY wWinMain(
 
                 // Fill the host window.
                 SetWindowPos(islandHwnd, nullptr, 0, 0,
-                    rc.right - rc.left, session->headerHeight,
+                    rc.right - rc.left, session->headerHeight - dragStrip,
                     SWP_SHOWWINDOW);
 
                 // WinUI 2 TabView — activated via SxS manifest entries
                 namespace muxc = winrt::Microsoft::UI::Xaml::Controls;
                 namespace xaml = winrt::Windows::UI::Xaml;
 
+                namespace controls = xaml::Controls;
+                namespace media = xaml::Media;
+
+                // Root layout: TabView on the left, system buttons on the right
+                auto root = controls::Grid();
+                root.RequestedTheme(xaml::ElementTheme::Dark);
+                root.HorizontalAlignment(xaml::HorizontalAlignment::Stretch);
+                root.VerticalAlignment(xaml::VerticalAlignment::Stretch);
+
+                // Two columns: TabView (star) + system buttons (auto)
+                auto col1 = controls::ColumnDefinition();
+                col1.Width(xaml::GridLengthHelper::FromValueAndType(1, xaml::GridUnitType::Star));
+                root.ColumnDefinitions().Append(col1);
+                auto col2 = controls::ColumnDefinition();
+                col2.Width(xaml::GridLengthHelper::Auto());
+                root.ColumnDefinitions().Append(col2);
+
+                // TabView
                 auto tabView = muxc::TabView();
                 tabView.HorizontalAlignment(xaml::HorizontalAlignment::Stretch);
                 tabView.VerticalAlignment(xaml::VerticalAlignment::Stretch);
                 tabView.IsAddTabButtonVisible(true);
                 tabView.TabWidthMode(muxc::TabViewWidthMode::Equal);
-                tabView.RequestedTheme(xaml::ElementTheme::Dark);
+                controls::Grid::SetColumn(tabView, 0);
 
-                // First tab — associate with the initial session via Tag
                 auto tab1 = muxc::TabViewItem();
                 tab1.Header(winrt::box_value(L"Terminal"));
                 tab1.IsClosable(false);
                 tab1.Tag(winrt::box_value(reinterpret_cast<uint64_t>(session->hwnd)));
                 tabView.TabItems().Append(tab1);
                 tabView.SelectedItem(tab1);
+                root.Children().Append(tabView);
 
-                xamlSource.Content(tabView);
+                HWND mainWnd = session->parentHwnd;
+
+                // System buttons (─ □ ×)
+                auto sysButtons = controls::StackPanel();
+                sysButtons.Orientation(controls::Orientation::Horizontal);
+                sysButtons.VerticalAlignment(xaml::VerticalAlignment::Top);
+                controls::Grid::SetColumn(sysButtons, 1);
+
+                auto makeBtn = [&](const wchar_t* text, double w) {
+                    auto btn = controls::Button();
+                    auto txt = controls::TextBlock();
+                    txt.Text(text);
+                    txt.FontSize(10);
+                    txt.Foreground(media::SolidColorBrush(
+                        winrt::Windows::UI::ColorHelper::FromArgb(255, 200, 200, 200)));
+                    btn.Content(txt);
+                    btn.Background(media::SolidColorBrush(
+                        winrt::Windows::UI::ColorHelper::FromArgb(0, 0, 0, 0)));
+                    btn.Width(w);
+                    btn.Height(32);
+                    btn.Padding(xaml::ThicknessHelper::FromUniformLength(0));
+                    btn.BorderThickness(xaml::ThicknessHelper::FromUniformLength(0));
+                    btn.VerticalAlignment(xaml::VerticalAlignment::Top);
+                    return btn;
+                };
+
+                auto minBtn = makeBtn(L"\xE949", 46);  // Minimize icon
+                minBtn.FontFamily(media::FontFamily(L"Segoe MDL2 Assets"));
+                minBtn.Click([mainWnd](auto&&, auto&&) {
+                    ShowWindow(mainWnd, SW_MINIMIZE);
+                });
+
+                auto maxBtn = makeBtn(L"\xE739", 46);  // Maximize icon
+                maxBtn.FontFamily(media::FontFamily(L"Segoe MDL2 Assets"));
+                maxBtn.Click([mainWnd](auto&&, auto&&) {
+                    ShowWindow(mainWnd, IsZoomed(mainWnd) ? SW_RESTORE : SW_MAXIMIZE);
+                });
+
+                auto closeBtn = makeBtn(L"\xE106", 46);  // Close icon
+                closeBtn.Click([mainWnd](auto&&, auto&&) {
+                    PostMessageW(mainWnd, WM_CLOSE, 0, 0);
+                });
+
+                sysButtons.Children().Append(minBtn);
+                sysButtons.Children().Append(maxBtn);
+                sysButtons.Children().Append(closeBtn);
+                root.Children().Append(sysButtons);
+
+                xamlSource.Content(root);
 
                 // --- Tab event handlers ---
-                HWND parentHwnd = session->parentHwnd;
+                HWND parentHwnd = mainWnd;
 
                 // [+] button: create a new terminal session + tab
                 tabView.AddTabButtonClick(

--- a/GhosttyWin32.cpp
+++ b/GhosttyWin32.cpp
@@ -36,6 +36,50 @@ struct GhosttyApp : winrt::Windows::UI::Xaml::ApplicationT<GhosttyApp,
     }
 };
 
+// Subclass proc for the XAML Island's own HWND (child of xamlHostWnd).
+// Intercepts WM_NCHITTEST to check if the mouse is over interactive XAML
+// content. If not → HTTRANSPARENT so the parent can return HTCAPTION.
+#include <commctrl.h>
+#pragma comment(lib, "comctl32.lib")
+
+static winrt::Windows::UI::Xaml::Hosting::DesktopWindowXamlSource* g_xamlSourceForHitTest = nullptr;
+
+static LRESULT CALLBACK islandSubclassProc(
+    HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam,
+    UINT_PTR /*subclassId*/, DWORD_PTR /*refData*/)
+{
+    if (msg == WM_NCHITTEST && g_xamlSourceForHitTest && *g_xamlSourceForHitTest) {
+        auto content = g_xamlSourceForHitTest->Content();
+        if (content) {
+            POINT pt;
+            pt.x = (short)LOWORD(lParam);
+            pt.y = (short)HIWORD(lParam);
+            ScreenToClient(hwnd, &pt);
+            namespace xaml = winrt::Windows::UI::Xaml;
+            auto point = winrt::Windows::Foundation::Point(
+                static_cast<float>(pt.x), static_cast<float>(pt.y));
+            auto elements = xaml::Media::VisualTreeHelper::FindElementsInHostCoordinates(
+                point, content);
+            for (auto const& elem : elements) {
+                auto name = winrt::get_class_name(elem);
+                std::wstring_view sv{ name };
+                if (sv.find(L"Button") != std::wstring_view::npos ||
+                    sv.find(L"TabViewItem") != std::wstring_view::npos ||
+                    sv.find(L"ListViewItem") != std::wstring_view::npos) {
+                    return DefSubclassProc(hwnd, msg, wParam, lParam);
+                }
+            }
+            return HTTRANSPARENT;
+        }
+    }
+    return DefSubclassProc(hwnd, msg, wParam, lParam);
+}
+
+static LRESULT CALLBACK xamlHostWndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
+    if (msg == WM_NCHITTEST) return HTTRANSPARENT;
+    return DefWindowProcW(hwnd, msg, wParam, lParam);
+}
+
 int APIENTRY wWinMain(
     _In_ HINSTANCE hInstance,
     _In_opt_ HINSTANCE hPrevInstance,
@@ -122,7 +166,7 @@ int APIENTRY wWinMain(
                 static bool xamlHostRegistered = false;
                 if (!xamlHostRegistered) {
                     WNDCLASSW wc = {};
-                    wc.lpfnWndProc = DefWindowProcW;
+                    wc.lpfnWndProc = xamlHostWndProc;
                     wc.hInstance = GetModuleHandleW(nullptr);
                     wc.lpszClassName = L"GhosttyXamlHost";
                     RegisterClassW(&wc);
@@ -130,11 +174,10 @@ int APIENTRY wWinMain(
                 }
                 RECT rc;
                 GetClientRect(hwnd, &rc);
-                const int dragStrip = 8;
                 HWND xamlHostWnd = CreateWindowExW(
                     0, L"GhosttyXamlHost", nullptr,
                     WS_CHILD | WS_VISIBLE,
-                    0, dragStrip, rc.right - rc.left, session->headerHeight - dragStrip,
+                    0, 0, rc.right - rc.left, session->headerHeight,
                     hwnd, nullptr, GetModuleHandleW(nullptr), nullptr);
 
                 session->xamlHostWnd = xamlHostWnd;
@@ -147,9 +190,14 @@ int APIENTRY wWinMain(
                 winrt::check_hresult(interop->get_WindowHandle(&islandHwnd));
                 session->xamlIslandHwnd = islandHwnd;
 
+                // Subclass the island HWND so we can intercept WM_NCHITTEST
+                // and return HTTRANSPARENT for empty tab bar areas (drag).
+                g_xamlSourceForHitTest = &xamlSource;
+                SetWindowSubclass(islandHwnd, islandSubclassProc, 0, 0);
+
                 // Fill the host window.
                 SetWindowPos(islandHwnd, nullptr, 0, 0,
-                    rc.right - rc.left, session->headerHeight - dragStrip,
+                    rc.right - rc.left, session->headerHeight,
                     SWP_SHOWWINDOW);
 
                 // WinUI 2 TabView — activated via SxS manifest entries

--- a/GhosttyWin32.cpp
+++ b/GhosttyWin32.cpp
@@ -18,19 +18,16 @@ int APIENTRY wWinMain(
     // Enable Per-Monitor DPI awareness
     SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
 
-    // Initialize C++/WinRT and the XAML hosting framework. The XamlApplication
-    // base class from Microsoft.Toolkit.Win32.UI.XamlApplication provides the
-    // metadata providers WinUI 2 controls need. Failing to initialize is not
-    // fatal — the app falls back to a plain Win32 host.
+    // Initialize C++/WinRT and WinUI 2 XAML Islands. The UWP XAML runtime
+    // is built into Windows — no bootstrap, resources.pri, or package
+    // identity needed (unlike WinUI 3, see issue #18).
     winrt::init_apartment(winrt::apartment_type::single_threaded);
     WindowsXamlManager xamlManager{ nullptr };
-    winrt::Microsoft::Toolkit::Win32::UI::XamlHost::XamlApplication xamlApp{ nullptr };
     try {
-        // Empty metadata providers list — WinUI 2 controls register themselves.
         auto providers = winrt::single_threaded_vector<winrt::Windows::UI::Xaml::Markup::IXamlMetadataProvider>();
-        xamlApp = winrt::Microsoft::Toolkit::Win32::UI::XamlHost::XamlApplication{ providers };
+        winrt::Microsoft::Toolkit::Win32::UI::XamlHost::XamlApplication xamlApp{ providers };
         xamlManager = WindowsXamlManager::InitializeForCurrentThread();
-        OutputDebugStringA("ghostty: XAML hosting initialized\n");
+        OutputDebugStringA("ghostty: WinUI 2 XAML hosting initialized\n");
     } catch (winrt::hresult_error const& e) {
         char buf[256];
         sprintf_s(buf, "ghostty: XAML init failed hr=0x%08x\n", (unsigned)e.code());

--- a/GhosttyWin32.cpp
+++ b/GhosttyWin32.cpp
@@ -57,21 +57,15 @@ int APIENTRY wWinMain(
     DesktopWindowXamlSource xamlSource{ nullptr }; // Must outlive the message loop
     bool xamlReady = false;
     try {
-        OutputDebugStringA("ghostty: step 1 — creating custom App...\n");
+        // 1. Custom App with IXamlMetadataProvider
         auto app = winrt::make<GhosttyApp>();
-        OutputDebugStringA("ghostty: step 2 — App created, calling InitializeForCurrentThread...\n");
+        // 2. Initialize XAML framework (reuses our App)
         xamlManager = WindowsXamlManager::InitializeForCurrentThread();
-        // Step 3: try merging WinUI 2 theme resources (optional — TabView
-        // may work unstyled even if this fails).
-        try {
-            auto muxResources = winrt::Microsoft::UI::Xaml::Controls::XamlControlsResources();
-            winrt::Windows::UI::Xaml::Application::Current().Resources().MergedDictionaries().Append(muxResources);
-            OutputDebugStringA("ghostty: step 3 — WinUI 2 resources merged\n");
-        } catch (...) {
-            OutputDebugStringA("ghostty: step 3 — WinUI 2 resources skipped (non-fatal)\n");
-        }
+        // 3. Merge WinUI 2 theme resources (Fluent styles for TabView etc.)
+        auto muxResources = winrt::Microsoft::UI::Xaml::Controls::XamlControlsResources();
+        winrt::Windows::UI::Xaml::Application::Current().Resources().MergedDictionaries().Append(muxResources);
         xamlReady = true;
-        OutputDebugStringA("ghostty: XAML initialized OK\n");
+        OutputDebugStringA("ghostty: XAML + WinUI 2 initialized\n");
     } catch (winrt::hresult_error const& e) {
         char buf[256];
         sprintf_s(buf, "ghostty: XAML init failed at hr=0x%08x\n", (unsigned)e.code());
@@ -157,23 +151,23 @@ int APIENTRY wWinMain(
                     rc.right - rc.left, session->headerHeight,
                     SWP_SHOWWINDOW);
 
-                // Create TabView via XAML markup so the type is resolved
-                // through our IXamlMetadataProvider (GhosttyApp), not via
-                // direct RoGetActivationFactory (which fails for WinUI 2).
-                auto tabViewXaml = winrt::Windows::UI::Xaml::Markup::XamlReader::Load(
-                    LR"(<muxc:TabView
-                        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                        xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
-                        HorizontalAlignment="Stretch"
-                        VerticalAlignment="Stretch"
-                        IsAddTabButtonVisible="True"
-                        TabWidthMode="Equal">
-                        <muxc:TabView.TabItems>
-                            <muxc:TabViewItem Header="Terminal" IsClosable="False"/>
-                        </muxc:TabView.TabItems>
-                    </muxc:TabView>)");
+                // WinUI 2 TabView — activated via SxS manifest entries
+                namespace muxc = winrt::Microsoft::UI::Xaml::Controls;
+                namespace xaml = winrt::Windows::UI::Xaml;
 
-                xamlSource.Content(tabViewXaml.as<winrt::Windows::UI::Xaml::UIElement>());
+                auto tabView = muxc::TabView();
+                tabView.HorizontalAlignment(xaml::HorizontalAlignment::Stretch);
+                tabView.VerticalAlignment(xaml::VerticalAlignment::Stretch);
+                tabView.IsAddTabButtonVisible(true);
+                tabView.TabWidthMode(muxc::TabViewWidthMode::Equal);
+
+                auto tab1 = muxc::TabViewItem();
+                tab1.Header(winrt::box_value(L"Terminal"));
+                tab1.IsClosable(false);
+                tabView.TabItems().Append(tab1);
+                tabView.SelectedItem(tab1);
+
+                xamlSource.Content(tabView);
 
                 OutputDebugStringA("ghostty: XAML Island attached to header\n");
             } catch (winrt::hresult_error const& e) {

--- a/GhosttyWin32.vcxproj
+++ b/GhosttyWin32.vcxproj
@@ -109,10 +109,14 @@
       <PreprocessorDefinitions>_DEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp20</LanguageStandard>
+      <AdditionalIncludeDirectories>$(ProjectDir)ghostty;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>$(ProjectDir)ghostty;$(ProjectDir)packages\Microsoft.Web.WebView2.1.0.1264.42\build\native\x64</AdditionalLibraryDirectories>
+      <AdditionalDependencies>ghostty.lib;opengl32.lib;gdi32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <StackReserveSize>4194304</StackReserveSize>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">

--- a/GhosttyWin32.vcxproj
+++ b/GhosttyWin32.vcxproj
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(ProjectDir)packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('$(ProjectDir)packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -146,6 +147,9 @@
     <ResourceCompile Include="GhosttyWin32.rc" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
     <Image Include="GhosttyWin32.ico" />
     <Image Include="small.ico" />
   </ItemGroup>
@@ -154,5 +158,13 @@
     <Copy SourceFiles="$(ProjectDir)ghostty\ghostty.dll" DestinationFolder="$(OutDir)" SkipUnchangedFiles="true" />
   </Target>
   <ImportGroup Label="ExtensionTargets">
+    <Import Project="$(ProjectDir)packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('$(ProjectDir)packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.targets')" />
   </ImportGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them. For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('$(ProjectDir)packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '$(ProjectDir)packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.props'))" />
+    <Error Condition="!Exists('$(ProjectDir)packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(ProjectDir)packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.targets'))" />
+  </Target>
 </Project>

--- a/GhosttyWin32.vcxproj
+++ b/GhosttyWin32.vcxproj
@@ -150,6 +150,9 @@
     <ResourceCompile Include="GhosttyWin32.rc" />
   </ItemGroup>
   <ItemGroup>
+    <Manifest Include="app.manifest" />
+  </ItemGroup>
+  <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/GhosttyWin32.vcxproj
+++ b/GhosttyWin32.vcxproj
@@ -3,7 +3,7 @@
   <Import Project="$(ProjectDir)packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('$(ProjectDir)packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.props')" />
   <Import Project="$(ProjectDir)packages\Microsoft.UI.Xaml.2.8.6\build\native\Microsoft.UI.Xaml.props" Condition="Exists('$(ProjectDir)packages\Microsoft.UI.Xaml.2.8.6\build\native\Microsoft.UI.Xaml.props')" />
   <Import Project="$(ProjectDir)packages\Microsoft.Toolkit.Win32.UI.XamlApplication.6.1.3\build\native\Microsoft.Toolkit.Win32.UI.XamlApplication.props" Condition="Exists('$(ProjectDir)packages\Microsoft.Toolkit.Win32.UI.XamlApplication.6.1.3\build\native\Microsoft.Toolkit.Win32.UI.XamlApplication.props')" />
-  <Import Project="$(ProjectDir)packages\Microsoft.Web.WebView2.1.0.1264.42\build\native\Microsoft.Web.WebView2.props" Condition="Exists('$(ProjectDir)packages\Microsoft.Web.WebView2.1.0.1264.42\build\native\Microsoft.Web.WebView2.props')" />
+  <Import Project="$(ProjectDir)packages\Microsoft.Web.WebView2.1.0.1264.42\build\native\Microsoft.Web.WebView2.targets" Condition="Exists('$(ProjectDir)packages\Microsoft.Web.WebView2.1.0.1264.42\build\native\Microsoft.Web.WebView2.targets')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -130,7 +130,7 @@
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalLibraryDirectories>$(ProjectDir)ghostty</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(ProjectDir)ghostty;$(ProjectDir)packages\Microsoft.Web.WebView2.1.0.1264.42\build\native\x64</AdditionalLibraryDirectories>
       <AdditionalDependencies>ghostty.lib;opengl32.lib;gdi32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <StackReserveSize>4194304</StackReserveSize>
     </Link>
@@ -164,14 +164,12 @@
     <Import Project="$(ProjectDir)packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('$(ProjectDir)packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.targets')" />
     <Import Project="$(ProjectDir)packages\Microsoft.UI.Xaml.2.8.6\build\native\Microsoft.UI.Xaml.targets" Condition="Exists('$(ProjectDir)packages\Microsoft.UI.Xaml.2.8.6\build\native\Microsoft.UI.Xaml.targets')" />
     <Import Project="$(ProjectDir)packages\Microsoft.Toolkit.Win32.UI.XamlApplication.6.1.3\build\native\Microsoft.Toolkit.Win32.UI.XamlApplication.targets" Condition="Exists('$(ProjectDir)packages\Microsoft.Toolkit.Win32.UI.XamlApplication.6.1.3\build\native\Microsoft.Toolkit.Win32.UI.XamlApplication.targets')" />
-    <Import Project="$(ProjectDir)packages\Microsoft.Web.WebView2.1.0.1264.42\build\native\Microsoft.Web.WebView2.targets" Condition="Exists('$(ProjectDir)packages\Microsoft.Web.WebView2.1.0.1264.42\build\native\Microsoft.Web.WebView2.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them. For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('$(ProjectDir)packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '$(ProjectDir)packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.props'))" />
-    <Error Condition="!Exists('$(ProjectDir)packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(ProjectDir)packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.targets'))" />
     <Error Condition="!Exists('$(ProjectDir)packages\Microsoft.UI.Xaml.2.8.6\build\native\Microsoft.UI.Xaml.props')" Text="$([System.String]::Format('$(ErrorText)', '$(ProjectDir)packages\Microsoft.UI.Xaml.2.8.6\build\native\Microsoft.UI.Xaml.props'))" />
     <Error Condition="!Exists('$(ProjectDir)packages\Microsoft.Toolkit.Win32.UI.XamlApplication.6.1.3\build\native\Microsoft.Toolkit.Win32.UI.XamlApplication.props')" Text="$([System.String]::Format('$(ErrorText)', '$(ProjectDir)packages\Microsoft.Toolkit.Win32.UI.XamlApplication.6.1.3\build\native\Microsoft.Toolkit.Win32.UI.XamlApplication.props'))" />
   </Target>

--- a/GhosttyWin32.vcxproj
+++ b/GhosttyWin32.vcxproj
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(ProjectDir)packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('$(ProjectDir)packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.props')" />
+  <Import Project="$(ProjectDir)packages\Microsoft.UI.Xaml.2.8.6\build\native\Microsoft.UI.Xaml.props" Condition="Exists('$(ProjectDir)packages\Microsoft.UI.Xaml.2.8.6\build\native\Microsoft.UI.Xaml.props')" />
+  <Import Project="$(ProjectDir)packages\Microsoft.Toolkit.Win32.UI.XamlApplication.6.1.3\build\native\Microsoft.Toolkit.Win32.UI.XamlApplication.props" Condition="Exists('$(ProjectDir)packages\Microsoft.Toolkit.Win32.UI.XamlApplication.6.1.3\build\native\Microsoft.Toolkit.Win32.UI.XamlApplication.props')" />
+  <Import Project="$(ProjectDir)packages\Microsoft.Web.WebView2.1.0.1264.42\build\native\Microsoft.Web.WebView2.props" Condition="Exists('$(ProjectDir)packages\Microsoft.Web.WebView2.1.0.1264.42\build\native\Microsoft.Web.WebView2.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -159,6 +162,9 @@
   </Target>
   <ImportGroup Label="ExtensionTargets">
     <Import Project="$(ProjectDir)packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('$(ProjectDir)packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.targets')" />
+    <Import Project="$(ProjectDir)packages\Microsoft.UI.Xaml.2.8.6\build\native\Microsoft.UI.Xaml.targets" Condition="Exists('$(ProjectDir)packages\Microsoft.UI.Xaml.2.8.6\build\native\Microsoft.UI.Xaml.targets')" />
+    <Import Project="$(ProjectDir)packages\Microsoft.Toolkit.Win32.UI.XamlApplication.6.1.3\build\native\Microsoft.Toolkit.Win32.UI.XamlApplication.targets" Condition="Exists('$(ProjectDir)packages\Microsoft.Toolkit.Win32.UI.XamlApplication.6.1.3\build\native\Microsoft.Toolkit.Win32.UI.XamlApplication.targets')" />
+    <Import Project="$(ProjectDir)packages\Microsoft.Web.WebView2.1.0.1264.42\build\native\Microsoft.Web.WebView2.targets" Condition="Exists('$(ProjectDir)packages\Microsoft.Web.WebView2.1.0.1264.42\build\native\Microsoft.Web.WebView2.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
@@ -166,5 +172,7 @@
     </PropertyGroup>
     <Error Condition="!Exists('$(ProjectDir)packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '$(ProjectDir)packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.props'))" />
     <Error Condition="!Exists('$(ProjectDir)packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(ProjectDir)packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.targets'))" />
+    <Error Condition="!Exists('$(ProjectDir)packages\Microsoft.UI.Xaml.2.8.6\build\native\Microsoft.UI.Xaml.props')" Text="$([System.String]::Format('$(ErrorText)', '$(ProjectDir)packages\Microsoft.UI.Xaml.2.8.6\build\native\Microsoft.UI.Xaml.props'))" />
+    <Error Condition="!Exists('$(ProjectDir)packages\Microsoft.Toolkit.Win32.UI.XamlApplication.6.1.3\build\native\Microsoft.Toolkit.Win32.UI.XamlApplication.props')" Text="$([System.String]::Format('$(ErrorText)', '$(ProjectDir)packages\Microsoft.Toolkit.Win32.UI.XamlApplication.6.1.3\build\native\Microsoft.Toolkit.Win32.UI.XamlApplication.props'))" />
   </Target>
 </Project>

--- a/app.manifest
+++ b/app.manifest
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0"
+          xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
   <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
     <application>
       <!-- Windows 10 1903+ (required for XAML Islands) -->
@@ -7,4 +8,14 @@
       <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
     </application>
   </compatibility>
+
+  <!-- Registration-free WinRT activation for local DLLs.
+       This lets our unpackaged app activate WinRT classes from DLLs
+       in the exe directory without COM registration in the registry. -->
+  <file name="Microsoft.Toolkit.Win32.UI.XamlHost.dll">
+    <activatableClass
+      name="Microsoft.Toolkit.Win32.UI.XamlHost.XamlApplication"
+      threadingModel="both"
+      xmlns="urn:schemas-microsoft-com:winrt.v1" />
+  </file>
 </assembly>

--- a/app.manifest
+++ b/app.manifest
@@ -9,12 +9,40 @@
     </application>
   </compatibility>
 
-  <!-- Registration-free WinRT activation for local DLLs.
-       This lets our unpackaged app activate WinRT classes from DLLs
-       in the exe directory without COM registration in the registry. -->
-  <file name="Microsoft.Toolkit.Win32.UI.XamlHost.dll">
+  <!-- Registration-free WinRT: activate WinUI 2 classes from the local DLL
+       without MSIX packaging or registry COM entries. The DLL is copied from
+       the Microsoft.UI.Xaml.2.8 framework package at build time. -->
+  <file name="Microsoft.UI.Xaml.dll">
     <activatableClass
-      name="Microsoft.Toolkit.Win32.UI.XamlHost.XamlApplication"
+      name="Microsoft.UI.Xaml.Controls.TabView"
+      threadingModel="both"
+      xmlns="urn:schemas-microsoft-com:winrt.v1" />
+    <activatableClass
+      name="Microsoft.UI.Xaml.Controls.TabViewItem"
+      threadingModel="both"
+      xmlns="urn:schemas-microsoft-com:winrt.v1" />
+    <activatableClass
+      name="Microsoft.UI.Xaml.Controls.TabViewItemTemplateSettings"
+      threadingModel="both"
+      xmlns="urn:schemas-microsoft-com:winrt.v1" />
+    <activatableClass
+      name="Microsoft.UI.Xaml.Controls.Primitives.TabViewListView"
+      threadingModel="both"
+      xmlns="urn:schemas-microsoft-com:winrt.v1" />
+    <activatableClass
+      name="Microsoft.UI.Xaml.Controls.XamlControlsResources"
+      threadingModel="both"
+      xmlns="urn:schemas-microsoft-com:winrt.v1" />
+    <activatableClass
+      name="Microsoft.UI.Xaml.XamlTypeInfo.XamlControlsXamlMetaDataProvider"
+      threadingModel="both"
+      xmlns="urn:schemas-microsoft-com:winrt.v1" />
+    <activatableClass
+      name="Microsoft.UI.Xaml.Automation.Peers.TabViewAutomationPeer"
+      threadingModel="both"
+      xmlns="urn:schemas-microsoft-com:winrt.v1" />
+    <activatableClass
+      name="Microsoft.UI.Xaml.Automation.Peers.TabViewItemAutomationPeer"
       threadingModel="both"
       xmlns="urn:schemas-microsoft-com:winrt.v1" />
   </file>

--- a/app.manifest
+++ b/app.manifest
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <!-- Windows 10 1903+ (required for XAML Islands) -->
+      <maxversiontested Id="10.0.26100.0"/>
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+    </application>
+  </compatibility>
+</assembly>

--- a/framework.h
+++ b/framework.h
@@ -13,3 +13,7 @@
 #include <malloc.h>
 #include <memory.h>
 #include <tchar.h>
+
+// C++/WinRT — base projection. WinUI 2 / XAML Islands projections will be
+// added in subsequent steps.
+#include <winrt/Windows.Foundation.h>

--- a/framework.h
+++ b/framework.h
@@ -26,4 +26,6 @@
 #include <winrt/Microsoft.Toolkit.Win32.UI.XamlHost.h>
 #include <winrt/Windows.UI.Xaml.Media.h>
 #include <winrt/Windows.UI.h>
+#include <winrt/Microsoft.UI.Xaml.Controls.h>
+#include <winrt/Microsoft.UI.Xaml.XamlTypeInfo.h>
 #include <windows.ui.xaml.hosting.desktopwindowxamlsource.h>

--- a/framework.h
+++ b/framework.h
@@ -1,4 +1,4 @@
-﻿// header.h : 標準のシステム インクルード ファイルのインクルード ファイル、
+// header.h : 標準のシステム インクルード ファイルのインクルード ファイル、
 // またはプロジェクト専用のインクルード ファイル
 //
 
@@ -14,7 +14,9 @@
 #include <memory.h>
 #include <tchar.h>
 
-// C++/WinRT — XAML Islands hosts WinUI 2 controls inside our Win32 window.
+// C++/WinRT — WinUI 2 XAML Islands hosts controls inside our Win32 window.
+// Only the tab bar lives in XAML; Ghostty's rendering and input stay in a
+// plain Win32 child window.
 #include <winrt/Windows.Foundation.h>
 #include <winrt/Windows.Foundation.Collections.h>
 #include <winrt/Windows.UI.Xaml.h>

--- a/framework.h
+++ b/framework.h
@@ -24,3 +24,6 @@
 #include <winrt/Windows.UI.Xaml.Controls.h>
 #include <winrt/Windows.UI.Xaml.Markup.h>
 #include <winrt/Microsoft.Toolkit.Win32.UI.XamlHost.h>
+#include <winrt/Windows.UI.Xaml.Media.h>
+#include <winrt/Windows.UI.h>
+#include <windows.ui.xaml.hosting.desktopwindowxamlsource.h>

--- a/framework.h
+++ b/framework.h
@@ -25,6 +25,8 @@
 #include <winrt/Windows.UI.Xaml.Markup.h>
 #include <winrt/Microsoft.Toolkit.Win32.UI.XamlHost.h>
 #include <winrt/Windows.UI.Xaml.Media.h>
+#include <winrt/Windows.UI.Xaml.Controls.Primitives.h>
+#include <winrt/Windows.UI.Xaml.Input.h>
 #include <winrt/Windows.UI.h>
 #include <winrt/Microsoft.UI.Xaml.Controls.h>
 #include <winrt/Microsoft.UI.Xaml.XamlTypeInfo.h>

--- a/framework.h
+++ b/framework.h
@@ -14,6 +14,11 @@
 #include <memory.h>
 #include <tchar.h>
 
-// C++/WinRT — base projection. WinUI 2 / XAML Islands projections will be
-// added in subsequent steps.
+// C++/WinRT — XAML Islands hosts WinUI 2 controls inside our Win32 window.
 #include <winrt/Windows.Foundation.h>
+#include <winrt/Windows.Foundation.Collections.h>
+#include <winrt/Windows.UI.Xaml.h>
+#include <winrt/Windows.UI.Xaml.Hosting.h>
+#include <winrt/Windows.UI.Xaml.Controls.h>
+#include <winrt/Windows.UI.Xaml.Markup.h>
+#include <winrt/Microsoft.Toolkit.Win32.UI.XamlHost.h>

--- a/framework.h
+++ b/framework.h
@@ -27,6 +27,7 @@
 #include <winrt/Windows.UI.Xaml.Media.h>
 #include <winrt/Windows.UI.Xaml.Controls.Primitives.h>
 #include <winrt/Windows.UI.Xaml.Input.h>
+#include <winrt/Windows.UI.Xaml.Media.h>
 #include <winrt/Windows.UI.h>
 #include <winrt/Microsoft.UI.Xaml.Controls.h>
 #include <winrt/Microsoft.UI.Xaml.XamlTypeInfo.h>

--- a/packages.config
+++ b/packages.config
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.250303.1" targetFramework="native" />
+</packages>

--- a/packages.config
+++ b/packages.config
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Windows.CppWinRT" version="2.0.250303.1" targetFramework="native" />
+  <package id="Microsoft.Toolkit.Win32.UI.XamlApplication" version="6.1.3" targetFramework="native" />
+  <package id="Microsoft.UI.Xaml" version="2.8.6" targetFramework="native" />
+  <package id="Microsoft.Web.WebView2" version="1.0.1264.42" targetFramework="native" />
 </packages>


### PR DESCRIPTION
## Summary / 概要

Full multi-tab terminal support using WinUI 2 TabView (XAML Islands) and DirectComposition for flicker-free tab switching.

<details><summary>日本語</summary>

WinUI 2 TabView（XAML Islands）と DirectComposition によるちらつきのないタブ切り替えを備えた完全なマルチタブターミナルサポート。

</details>

## Changes / 変更

### Modified Files / 変更ファイル

| File | Change |
|------|--------|
| `GhosttyBridge.h` | Add `m_wakeupHwnd`, `m_xamlHostWnd/IslandHwnd`, `m_bgColor`, `kDefaultHeaderHeight`, `BgColorChangedFn`, `DBG_LOG` macro |
| `GhosttyBridge.cpp` | Multi-surface lifecycle, DirectComposition visibility (`dx_set_surface_visible`), WM_NCHITTEST drag/resize, WM_PAINT background fill, thread-safe wakeup, all-surface resize on WM_SIZE |
| `GhosttyWin32.cpp` | TabView setup, tab event handlers (create/switch/close), system buttons (Segoe MDL2 Assets), XAML host with HTTRANSPARENT resize edges, MaxWidth 70% tab cap, dynamic background color sync |
| `GhosttyWin32.vcxproj` | Debug\|x64 build configuration |

## Technical Decisions / 技術的決定

**DirectComposition visibility over ShowWindow**: `ShowWindow(SW_HIDE)` crashes NVIDIA drivers when the renderer thread is mid-`Present()`. Tab switching uses `dx_set_surface_visible` which detaches/attaches the DirectComposition visual root — the HWND stays alive for input, the swap chain stays valid, only the compositor output is toggled.

<details><summary>日本語</summary>

レンダラースレッドが `Present()` 中に `ShowWindow(SW_HIDE)` すると NVIDIA ドライバーがクラッシュする。タブ切り替えは `dx_set_surface_visible` で DirectComposition のビジュアルルートを着脱 — HWND は入力用に生存、スワップチェーンは有効のまま、コンポジター出力のみ切り替え。

</details>

**WS_EX_NOREDIRECTIONBITMAP on child windows**: Prevents GDI redirection surface from covering DirectComposition output. Child windows have no GDI bitmap — composition visuals show through directly.

<details><summary>日本語</summary>

GDI リダイレクション面が DirectComposition 出力を覆うのを防止。子ウィンドウは GDI ビットマップを持たず、コンポジションビジュアルが直接表示される。

</details>

**Deferred focus via PostMessage(WM_APP)**: XAML Islands steal focus during `SelectionChanged` event dispatch. Focus is deferred to the next message loop iteration, finding the topmost session child via `GetTopWindow`.

<details><summary>日本語</summary>

XAML Islands が `SelectionChanged` イベント処理中にフォーカスを奪う。フォーカスは次のメッセージループ反復に遅延し、`GetTopWindow` で最前面のセッション子ウィンドウを検出。

</details>

**WM_PAINT background fill during resize**: XAML Islands don't resize synchronously with the native window (microsoft/microsoft-ui-xaml#759). Exposed areas are painted with the terminal background color — same technique as Windows Terminal.

<details><summary>日本語</summary>

XAML Islands はネイティブウィンドウと同期してリサイズしない。露出した領域をターミナル背景色で塗りつぶす — Windows Terminal と同じ手法。

</details>

**Thread-safe wakeup via m_wakeupHwnd**: `onWakeup` is called from renderer threads. Previously it accessed `m_sessions` (data race on `push_back` reallocation). Now posts to a fixed main window HWND.

<details><summary>日本語</summary>

`onWakeup` はレンダラースレッドから呼ばれる。以前は `m_sessions` にアクセスしていた（`push_back` 再割り当てでデータ競合）。現在は固定のメインウィンドウ HWND にポスト。

</details>

## Build / ビルド

Open `GhosttyWin32.sln` in Visual Studio, build Release|x64.

Requires ghostty DLL built with DirectComposition support (i999rri/ghostty#32).

## Known Issues / 既知の問題

- i999rri/GhosttyWin32#22 — Tab creation flicker (new surface visible before first render)

🤖 Generated with [Claude Code](https://claude.com/claude-code)