### PR TITLE
Restore packages.config and PackageReference projects together

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -89,12 +89,20 @@ jobs:
       - name: Setup MSBuild
         uses: microsoft/setup-msbuild@v2
 
-      # NuGet CLI doesn't understand the new .slnx solution format yet, so
-      # restore via msbuild's Restore target instead. msbuild 17.7+ handles
-      # .slnx natively and the wapproj's PackageReferences resolve the same
-      # way as `nuget restore` would on a legacy .sln.
+      - name: Setup NuGet
+        uses: NuGet/setup-nuget@v2
+
+      # The wapproj uses PackageReference (handled by msbuild /t:Restore),
+      # but GhosttyWin32App.vcxproj / GhosttyTests.vcxproj still use the
+      # legacy packages.config format which msbuild's Restore target ignores.
+      # We need both: nuget restore expands ..\packages\ for the vcxprojs,
+      # then msbuild /t:Restore resolves the wapproj's PackageReferences.
+      # NuGet CLI doesn't read .slnx so we point it at each vcxproj.
       - name: Restore NuGet packages
-        run: msbuild GhosttyWin32.slnx /t:Restore /p:Configuration=Release /p:Platform=x64
+        run: |
+          nuget restore "GhosttyWin32App/GhosttyWin32App.vcxproj" -PackagesDirectory packages -SolutionDirectory .
+          nuget restore "GhosttyTests/GhosttyTests.vcxproj" -PackagesDirectory packages -SolutionDirectory .
+          msbuild GhosttyWin32.slnx /t:Restore /p:Configuration=Release /p:Platform=x64
 
       - name: Patch manifest version
         shell: pwsh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,12 +67,20 @@ jobs:
       - name: Setup MSBuild
         uses: microsoft/setup-msbuild@v2
 
-      # NuGet CLI doesn't understand the new .slnx solution format yet, so
-      # restore via msbuild's Restore target instead. msbuild 17.7+ handles
-      # .slnx natively and the wapproj's PackageReferences resolve the same
-      # way as `nuget restore` would on a legacy .sln.
+      - name: Setup NuGet
+        uses: NuGet/setup-nuget@v2
+
+      # The wapproj uses PackageReference (handled by msbuild /t:Restore),
+      # but GhosttyWin32App.vcxproj / GhosttyTests.vcxproj still use the
+      # legacy packages.config format which msbuild's Restore target ignores.
+      # We need both: nuget restore expands ..\packages\ for the vcxprojs,
+      # then msbuild /t:Restore resolves the wapproj's PackageReferences.
+      # NuGet CLI doesn't read .slnx so we point it at each vcxproj.
       - name: Restore NuGet packages
-        run: msbuild GhosttyWin32.slnx /t:Restore /p:Configuration=Release /p:Platform=x64
+        run: |
+          nuget restore "GhosttyWin32App/GhosttyWin32App.vcxproj" -PackagesDirectory packages -SolutionDirectory .
+          nuget restore "GhosttyTests/GhosttyTests.vcxproj" -PackagesDirectory packages -SolutionDirectory .
+          msbuild GhosttyWin32.slnx /t:Restore /p:Configuration=Release /p:Platform=x64
 
       - name: Set MSIX version from tag
         shell: pwsh


### PR DESCRIPTION
## Summary

The previous fix (#32) only ran `msbuild /t:Restore`, which silently skips packages.config projects. The wapproj uses PackageReference and worked, but `GhosttyWin32App.vcxproj` / `GhosttyTests.vcxproj` are still on packages.config and need the literal `..\packages\<id>.<version>\` paths expanded on disk before they can `<Import>` their `.targets` files.

CI failure:

```
GhosttyWin32App.vcxproj(192,5): error : このプロジェクトは、このコンピューター上にない NuGet パッケージを参照しています。
見つからないファイルは ..\packages\Microsoft.Web.WebView2.1.0.3179.45\build\native\Microsoft.Web.WebView2.targets です。
```

## Why local builds worked anyway

The earlier local verification of #32 was a false positive — the local `packages/` directory was already populated from prior Visual Studio sessions. Re-verified after deleting `packages/`, which reproduced the CI error. Adding the two `nuget restore` calls fixes it. The MSIX now builds end-to-end on a clean checkout.

## Change

```yaml
- name: Restore NuGet packages
  run: |
    nuget restore "GhosttyWin32App/GhosttyWin32App.vcxproj" -PackagesDirectory packages -SolutionDirectory .
    nuget restore "GhosttyTests/GhosttyTests.vcxproj" -PackagesDirectory packages -SolutionDirectory .
    msbuild GhosttyWin32.slnx /t:Restore /p:Configuration=Release /p:Platform=x64
```

`Setup NuGet` action restored. Both restore calls (legacy + modern) coexist because they target different project formats — neither alone covers both.

## Future cleanup

Migrating the two vcxprojs to PackageReference would let us drop the `nuget restore` calls entirely, but that's a separate refactor (touches `.vcxproj` and `.config` files) and not in scope here.

## Verification

- Locally: `Remove-Item packages -Recurse -Force` → run the three restore commands → `msbuild ... .wapproj /p:GenerateAppxPackageOnBuild=true /p:AppxPackageSigningEnabled=false` → MSIX produced
- CI: pending merge

<details>
<summary>日本語</summary>

## 概要

前回の修正 (#32) では `msbuild /t:Restore` だけを実行していたが、packages.config プロジェクトはこのターゲットでは復元されない。wapproj は PackageReference 形式で問題なかったが、`GhosttyWin32App.vcxproj` / `GhosttyTests.vcxproj` はレガシーな packages.config 形式で `..\packages\<id>.<version>\` という物理パスを `<Import>` しているため、ディスクに展開されていないと失敗する。

CI のエラー:

```
GhosttyWin32App.vcxproj(192,5): error : このプロジェクトは、このコンピューター上にない NuGet パッケージを参照しています。
見つからないファイルは ..\packages\Microsoft.Web.WebView2.1.0.3179.45\build\native\Microsoft.Web.WebView2.targets です。
```

## ローカルビルドが通ってしまった理由

前回 #32 のローカル検証は偽陽性。`packages/` が過去の Visual Studio ビルドで populated されていたため、復元ステップを動かすまでもなく既存ファイルで build が通っていた。`packages/` を削除してから検証し直すと CI と同じエラーが再現。`nuget restore` × 2 を追加することで解決し、クリーン状態から MSIX 生成まで通った。

## 変更

```yaml
- name: Restore NuGet packages
  run: |
    nuget restore "GhosttyWin32App/GhosttyWin32App.vcxproj" -PackagesDirectory packages -SolutionDirectory .
    nuget restore "GhosttyTests/GhosttyTests.vcxproj" -PackagesDirectory packages -SolutionDirectory .
    msbuild GhosttyWin32.slnx /t:Restore /p:Configuration=Release /p:Platform=x64
```

`Setup NuGet` action を復活。レガシー (packages.config) と現代的 (PackageReference) のどちらか単独では両方をカバーできないので、両方を併走させる。

## 将来の整理

vcxproj を PackageReference 形式に移行すれば `nuget restore` 呼び出しを削除できるが、`.vcxproj` と `.config` の書き換えが必要なリファクタなので本 PR の範囲外。

## 検証

- ローカル: `Remove-Item packages -Recurse -Force` 後に3つの restore コマンド実行 → wapproj ビルド (署名OFF) → MSIX 生成成功
- CI: マージ後に確認
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)