### PR TITLE
Fix dev-build: rename ghostty-internal.dll back on copy

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -66,7 +66,10 @@ jobs:
         run: |
           cd ghostty
           zig build -Doptimize=ReleaseSafe -Drenderer=directx
-          Copy-Item zig-out/lib/ghostty.dll ../ghostty/
+          # upstream renamed the install artifact: zig-out/lib/ghostty.dll →
+          # ghostty-internal.dll (ghostty commit 4fd16ef9b). GhosttyWin32App
+          # still links against ghostty.dll, so rename on copy.
+          Copy-Item zig-out/lib/ghostty-internal.dll ../ghostty/ghostty.dll
           Copy-Item include/ghostty.h ../ghostty/
           $searchPaths = @(".")
           if ($env:ZIG_LOCAL_CACHE_DIR) { $searchPaths += $env:ZIG_LOCAL_CACHE_DIR }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,8 +41,10 @@ jobs:
           cd ghostty
           zig build -Doptimize=ReleaseSafe -Drenderer=directx
           # GhosttyWin32App.vcxproj links against ../ghostty/ghostty.{dll,lib,h}
-          # at the workspace root; copy the canonical artifacts there.
-          Copy-Item zig-out/lib/ghostty.dll ../ghostty/
+          # at the workspace root. upstream renamed the install artifact
+          # ghostty.dll → ghostty-internal.dll (ghostty 4fd16ef9b), so rename
+          # on copy to keep the linker target stable.
+          Copy-Item zig-out/lib/ghostty-internal.dll ../ghostty/ghostty.dll
           Copy-Item include/ghostty.h ../ghostty/
           # The Zig build writes the small import lib into the cache, not
           # zig-out. Hunt for the most recently produced one (~60 KB) and


### PR DESCRIPTION
## Summary

The dev-build CI step copies the wrong filename — upstream ghostty renamed the install artifact from `ghostty.dll` to `ghostty-internal.dll` in commit `4fd16ef9b`, and `windows-port` picked this up via its recent `origin/main` merge. Both `release.yml` and `dev-build.yml` now copy `zig-out/lib/ghostty-internal.dll` and rename to `ghostty.dll` at the destination so `GhosttyWin32App.vcxproj` keeps linking against the same name it always has.

## Why rename instead of chasing the new name

Two reasons:

1. The host project (`GhosttyWin32App`) and Visual Studio link configs reference `ghostty.dll/.lib`. Renaming would touch a lot more files for no functional benefit.
2. The import library in the Zig cache is still `ghostty.lib` (the build.zig artifact name didn't change — only the install rename), so the existing cache-search logic for the `.lib` keeps working unchanged. Keeping the DLL named the same way avoids a split where the DLL and LIB use different conventions.

## Failure log

```
Cannot find path 'D:\a\GhosttyWin32\GhosttyWin32\ghostty\zig-out\lib\ghostty.dll' because it does not exist.
```

## Verification plan

- [ ] Merge → `dev` branch sync triggers dev-build → green run
- [ ] Eventually: cut `v0.3.0-rc1` to verify the same fix on the `release` workflow path

<details>
<summary>日本語</summary>

## 概要

dev-build CI で参照する DLL ファイル名が古いまま。upstream ghostty が commit `4fd16ef9b` で install 成果物を `ghostty.dll` → `ghostty-internal.dll` にリネームし、それが `windows-port` の最近の `origin/main` マージで取り込まれた。`release.yml` / `dev-build.yml` どちらも `zig-out/lib/ghostty-internal.dll` をコピーしつつコピー先で `ghostty.dll` にリネームするよう修正。これで `GhosttyWin32App.vcxproj` のリンク設定は変えずに済む。

## 新しい名前を追う代わりにリネームする理由

二点:

1. host project (`GhosttyWin32App`) と Visual Studio のリンク設定は `ghostty.dll/.lib` 参照。リネーム追従だと変更範囲が広がるだけで実利益はない。
2. Zig cache の import library はまだ `ghostty.lib` のまま (build.zig の artifact 名は不変、install 時のリネームだけ追加された)。既存の cache 探索ロジックがそのまま動く。DLL と LIB で命名規則が分かれるのを避ける。

## 失敗ログ

```
Cannot find path 'D:\a\GhosttyWin32\GhosttyWin32\ghostty\zig-out\lib\ghostty.dll' because it does not exist.
```

## 検証

- [ ] マージ → `dev` 同期で dev-build トリガー → green を確認
- [ ] のちに `v0.3.0-rc1` を切って `release` workflow 側でも同じ修正が効くことを確認
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)