### PR TITLE
Point ghostty checkout at windows-port

### DIFF
--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -125,7 +125,7 @@ git push origin v0.3.0
 ```
 
 挙動:
-1. ghostty fork の `feature/swapchain-panel-api` から `ghostty.dll` をビルド
+1. ghostty fork の `windows-port` から `ghostty.dll` をビルド
 2. `Package.appxmanifest` の `Version` をタグから動的書き換え (`v0.3.0` → `0.3.0.0`)
 3. **`release` Environment が承認待ち** → Actions タブ → "Review pending deployments" で承認
 4. 承認後: PFX を Secrets から復元 → MSIX 署名 → PFX 削除 → Releases にアップロード
@@ -148,7 +148,7 @@ git push origin dev
 ```
 
 挙動:
-1. 自動的に `feature/swapchain-panel-api` の最新 ghostty.dll をビルド
+1. 自動的に `windows-port` の最新 ghostty.dll をビルド
 2. MSIX manifest version は `0.3.0.<run_number>` (例: `0.3.0.42`)
 3. 自動承認、即ビルド
 4. **`dev-build` という固定タグの Release を上書き作成**（前回の dev-build は削除される）

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: i999rri/ghostty
-          ref: feature/swapchain-panel-api
+          ref: windows-port
           path: ghostty
 
       - name: Compute dev version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: i999rri/ghostty
-          ref: feature/swapchain-panel-api
+          ref: windows-port
           path: ghostty
 
       - name: Setup Zig

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ This requires a forked version of Ghostty with Windows support patches:
 ```bash
 git clone https://github.com/i999rri/ghostty.git
 cd ghostty
-git switch feature/swapchain-panel-api
+git switch windows-port
 zig build -Doptimize=ReleaseSafe -Drenderer=directx
 ```
 


### PR DESCRIPTION
## Summary

CI now checks out the ghostty fork at `windows-port` instead of `feature/swapchain-panel-api`. With i999rri/ghostty#35 merged, `windows-port` is the active main of the Windows port — the SwapChainPanel API, NVIDIA AV root-cause fix, pipeline cache mutex, and texture upload audit all live there. Pinning CI to the old feature branch would freeze us on a stale ref.

## Changes

| File | Change |
|---|---|
| `.github/workflows/release.yml` | `ref: windows-port` |
| `.github/workflows/dev-build.yml` | `ref: windows-port` |
| `.github/RELEASING.md` | matching wording (build-flow section + dev-build description) |
| `README.md` | `git switch windows-port` in the build instructions |

## Dependency

**Must not merge before i999rri/ghostty#35.** That PR is what brings `dx_create_from_swap_chain`, the Presentation cell, and `planTextureUpload` into `windows-port`. If we merge this first, CI will checkout a `windows-port` that doesn't yet have those symbols and the link step will fail.

Order: merge ghostty#35 → merge this.

<details>
<summary>日本語</summary>

## 概要

CI で参照する ghostty fork のブランチを `feature/swapchain-panel-api` から `windows-port` に変更する。i999rri/ghostty#35 がマージされて、SwapChainPanel API・NVIDIA AV 修正・パイプラインキャッシュ mutex・テクスチャアップロード監査がすべて `windows-port` に入った。これにより `windows-port` が Windows port の active main となったため、古い feature ブランチを参照し続けると CI が stale な ref に固定されてしまう。

## 変更

| ファイル | 変更 |
|---|---|
| `.github/workflows/release.yml` | `ref: windows-port` |
| `.github/workflows/dev-build.yml` | `ref: windows-port` |
| `.github/RELEASING.md` | build-flow セクションと dev-build 説明の文言 |
| `README.md` | ビルド手順を `git switch windows-port` に |

## 依存関係

**i999rri/ghostty#35 より先にマージしてはいけない。** そのPRが `dx_create_from_swap_chain` / Presentation cell / `planTextureUpload` を `windows-port` に取り込む。先にこちらをマージすると、CI がそれらのシンボルを持たない `windows-port` を checkout してリンク段階で失敗する。

順序: ghostty#35 → このPR の順でマージ。
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)