### PR TITLE
Enable strict PowerShell error handling in CI

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -38,6 +38,8 @@ jobs:
         id: version
         shell: pwsh
         run: |
+          $ErrorActionPreference = 'Stop'
+          $PSNativeCommandUseErrorActionPreference = $true
           # MSIX manifest Version is X.Y.Z.W (each part is UInt16, max 65535).
           # We use 0.3.0.<run_number> so each CI build is monotonically
           # increasing within a base version. Bump $base manually before
@@ -64,6 +66,8 @@ jobs:
       - name: Build ghostty.dll
         shell: pwsh
         run: |
+          $ErrorActionPreference = 'Stop'
+          $PSNativeCommandUseErrorActionPreference = $true
           cd ghostty
           zig build -Doptimize=ReleaseSafe -Drenderer=directx
           # upstream renamed the install artifact: zig-out/lib/ghostty.dll →
@@ -107,6 +111,8 @@ jobs:
       - name: Patch manifest version
         shell: pwsh
         run: |
+          $ErrorActionPreference = 'Stop'
+          $PSNativeCommandUseErrorActionPreference = $true
           # Read with -Raw so existing line endings are preserved verbatim
           # (the previous Get-Content + Set-Content -NoNewline approach
           # joined array elements with no separator, collapsing the XML
@@ -128,6 +134,8 @@ jobs:
           PFX_BASE64: ${{ secrets.SIGNING_PFX_BASE64 }}
           PFX_PASSWORD: ${{ secrets.SIGNING_PFX_PASSWORD }}
         run: |
+          $ErrorActionPreference = 'Stop'
+          $PSNativeCommandUseErrorActionPreference = $true
           if (-not $env:PFX_BASE64) {
             Write-Error "SIGNING_PFX_BASE64 secret is empty. See .github/RELEASING.md."
             exit 1
@@ -151,6 +159,8 @@ jobs:
         env:
           PFX_PASSWORD: ${{ secrets.SIGNING_PFX_PASSWORD }}
         run: |
+          $ErrorActionPreference = 'Stop'
+          $PSNativeCommandUseErrorActionPreference = $true
           $pfxPath = (Resolve-Path "ghostty-signing.pfx").Path
           msbuild "GhosttyWin32 (Package)/GhosttyWin32 (Package).wapproj" `
             /p:Configuration=Release `
@@ -174,6 +184,8 @@ jobs:
         id: locate
         shell: pwsh
         run: |
+          $ErrorActionPreference = 'Stop'
+          $PSNativeCommandUseErrorActionPreference = $true
           $msix = Get-ChildItem -Recurse -Filter "*.msix" -Path "GhosttyWin32 (Package)/AppPackages" |
                   Where-Object { $_.Name -notlike "*Microsoft.*" } |
                   Select-Object -First 1
@@ -194,15 +206,27 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release delete dev-build --yes --cleanup-tag 2>$null
-          $LASTEXITCODE = 0
-          Write-Host "Cleared any previous dev-build release."
+          # This step intentionally swallows errors: on the very first run
+          # there's no `dev-build` release to delete, so gh exits non-zero.
+          # We use try/catch (with strict preferences set) instead of the
+          # old `$LASTEXITCODE = 0` reset trick which is brittle once
+          # PSNativeCommandUseErrorActionPreference is on globally.
+          $ErrorActionPreference = 'Stop'
+          $PSNativeCommandUseErrorActionPreference = $true
+          try {
+            gh release delete dev-build --yes --cleanup-tag 2>$null
+            Write-Host "Deleted previous dev-build release."
+          } catch {
+            Write-Host "No previous dev-build release to delete (first run or already gone)."
+          }
 
       - name: Create dev-build release
         shell: pwsh
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          $ErrorActionPreference = 'Stop'
+          $PSNativeCommandUseErrorActionPreference = $true
           $shortSha = "${{ steps.version.outputs.short_sha }}"
           $now = Get-Date -Format 'yyyy-MM-dd HH:mm UTC'
           $repo = "${{ github.repository }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,10 @@ name: Release
 on:
   push:
     tags:
-      - 'v*'
+      # Restrict to v<digit>... so 'vfoo' or 'v-' tags don't trigger a
+      # release run. The tag-format validation in "Set MSIX version
+      # from tag" still rejects 2-part / 5-part / non-numeric variants.
+      - 'v[0-9]*'
 
 permissions:
   contents: write
@@ -93,6 +96,14 @@ jobs:
           # suffix because appxmanifest only accepts a four-part numeric.
           $tag = "${{ github.ref_name }}"
           $version = ($tag.TrimStart('v') -split '-')[0]
+          # Fail-fast on malformed tags. The MSIX manifest only accepts a
+          # 4-part numeric Version, so anything that doesn't reduce to
+          # exactly 3 numeric segments here would fail later in obscure
+          # ways. Reject up front with a clear message instead.
+          if ($version -notmatch '^\d+\.\d+\.\d+$') {
+            Write-Error "Tag '$tag' produced version '$version', which is not 3 numeric parts. Expected v<major>.<minor>.<patch> (optional -rcN / -beta suffix)."
+            exit 1
+          }
           $fullVersion = "$version.0"
           # Read with -Raw so existing line endings are preserved verbatim
           # (the previous Get-Content + Set-Content -NoNewline approach

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,8 @@ jobs:
       - name: Build ghostty.dll
         shell: pwsh
         run: |
+          $ErrorActionPreference = 'Stop'
+          $PSNativeCommandUseErrorActionPreference = $true
           cd ghostty
           zig build -Doptimize=ReleaseSafe -Drenderer=directx
           # GhosttyWin32App.vcxproj links against ../ghostty/ghostty.{dll,lib,h}
@@ -85,6 +87,8 @@ jobs:
       - name: Set MSIX version from tag
         shell: pwsh
         run: |
+          $ErrorActionPreference = 'Stop'
+          $PSNativeCommandUseErrorActionPreference = $true
           # Tag "vX.Y.Z" -> manifest Version "X.Y.Z.0". Strip any -rcN / -beta
           # suffix because appxmanifest only accepts a four-part numeric.
           $tag = "${{ github.ref_name }}"
@@ -115,6 +119,8 @@ jobs:
           PFX_BASE64: ${{ secrets.SIGNING_PFX_BASE64 }}
           PFX_PASSWORD: ${{ secrets.SIGNING_PFX_PASSWORD }}
         run: |
+          $ErrorActionPreference = 'Stop'
+          $PSNativeCommandUseErrorActionPreference = $true
           if (-not $env:PFX_BASE64) {
             Write-Error "SIGNING_PFX_BASE64 secret is empty. See .github/RELEASING.md."
             exit 1
@@ -140,6 +146,8 @@ jobs:
         env:
           PFX_PASSWORD: ${{ secrets.SIGNING_PFX_PASSWORD }}
         run: |
+          $ErrorActionPreference = 'Stop'
+          $PSNativeCommandUseErrorActionPreference = $true
           $pfxPath = (Resolve-Path "ghostty-signing.pfx").Path
           msbuild "GhosttyWin32 (Package)/GhosttyWin32 (Package).wapproj" `
             /p:Configuration=Release `
@@ -163,6 +171,8 @@ jobs:
         id: locate
         shell: pwsh
         run: |
+          $ErrorActionPreference = 'Stop'
+          $PSNativeCommandUseErrorActionPreference = $true
           $msix = Get-ChildItem -Recurse -Filter "*.msix" -Path "GhosttyWin32 (Package)/AppPackages" |
                   Where-Object { $_.Name -notlike "*Microsoft.*" } |
                   Select-Object -First 1


### PR DESCRIPTION
## Summary / 概要

Earlier CI failures were buried because PowerShell defaults to lenient error handling: non-terminating cmdlet errors continue, and native command non-zero exits don't terminate the script. The DLL rename incident was a clear example — `zig build` failed silently and we only saw a downstream `Copy-Item: not found`, hiding the real zig output for ~15 minutes of debugging. This PR adds three layered fail-fast measures.

<details><summary>日本語</summary>

これまでの CI 失敗のいくつかは PowerShell のデフォルト挙動 (non-terminating な cmdlet エラーは続行 / ネイティブコマンドの非ゼロ終了でも止まらない) に隠蔽されていた。DLL リネーム時の事例がわかりやすく、`zig build` の本当のエラーが下流の `Copy-Item: not found` に潰されて 15分くらい無駄になった。3層の fail-fast 防御を追加する。

</details>

## Changes / 変更

### 1. Strict PowerShell error preferences / 厳格な PowerShell エラー設定

Two preferences set at the top of every pwsh `run` block:

```powershell
$ErrorActionPreference = 'Stop'
$PSNativeCommandUseErrorActionPreference = $true
```

Cmdlet errors AND native-command non-zero exits both terminate the step at the actual point of failure.

<details><summary>日本語</summary>

各 pwsh `run` ブロック先頭に設定。cmdlet エラー / ネイティブ非ゼロ終了の両方で step が即停止。

</details>

### 2. Stricter tag trigger pattern / 厳しめのタグ trigger パターン

```diff
 on:
   push:
     tags:
-      - 'v*'
+      - 'v[0-9]*'
```

`v*` matched any tag starting with `v` (e.g. `vfoo`, `vbeta`). The new pattern requires `v` + at least one digit, so `v0.3.0`, `v20.0.1`, `v1` all match while typos and aspirational labels don't fire the workflow.

<details><summary>日本語</summary>

`v*` だと `vfoo` や `vbeta` も発火していた。`v[0-9]*` で「`v` + 1桁以上の数字 + 任意」に限定。`v0.3.0`, `v20.0.1`, `v1` 等は通り、typo タグは無視される。

</details>

### 3. Tag-format validator inside the version step / バージョン解析時のフォーマット検証

```powershell
if ($version -notmatch '^\d+\.\d+\.\d+$') {
  Write-Error "Tag '$tag' produced version '$version', which is not 3 numeric parts. Expected v<major>.<minor>.<patch> (optional -rcN / -beta suffix)."
  exit 1
}
```

Even after the trigger filter, malformed tags like `v0.3` (2 parts) or `v0.3.0.0` (4 parts) would surface obscure failures inside msbuild's manifest validation. Reject up front with a clear message.

<details><summary>日本語</summary>

trigger filter 通過後でも、`v0.3` (2部) や `v0.3.0.0` (4部) のような malformed タグは msbuild の manifest 検証で謎のエラーを出すことになる。事前に明確なメッセージで弾く。

</details>

## The one swallow site / 例外的にエラーを握り潰すステップ

`Delete previous dev-build release` legitimately needs to no-op on first run (nothing to delete → `gh` exits non-zero). The old `$LASTEXITCODE = 0` reset is brittle once strict preferences are global, so it gets a `try/catch` instead:

<details><summary>日本語</summary>

`Delete previous dev-build release` は初回 run で「リリース無し」エラーが正常な挙動。`$LASTEXITCODE = 0` リセットは strict 化後だと壊れるので `try/catch` に置き換え。

</details>

```powershell
try {
  gh release delete dev-build --yes --cleanup-tag 2>$null
  Write-Host "Deleted previous dev-build release."
} catch {
  Write-Host "No previous dev-build release to delete (first run or already gone)."
}
```

## Why not also touch Cleanup PFX / Cleanup PFX に手を入れない理由

That step uses `if: always()` + `-ErrorAction SilentlyContinue` because it must run even when an earlier step failed (and may run before the PFX file ever existed). Strict preferences would make the cleanup itself fail and mask the real upstream error in the run summary.

<details><summary>日本語</summary>

`if: always()` + `-ErrorAction SilentlyContinue` で、前段が失敗した場合 (PFX 作成前) も走る必要がある。strict 化すると cleanup 自体が失敗して、本来の上流エラーがログ上で埋もれる。

</details>

## Verification / 検証

- Locally: applied to a copy and reran the patch / build flow — both pass and produce the same outputs.
- CI: pending merge. Worst case if a previously-tolerated benign error now trips the strict mode, we'll see exactly which command failed (which is the goal).

<details><summary>日本語</summary>

- ローカル: コピーに適用して patch / build フローを再実行、同じ出力を生成
- CI: マージ後に確認。万一これまで許容されていた良性のエラーが strict 化で引っかかっても、エラー発生地点が明示されるのでデバッグしやすい (それが狙い)

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)