### PR TITLE
Restore via msbuild for .slnx compatibility

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -89,11 +89,12 @@ jobs:
       - name: Setup MSBuild
         uses: microsoft/setup-msbuild@v2
 
-      - name: Setup NuGet
-        uses: NuGet/setup-nuget@v2
-
+      # NuGet CLI doesn't understand the new .slnx solution format yet, so
+      # restore via msbuild's Restore target instead. msbuild 17.7+ handles
+      # .slnx natively and the wapproj's PackageReferences resolve the same
+      # way as `nuget restore` would on a legacy .sln.
       - name: Restore NuGet packages
-        run: nuget restore GhosttyWin32.sln
+        run: msbuild GhosttyWin32.slnx /t:Restore /p:Configuration=Release /p:Platform=x64
 
       - name: Patch manifest version
         shell: pwsh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,11 +67,12 @@ jobs:
       - name: Setup MSBuild
         uses: microsoft/setup-msbuild@v2
 
-      - name: Setup NuGet
-        uses: NuGet/setup-nuget@v2
-
+      # NuGet CLI doesn't understand the new .slnx solution format yet, so
+      # restore via msbuild's Restore target instead. msbuild 17.7+ handles
+      # .slnx natively and the wapproj's PackageReferences resolve the same
+      # way as `nuget restore` would on a legacy .sln.
       - name: Restore NuGet packages
-        run: nuget restore GhosttyWin32.sln
+        run: msbuild GhosttyWin32.slnx /t:Restore /p:Configuration=Release /p:Platform=x64
 
       - name: Set MSIX version from tag
         shell: pwsh


### PR DESCRIPTION
## Summary

NuGet CLI 7.x can't read the new XML-based `.slnx` solution format, so the post-WinUI 3 dev-build was failing at the restore step:

```
Input file does not exist: GhosttyWin32.sln.
```

(The WinUI 3 migration in #25 renamed `GhosttyWin32.sln` → `GhosttyWin32.slnx`, but NuGet CLI lags on `.slnx` support.)

## Change

Replace `nuget restore GhosttyWin32.sln` with `msbuild GhosttyWin32.slnx /t:Restore`. msbuild 17.7+ handles `.slnx` natively and resolves the wapproj's `PackageReference`s the same way `nuget restore` would on a legacy `.sln`. The `setup-nuget` action becomes dead weight after the swap and is removed.

Both `release.yml` and `dev-build.yml` get the same treatment for parity.

## Verification plan

- [ ] Merge → dev sync → dev-build green run
- [ ] Then cut a `v0.3.0-rc1` tag to verify `release.yml`

<details>
<summary>日本語</summary>

## 概要

WinUI 3 移行 (#25) で `GhosttyWin32.sln` が `GhosttyWin32.slnx` (新 XML 形式) にリネームされたが、NuGet CLI 7.x はまだ `.slnx` を読めないため dev-build が restore 段階で失敗していた:

```
Input file does not exist: GhosttyWin32.sln.
```

## 変更

`nuget restore GhosttyWin32.sln` を `msbuild GhosttyWin32.slnx /t:Restore` に置き換え。msbuild 17.7+ は `.slnx` をネイティブにサポートしており、wapproj の `PackageReference` を従来の `nuget restore` と同じように解決する。`setup-nuget` action は不要になったので削除。

`release.yml` と `dev-build.yml` を揃えて同じ修正を適用。

## 検証

- [ ] マージ → dev sync → dev-build green を確認
- [ ] その後 `v0.3.0-rc1` を切って `release.yml` も確認
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)