### PR TITLE
Fix manifest version patching: preserve XML and scope to Identity

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -107,10 +107,20 @@ jobs:
       - name: Patch manifest version
         shell: pwsh
         run: |
+          # Read with -Raw so existing line endings are preserved verbatim
+          # (the previous Get-Content + Set-Content -NoNewline approach
+          # joined array elements with no separator, collapsing the XML
+          # declaration into the next line and producing APPX1402).
+          # Use -creplace (case-sensitive) on uppercase Version=, otherwise
+          # -replace also clobbers `version="1.0"` in the <?xml ... ?>
+          # declaration since PowerShell -replace is case-insensitive.
           $manifestPath = "GhosttyWin32 (Package)/Package.appxmanifest"
-          (Get-Content $manifestPath) `
-            -replace 'Version="[\d\.]+"', "Version=`"${{ steps.version.outputs.msix_version }}`"" |
-            Set-Content $manifestPath -NoNewline
+          $content = Get-Content $manifestPath -Raw
+          # (?<=\s) lookbehind requires whitespace before Version=, so
+          # MinVersion= / MaxVersionTested= in <TargetDeviceFamily> aren't
+          # touched — only the Version= attribute on <Identity> matches.
+          $content = $content -creplace '(?<=\s)Version="[\d\.]+"', "Version=`"${{ steps.version.outputs.msix_version }}`""
+          [System.IO.File]::WriteAllText((Resolve-Path $manifestPath), $content)
 
       - name: Decode signing certificate
         shell: pwsh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,10 +90,20 @@ jobs:
           $tag = "${{ github.ref_name }}"
           $version = ($tag.TrimStart('v') -split '-')[0]
           $fullVersion = "$version.0"
+          # Read with -Raw so existing line endings are preserved verbatim
+          # (the previous Get-Content + Set-Content -NoNewline approach
+          # joined array elements with no separator, collapsing the XML
+          # declaration into the next line and producing APPX1402).
+          # Use -creplace (case-sensitive) on uppercase Version=, otherwise
+          # -replace also clobbers `version="1.0"` in the <?xml ... ?>
+          # declaration since PowerShell -replace is case-insensitive.
           $manifestPath = "GhosttyWin32 (Package)/Package.appxmanifest"
-          (Get-Content $manifestPath) `
-            -replace 'Version="[\d\.]+"', "Version=`"$fullVersion`"" |
-            Set-Content $manifestPath -NoNewline
+          $content = Get-Content $manifestPath -Raw
+          # (?<=\s) lookbehind requires whitespace before Version=, so
+          # MinVersion= / MaxVersionTested= in <TargetDeviceFamily> aren't
+          # touched — only the Version= attribute on <Identity> matches.
+          $content = $content -creplace '(?<=\s)Version="[\d\.]+"', "Version=`"$fullVersion`""
+          [System.IO.File]::WriteAllText((Resolve-Path $manifestPath), $content)
           Write-Host "Set MSIX version to $fullVersion"
           # Echo for downstream steps.
           "msix_version=$fullVersion" >> $env:GITHUB_ENV


### PR DESCRIPTION
## Summary

Three independent bugs in the same step were stacked on top of each other; the first masked the others, so they only became visible after each previous fix.

| # | Bug | Symptom | Fix |
|---|---|---|---|
| 1 | `Set-Content -NoNewline` with array input concatenates with no separator | XML declaration collapsed into next line → `APPX1402 not well-formed XML` | `Get-Content -Raw` + `[IO.File]::WriteAllText` to preserve original line endings |
| 2 | PowerShell `-replace` is case-insensitive | `version="1.0"` in `<?xml ... ?>` was rewritten to `Version="0.3.0.99"` | `-creplace` (case-sensitive on uppercase `Version=`) |
| 3 | Regex matched `Version=` as substring of `MinVersion=` / `MaxVersionTested=` | `<TargetDeviceFamily>` OS lower bounds got clobbered with the package version | `(?<=\s)` lookbehind so only standalone `Version=` (the one on `<Identity>`) matches |

## Verification

Locally end-to-end with the `Remove-Item packages -Recurse -Force` simulating a clean CI checkout:
- Patched manifest: XML declaration intact, `<Identity Version="0.3.0.99" />`, `<TargetDeviceFamily ... MinVersion="10.0.17763.0" MaxVersionTested="10.0.26226.0" />` untouched
- Full msbuild pipeline against the wapproj → MSIX produced (`GhosttyWin32 (Package)_0.3.0.99_x64.msix`)

<details>
<summary>日本語</summary>

## 概要

同じステップに独立した3つのバグが積み重なっていて、前段のバグが後段を隠していたため、修正のたびに次のバグが顔を出した。

| # | バグ | 症状 | 修正 |
|---|---|---|---|
| 1 | `Set-Content -NoNewline` に配列を渡すと区切り無しで結合される | XML 宣言と次の行が連結され `APPX1402 not well-formed XML` | `Get-Content -Raw` + `[IO.File]::WriteAllText` で元の改行を保持 |
| 2 | PowerShell `-replace` は大文字小文字を区別しない | `<?xml ... ?>` の `version="1.0"` まで `Version="0.3.0.99"` に書き換え | `-creplace` (大文字 `Version=` のみマッチ) |
| 3 | regex が `MinVersion=` / `MaxVersionTested=` の部分文字列にもマッチ | `<TargetDeviceFamily>` の OS 下限値がパッケージバージョンに上書きされる | `(?<=\s)` lookbehind で空白の後の `Version=` (= Identity 要素の Version) のみに限定 |

## 検証

ローカルで `Remove-Item packages -Recurse -Force` でクリーンチェックアウトを再現:
- patch 後の manifest: XML 宣言保持、`<Identity Version="0.3.0.99" />`、`<TargetDeviceFamily ... MinVersion="10.0.17763.0" MaxVersionTested="10.0.26226.0" />` 不変
- wapproj に対する msbuild フル実行 → MSIX 生成成功 (`GhosttyWin32 (Package)_0.3.0.99_x64.msix`)
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)