### PR TITLE
Fix dev-build YAML parse error from PowerShell here-string

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -189,35 +189,40 @@ jobs:
           $sha = "${{ github.sha }}"
           $msixVer = "${{ steps.version.outputs.msix_version }}"
 
-          $body = @"
-**Dev build** — automated build of the latest ``dev`` branch.
-
-⚠️ This is **not** a stable release. Expect bugs.
-
-## Install
-
-1. Download ``Ghostty-dev-x64.msix`` and ``Ghostty.cer``
-2. Right-click ``Ghostty.cer`` → Install Certificate → **Local Machine** →
-   **Trusted People** (UAC prompt; one-time per machine)
-3. Double-click the ``.msix`` to install
-
-If you previously installed Ghostty (stable or dev), this MSIX upgrades it
-in place.
-
-## Source
-
-| | |
-|---|---|
-| Branch | ``dev`` |
-| Commit | [``$shortSha``](https://github.com/$repo/commit/$sha) |
-| Build  | [\#$runNum](https://github.com/$repo/actions/runs/$runId) |
-| MSIX version | ``$msixVer`` |
-| Built | $now |
-"@
+          # Build the release notes as an array of lines and write to a file.
+          # PowerShell here-strings (@"..."@) require the closing "@ at column 0,
+          # which YAML's `run: |` block scalar can't satisfy because every line
+          # in the block needs indenting. Building line-by-line avoids the
+          # conflict entirely.
+          $bt = [char]0x60   # backtick — used in markdown as code delimiter
+          $lines = @(
+            "**Dev build** — automated build of the latest ${bt}dev${bt} branch.",
+            "",
+            "⚠️ This is **not** a stable release. Expect bugs.",
+            "",
+            "## Install",
+            "",
+            "1. Download ${bt}Ghostty-dev-x64.msix${bt} and ${bt}Ghostty.cer${bt}",
+            "2. Right-click ${bt}Ghostty.cer${bt} → Install Certificate → **Local Machine** → **Trusted People** (UAC prompt; one-time per machine)",
+            "3. Double-click the ${bt}.msix${bt} to install",
+            "",
+            "If you previously installed Ghostty (stable or dev), this MSIX upgrades it in place.",
+            "",
+            "## Source",
+            "",
+            "| | |",
+            "|---|---|",
+            "| Branch | ${bt}dev${bt} |",
+            "| Commit | [${bt}${shortSha}${bt}](https://github.com/${repo}/commit/${sha}) |",
+            "| Build  | [#${runNum}](https://github.com/${repo}/actions/runs/${runId}) |",
+            "| MSIX version | ${bt}${msixVer}${bt} |",
+            "| Built | ${now} |"
+          )
+          $lines | Set-Content -Path release-notes.md -Encoding utf8
 
           gh release create dev-build `
             --title "Dev build (${{ steps.version.outputs.display_version }})" `
-            --notes "$body" `
+            --notes-file release-notes.md `
             --prerelease `
             "${{ steps.locate.outputs.msix_path }}" `
             Ghostty.cer


### PR DESCRIPTION
## Summary / 概要

Fix the YAML syntax error in `.github/workflows/dev-build.yml` line 193
that was blocking workflow validation. The PowerShell here-string used
to build the release notes conflicted with YAML's indentation rules.

<details><summary>日本語</summary>

`.github/workflows/dev-build.yml` の line 193 で発生していた YAML 構文エラーを
修正する。リリースノート本文の組み立てに使っていた PowerShell の here-string が
YAML のインデント規則と衝突していた。

</details>

## Root Cause / 根本原因

PowerShell `@"..."@` here-strings require the closing `"@` to be at
column 0 (no leading whitespace). YAML's `run: |` block scalar requires
every line to be indented by at least the same amount as the first
content line. The two requirements are mutually exclusive — you can't
have a closer at column 0 *and* indented to match the block.

GitHub's workflow validator chokes on the resulting line, reporting it
as a YAML syntax error even though the immediate cause is in PowerShell.

<details><summary>日本語</summary>

PowerShell の `@"..."@` here-string は閉じ `"@` を列 0（先頭インデント無し）に
置く必要がある。一方 YAML の `run: |` ブロックスカラーは全行を最初の行と同じ
量だけインデントする必要がある。両者は両立しない — 列 0 にあって、かつ
ブロック内インデントに揃えることはできない。

GitHub の workflow validator はこのファイルで詰まり、PowerShell 側が原因なのに
YAML 構文エラーとして報告される。

</details>

## Fix / 修正

Build the release notes as an array of strings and write to
`release-notes.md`, then pass `--notes-file` to `gh release create`. The
output is identical to the previous here-string; only the construction
changed.

<details><summary>日本語</summary>

リリースノートを文字列配列で組み立てて `release-notes.md` に書き出し、
`gh release create` には `--notes-file` で渡すようにした。出力内容は元の
here-string と同一で、構築方法だけ変わっている。

</details>

```powershell
$bt = [char]0x60
$lines = @(
  "**Dev build** — automated build of the latest ${bt}dev${bt} branch.",
  "",
  ...
)
$lines | Set-Content -Path release-notes.md -Encoding utf8

gh release create dev-build --notes-file release-notes.md ...
```

Backticks (markdown code delimiters) are inserted via `[char]0x60` to
avoid the PowerShell escape interpretation when wrapped in
double-quoted strings.

<details><summary>日本語</summary>

バッククォート（markdown のコード区切り）は `[char]0x60` 経由で埋め込む。
ダブルクォート文字列内ではバッククォートがエスケープ文字として解釈されるため。

</details>

## Build / ビルド

CI 検証のみ。マージ後に `dev` ブランチへ push すれば dev-build ワークフロー
が正常に走るはず。

## Known Issues / 既知の問題

なし。
