### PR TITLE
Fix OpenGL renderer: white screen, renderer-agnostic API, build improvements

### DIFF
--- a/GhosttyBridge.cpp
+++ b/GhosttyBridge.cpp
@@ -13,13 +13,6 @@
 #pragma comment(lib, "opengl32.lib")
 #pragma comment(lib, "gdi32.lib")
 
-// DirectX renderer: notify resize from main thread (exported from ghostty.dll)
-extern "C" void dx_notify_resize(void* dev, uint32_t w, uint32_t h);
-// Get the DxDevice pointer from a ghostty surface (returns the per-surface device)
-extern "C" void* ghostty_surface_dx_device(void* surface);
-// DirectComposition visibility control (safe while renderer is active)
-extern "C" void dx_set_surface_visible(void* dev, bool visible);
-
 GhosttyBridge::TitleChangedFn GhosttyBridge::s_titleChangedFn = nullptr;
 void* GhosttyBridge::s_titleChangedCtx = nullptr;
 GhosttyBridge::BgColorChangedFn GhosttyBridge::s_bgColorChangedFn = nullptr;
@@ -385,16 +378,11 @@ LRESULT CALLBACK GhosttyBridge::renderWndProc(HWND hwnd, UINT msg, WPARAM wParam
     case WM_SIZE: {
         UINT width = LOWORD(lParam);
         UINT height = HIWORD(lParam);
-        if (width > 0 && height > 0) {
-            // Notify the per-surface DirectX device of the new size
-            if (hasSurface) {
-                void* dxDev = ghostty_surface_dx_device(sess->surface);
-                dx_notify_resize(dxDev, width, height);
-            }
-            if (hasSurface) {
-                ghostty_surface_set_size(sess->surface, width, height);
-                ghostty_surface_refresh(sess->surface);
-            }
+        if (width > 0 && height > 0 && hasSurface) {
+            // Renderer-agnostic resize notification. For DirectX this routes
+            // to a renderer-thread hook that updates the swap chain size.
+            ghostty_surface_set_size(sess->surface, width, height);
+            ghostty_surface_refresh(sess->surface);
         }
         return 0;
     }

--- a/GhosttyBridge.cpp
+++ b/GhosttyBridge.cpp
@@ -766,10 +766,7 @@ void GhosttyBridge::ensureRenderClassRegistered() {
 }
 
 HWND GhosttyBridge::createRendererWindow(HWND parent, TerminalSession* session) {
-    char rendererBuf[32] = {};
-    GetEnvironmentVariableA("GHOSTTY_RENDERER", rendererBuf, sizeof(rendererBuf));
-    bool useDirectX = (strcmp(rendererBuf, "opengl") != 0);
-    return useDirectX
+    return shouldUseDirectX()
         ? createDirectXWindow(parent, session)
         : createGLWindow(parent, session);
 }
@@ -847,10 +844,7 @@ TerminalSession* GhosttyBridge::createSurface(HWND parentHwnd) {
             auto* a = static_cast<Args*>(param);
             TerminalSession* sess = a->session;
 
-            // Default to DirectX, use GHOSTTY_RENDERER=opengl to override
-            char rendererBuf[32] = {};
-            GetEnvironmentVariableA("GHOSTTY_RENDERER", rendererBuf, sizeof(rendererBuf));
-            bool useDirectX = (strcmp(rendererBuf, "opengl") != 0);
+            bool useDirectX = shouldUseDirectX();
 
             if (!useDirectX) {
                 // Create and activate OpenGL context on this thread

--- a/GhosttyBridge.cpp
+++ b/GhosttyBridge.cpp
@@ -780,8 +780,14 @@ HWND GhosttyBridge::createGLWindow(HWND parent, TerminalSession* session) {
     RECT rc;
     GetClientRect(parent, &rc);
     int top = session ? session->headerHeight : 0;
+    // WS_EX_NOREDIRECTIONBITMAP is required for DirectComposition rendering
+    // but incompatible with OpenGL (which needs the GDI redirection surface).
+    char rendererBuf[32] = {};
+    GetEnvironmentVariableA("GHOSTTY_RENDERER", rendererBuf, sizeof(rendererBuf));
+    bool useDirectX = (strcmp(rendererBuf, "opengl") != 0);
+    DWORD exStyle = useDirectX ? WS_EX_NOREDIRECTIONBITMAP : 0;
     HWND hwnd = CreateWindowExW(
-        WS_EX_NOREDIRECTIONBITMAP, L"GhosttyGLWindow", nullptr,
+        exStyle, L"GhosttyGLWindow", nullptr,
         WS_CHILD | WS_VISIBLE | WS_CLIPSIBLINGS | WS_CLIPCHILDREN,
         0, top, rc.right - rc.left, (rc.bottom - rc.top) - top,
         parent, nullptr, GetModuleHandleW(nullptr), session);

--- a/GhosttyBridge.cpp
+++ b/GhosttyBridge.cpp
@@ -225,7 +225,7 @@ TerminalSession* GhosttyBridge::sessionFromSurface(ghostty_surface_t surface) {
     return static_cast<TerminalSession*>(ghostty_surface_userdata(surface));
 }
 
-LRESULT CALLBACK GhosttyBridge::glWndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
+LRESULT CALLBACK GhosttyBridge::renderWndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
     // Stash the TerminalSession* passed via CreateWindowEx lpParam
     if (msg == WM_NCCREATE) {
         auto* cs = reinterpret_cast<CREATESTRUCTW*>(lParam);
@@ -764,43 +764,53 @@ HWND GhosttyBridge::createMainWindow(TerminalSession* session) {
         nullptr, nullptr, GetModuleHandleW(nullptr), session);
 }
 
-HWND GhosttyBridge::createGLWindow(HWND parent, TerminalSession* session) {
+void GhosttyBridge::ensureRenderClassRegistered() {
     static bool registered = false;
-    if (!registered) {
-        WNDCLASSW wc = {};
-        wc.lpfnWndProc = glWndProc;
-        wc.hInstance = GetModuleHandleW(nullptr);
-        wc.lpszClassName = L"GhosttyGLWindow";
-        wc.style = CS_OWNDC;
-        wc.hCursor = LoadCursorW(nullptr, IDC_IBEAM);
-        RegisterClassW(&wc);
-        registered = true;
-    }
+    if (registered) return;
+    WNDCLASSW wc = {};
+    wc.lpfnWndProc = renderWndProc;
+    wc.hInstance = GetModuleHandleW(nullptr);
+    wc.lpszClassName = L"GhosttyRenderWindow";
+    wc.style = CS_OWNDC;
+    wc.hCursor = LoadCursorW(nullptr, IDC_IBEAM);
+    RegisterClassW(&wc);
+    registered = true;
+}
 
-    RECT rc;
-    GetClientRect(parent, &rc);
-    int top = session ? session->headerHeight : 0;
-    // WS_EX_NOREDIRECTIONBITMAP is required for DirectComposition rendering
-    // but incompatible with OpenGL (which needs the GDI redirection surface).
+HWND GhosttyBridge::createRendererWindow(HWND parent, TerminalSession* session) {
     char rendererBuf[32] = {};
     GetEnvironmentVariableA("GHOSTTY_RENDERER", rendererBuf, sizeof(rendererBuf));
     bool useDirectX = (strcmp(rendererBuf, "opengl") != 0);
-    DWORD exStyle = useDirectX ? WS_EX_NOREDIRECTIONBITMAP : 0;
-    HWND hwnd = CreateWindowExW(
-        exStyle, L"GhosttyGLWindow", nullptr,
+    return useDirectX
+        ? createDirectXWindow(parent, session)
+        : createGLWindow(parent, session);
+}
+
+HWND GhosttyBridge::createDirectXWindow(HWND parent, TerminalSession* session) {
+    ensureRenderClassRegistered();
+    // DirectComposition needs WS_EX_NOREDIRECTIONBITMAP — no GDI surface,
+    // composition visuals show through directly.
+    RECT rc;
+    GetClientRect(parent, &rc);
+    int top = session ? session->headerHeight : 0;
+    return CreateWindowExW(
+        WS_EX_NOREDIRECTIONBITMAP, L"GhosttyRenderWindow", nullptr,
         WS_CHILD | WS_VISIBLE | WS_CLIPSIBLINGS | WS_CLIPCHILDREN,
         0, top, rc.right - rc.left, (rc.bottom - rc.top) - top,
         parent, nullptr, GetModuleHandleW(nullptr), session);
+}
 
-    if (hwnd) {
-        char buf[128];
-        sprintf_s(buf, "ghostty: GL window created: %p\n", hwnd);
-        DBG_LOG(buf);
-    } else {
-        DBG_LOG("ghostty: failed to create GL window\n");
-    }
-
-    return hwnd;
+HWND GhosttyBridge::createGLWindow(HWND parent, TerminalSession* session) {
+    ensureRenderClassRegistered();
+    // OpenGL needs a standard GDI surface — no WS_EX_NOREDIRECTIONBITMAP.
+    RECT rc;
+    GetClientRect(parent, &rc);
+    int top = session ? session->headerHeight : 0;
+    return CreateWindowExW(
+        0, L"GhosttyRenderWindow", nullptr,
+        WS_CHILD | WS_VISIBLE | WS_CLIPSIBLINGS | WS_CLIPCHILDREN,
+        0, top, rc.right - rc.left, (rc.bottom - rc.top) - top,
+        parent, nullptr, GetModuleHandleW(nullptr), session);
 }
 
 TerminalSession* GhosttyBridge::createSurface(HWND parentHwnd) {
@@ -830,7 +840,7 @@ TerminalSession* GhosttyBridge::createSurface(HWND parentHwnd) {
     }
 
     // Create the rendering child — session pointer is plumbed through WM_NCCREATE
-    session->hwnd = createGLWindow(parentHwnd, session);
+    session->hwnd = createRendererWindow(parentHwnd, session);
     if (!session->hwnd) {
         if (session->parentHwnd) DestroyWindow(session->parentHwnd);
         return nullptr;

--- a/GhosttyBridge.h
+++ b/GhosttyBridge.h
@@ -12,6 +12,18 @@
 #define DBG_LOG(msg) ((void)0)
 #endif
 
+// Returns true if DirectX should be used, false for OpenGL.
+// Accepts "opengl" or "directx"; anything else falls back to DirectX.
+inline bool shouldUseDirectX() {
+    char buf[32] = {};
+    GetEnvironmentVariableA("GHOSTTY_RENDERER", buf, sizeof(buf));
+    if (_stricmp(buf, "opengl") == 0) return false;
+    if (buf[0] != '\0' && _stricmp(buf, "directx") != 0) {
+        DBG_LOG("ghostty: unknown GHOSTTY_RENDERER value, defaulting to DirectX\n");
+    }
+    return true;
+}
+
 // Bridge between libghostty and Win32
 // Equivalent to the Swift AppDelegate on macOS
 

--- a/GhosttyBridge.h
+++ b/GhosttyBridge.h
@@ -91,8 +91,11 @@ private:
     static LRESULT CALLBACK mainWndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam);
     HWND createMainWindow(TerminalSession* session);
 
-    // Win32 child window for OpenGL/DirectX rendering
-    static LRESULT CALLBACK glWndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam);
+    // Win32 child window for rendering (dispatches to GL or DirectX)
+    static LRESULT CALLBACK renderWndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam);
+    static void ensureRenderClassRegistered();
+    HWND createRendererWindow(HWND parent, TerminalSession* session);
+    HWND createDirectXWindow(HWND parent, TerminalSession* session);
     HWND createGLWindow(HWND parent, TerminalSession* session);
 
     // OpenGL context for WGL (per-session)

--- a/GhosttyWin32.cpp
+++ b/GhosttyWin32.cpp
@@ -77,9 +77,9 @@ int APIENTRY wWinMain(
             static_cast<unsigned int>(e.code()));
         DBG_LOG(buf);
     }
-    // Default to Mesa Zink (GL→Vulkan) for flicker-free rendering.
-    // Set before any OpenGL calls. Users can override with GALLIUM_DRIVER env var.
-    if (!GetEnvironmentVariableA("GALLIUM_DRIVER", nullptr, 0)) {
+    // Default to Mesa Zink (GL→Vulkan) for flicker-free OpenGL rendering.
+    // Only set when using the OpenGL renderer; DirectX doesn't use Mesa.
+    if (!shouldUseDirectX() && !GetEnvironmentVariableA("GALLIUM_DRIVER", nullptr, 0)) {
         SetEnvironmentVariableA("GALLIUM_DRIVER", "zink");
     }
 

--- a/GhosttyWin32.cpp
+++ b/GhosttyWin32.cpp
@@ -3,9 +3,6 @@
 #include <windowsx.h>
 #include "GhosttyBridge.h"
 
-extern "C" void dx_set_surface_visible(void* dev, bool visible);
-extern "C" void* ghostty_surface_dx_device(void* surface);
-
 using namespace winrt;
 using namespace winrt::Windows::UI::Xaml::Hosting;
 
@@ -347,8 +344,7 @@ int APIENTRY wWinMain(
                         // Show/hide via DirectComposition (safe while renderers are active)
                         for (auto& s : bridge.sessions()) {
                             if (s->hwnd && s->surface) {
-                                void* dxDev = ghostty_surface_dx_device(s->surface);
-                                if (dxDev) dx_set_surface_visible(dxDev, s->hwnd == selHwnd);
+                                ghostty_surface_set_occlusion(s->surface, s->hwnd == selHwnd);
                             }
                         }
                         SetWindowPos(selHwnd, HWND_TOP, 0, 0, 0, 0,
@@ -391,8 +387,7 @@ int APIENTRY wWinMain(
                             HWND selHwnd = reinterpret_cast<HWND>(selTag);
                             for (auto& s : bridge.sessions()) {
                                 if (s->hwnd && s->surface) {
-                                    void* dxDev = ghostty_surface_dx_device(s->surface);
-                                    if (dxDev) dx_set_surface_visible(dxDev, s->hwnd == selHwnd);
+                                    ghostty_surface_set_occlusion(s->surface, s->hwnd == selHwnd);
                                 }
                             }
                             SetWindowPos(selHwnd, HWND_TOP, 0, 0, 0, 0,

--- a/GhosttyWin32.cpp
+++ b/GhosttyWin32.cpp
@@ -72,10 +72,11 @@ int APIENTRY wWinMain(
         xamlReady = true;
         DBG_LOG("ghostty: XAML + WinUI 2 initialized\n");
     } catch (winrt::hresult_error const& e) {
-        (void)e;
-        DBG_LOG("ghostty: XAML init failed\n");
+        char buf[128];
+        sprintf_s(buf, "ghostty: XAML init failed hr=0x%08X\n",
+            static_cast<unsigned int>(e.code()));
+        DBG_LOG(buf);
     }
-
     // Default to Mesa Zink (GL→Vulkan) for flicker-free rendering.
     // Set before any OpenGL calls. Users can override with GALLIUM_DRIVER env var.
     if (!GetEnvironmentVariableA("GALLIUM_DRIVER", nullptr, 0)) {

--- a/GhosttyWin32.vcxproj
+++ b/GhosttyWin32.vcxproj
@@ -164,8 +164,19 @@
     <Image Include="small.ico" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
-  <Target Name="CopyGhosttyDll" AfterTargets="Build">
+  <PropertyGroup>
+    <MuxPkgDir>$(ProjectDir)packages\Microsoft.UI.Xaml.2.8.6\</MuxPkgDir>
+    <MuxAppxPath>$(MuxPkgDir)tools\AppX\x64\Release\Microsoft.UI.Xaml.2.8.appx</MuxAppxPath>
+    <MuxExtractDir>$(IntDir)MicrosoftUIXaml\</MuxExtractDir>
+  </PropertyGroup>
+  <Target Name="ExtractWinUI" BeforeTargets="Build" Condition="!Exists('$(MuxExtractDir)Microsoft.UI.Xaml.dll')">
+    <MakeDir Directories="$(MuxExtractDir)" />
+    <Unzip SourceFiles="$(MuxAppxPath)" DestinationFolder="$(MuxExtractDir)" OverwriteReadOnlyFiles="true" />
+  </Target>
+  <Target Name="CopyRuntimeDeps" AfterTargets="Build">
     <Copy SourceFiles="$(ProjectDir)ghostty\ghostty.dll" DestinationFolder="$(OutDir)" SkipUnchangedFiles="true" />
+    <Copy SourceFiles="$(MuxExtractDir)Microsoft.UI.Xaml.dll" DestinationFolder="$(OutDir)" SkipUnchangedFiles="true" />
+    <Copy SourceFiles="$(MuxExtractDir)resources.pri" DestinationFolder="$(OutDir)" SkipUnchangedFiles="true" />
   </Target>
   <ImportGroup Label="ExtensionTargets">
     <Import Project="$(ProjectDir)packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('$(ProjectDir)packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.targets')" />


### PR DESCRIPTION
## Summary / 概要

Fix the OpenGL renderer path so it works correctly alongside the DirectX renderer. The host binary now links against either renderer build of `ghostty.dll` using the same renderer-agnostic surface APIs the macOS apprt uses.

<details><summary>日本語</summary>

OpenGL レンダラーのパスを修正し、DirectX レンダラーと共存できるようにした。ホストバイナリは macOS apprt と同じ renderer 非依存の surface API を使い、どちらの renderer ビルドの `ghostty.dll` にもリンクできる。

</details>

Pairs with i999rri/ghostty#33, which adds the `notifyResize` / `setVisible` graphics-API hooks on the ghostty side.

## Changes / 変更

### Modified Files / 変更ファイル

| File | Change |
|------|--------|
| `GhosttyBridge.h` | Add `shouldUseDirectX()` helper (validates `GHOSTTY_RENDERER`, case-insensitive, falls back to DirectX). Add `createRendererWindow`, `createDirectXWindow`, `ensureRenderClassRegistered`. Rename `glWndProc` → `renderWndProc`. |
| `GhosttyBridge.cpp` | Split window creation into `createRendererWindow` (dispatcher), `createDirectXWindow` (`WS_EX_NOREDIRECTIONBITMAP`), and `createGLWindow` (no extended style). Replace `dx_notify_resize` / `ghostty_surface_dx_device` with `ghostty_surface_set_size`. Remove all DirectX-specific `extern "C"` forward declarations. |
| `GhosttyWin32.cpp` | Replace `dx_set_surface_visible` / `ghostty_surface_dx_device` with `ghostty_surface_set_occlusion`. Scope `GALLIUM_DRIVER=zink` to OpenGL mode only. Improve XAML init error logging with HRESULT code. |
| `GhosttyWin32.vcxproj` | Add MSBuild `Unzip` task to extract `Microsoft.UI.Xaml.dll` and `resources.pri` from the NuGet `.appx` at build time, ensuring both Debug and Release have the required WinUI 2 DLLs. |

## Technical Decisions / 技術的決定

### 1. Renderer-agnostic surface API

Previously the host called three DirectX-internal exports (`dx_notify_resize`, `dx_set_surface_visible`, `ghostty_surface_dx_device`). These symbols don't exist in an OpenGL build, breaking linkage. Now uses `ghostty_surface_set_size` / `ghostty_surface_set_occlusion` — the same APIs the macOS apprt uses.

### 2. Window creation split

`createGLWindow` used to apply `WS_EX_NOREDIRECTIONBITMAP` conditionally. This flag is required for DirectComposition but incompatible with OpenGL's GDI pixel formats. Split into `createRendererWindow` → `createDirectXWindow` / `createGLWindow` with shared `ensureRenderClassRegistered`.

### 3. Environment variable validation

`shouldUseDirectX()` accepts `"opengl"` or `"directx"` (case-insensitive). Unknown values fall back to DirectX with a debug warning, preventing crashes from typos. `GALLIUM_DRIVER=zink` is only set automatically when the OpenGL renderer is active.

### 4. WinUI 2 DLL extraction at build time

The `Microsoft.UI.Xaml` NuGet package bundles its DLLs inside an `.appx` archive and doesn't copy them to the output directory. Debug builds would fail XAML initialization with `ERROR_MOD_NOT_FOUND` (0x8007007E). Added an MSBuild `Unzip` task to extract from the `.appx` and copy to `$(OutDir)`.

<details><summary>日本語</summary>

### 1. Renderer 非依存 surface API

従来はホストから DirectX 内部 export 3 種を直接呼んでいたが、OpenGL ビルドにはこれらのシンボルが存在せずリンクできなかった。macOS apprt が使っている `ghostty_surface_set_size` / `ghostty_surface_set_occlusion` に統一。

### 2. ウィンドウ作成の分離

`createGLWindow` が `WS_EX_NOREDIRECTIONBITMAP` を条件分岐で付けていたが、このフラグは DirectComposition 専用で OpenGL と非互換。`createRendererWindow` → `createDirectXWindow` / `createGLWindow` に分離。

### 3. 環境変数バリデーション

`shouldUseDirectX()` は `"opengl"` / `"directx"`（大文字小文字不問）のみ受け付け、不明な値は DirectX にフォールバック。`GALLIUM_DRIVER=zink` は OpenGL モード時のみ自動設定。

### 4. WinUI 2 DLL のビルド時展開

`Microsoft.UI.Xaml` NuGet パッケージは DLL を `.appx` 内にバンドルしており、出力ディレクトリにコピーしない。Debug ビルドで XAML 初期化が `ERROR_MOD_NOT_FOUND` で失敗していた。MSBuild の `Unzip` タスクで `.appx` から展開し `$(OutDir)` にコピーするよう修正。

</details>

## Build / ビルド

```powershell
# DirectX (default)
msbuild GhosttyWin32.vcxproj /p:Configuration=Release /p:Platform=x64

# OpenGL
$env:GHOSTTY_RENDERER = "opengl"
.\x64\Release\GhosttyWin32.exe
```

## Verified / 動作確認

- [x] DirectX renderer (default)
- [x] OpenGL + native NVIDIA driver
- [x] OpenGL + Mesa Zink 26.0.4
- [x] Debug and Release configurations
- [x] XAML TabView in all renderer modes
- [x] Invalid `GHOSTTY_RENDERER` value → falls back to DirectX

Fixes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)