### PR TITLE
Close tab on shell exit (#8)

### DIFF
--- a/GhosttyWin32App/GhosttyWin32App.vcxproj
+++ b/GhosttyWin32App/GhosttyWin32App.vcxproj
@@ -131,6 +131,7 @@
       <DependentUpon>MainWindow.xaml</DependentUpon>
     </ClInclude>
     <ClInclude Include="Tab.h" />
+    <ClInclude Include="TabFactory.h" />
     <ClInclude Include="TabId.h" />
     <ClInclude Include="TabIdAllocator.h" />
   </ItemGroup>

--- a/GhosttyWin32App/GhosttyWin32App.vcxproj
+++ b/GhosttyWin32App/GhosttyWin32App.vcxproj
@@ -131,6 +131,7 @@
       <DependentUpon>MainWindow.xaml</DependentUpon>
     </ClInclude>
     <ClInclude Include="Tab.h" />
+    <ClInclude Include="TabId.h" />
   </ItemGroup>
   <ItemGroup>
     <ApplicationDefinition Include="App.xaml" />

--- a/GhosttyWin32App/GhosttyWin32App.vcxproj
+++ b/GhosttyWin32App/GhosttyWin32App.vcxproj
@@ -132,6 +132,7 @@
     </ClInclude>
     <ClInclude Include="Tab.h" />
     <ClInclude Include="TabId.h" />
+    <ClInclude Include="TabIdAllocator.h" />
   </ItemGroup>
   <ItemGroup>
     <ApplicationDefinition Include="App.xaml" />

--- a/GhosttyWin32App/MainWindow.xaml.cpp
+++ b/GhosttyWin32App/MainWindow.xaml.cpp
@@ -622,8 +622,36 @@ namespace winrt::GhosttyWin32::implementation
             HWND hwnd = g_mainWindow ? g_mainWindow->m_hwnd : nullptr;
             Clipboard::write(hwnd, Encoding::toUtf16(content[0].data));
         };
-        // TODO: ghostty doesn't call close_surface_cb on shell exit (see ghostty#34)
-        rtConfig.close_surface_cb = [](void*, bool) {};
+        // Shell exited (e.g. user typed `exit`). ghostty hands us back the
+        // Tab pointer slot we set in Tab::Create via cfg.userdata; we
+        // dispatch the actual TabView mutation to the next UI tick to
+        // mirror the GHOSTTY_ACTION_CLOSE_TAB handler — both end up
+        // doing the same teardown so they share the deferred shape.
+        rtConfig.close_surface_cb = [](void* userdata, bool /*process_alive*/) {
+            if (!g_mainWindow || !userdata) return;
+            auto* slot = static_cast<implementation::Tab**>(userdata);
+            auto* tabRaw = *slot;
+            if (!tabRaw) return; // Tab already torn down by the host
+            auto mw = g_mainWindow;
+            mw->DispatcherQueue().TryEnqueue([mw, tabRaw]() {
+                // Verify the Tab still exists — the user may have closed
+                // it via the UI between the callback firing and this
+                // dispatched lambda running.
+                auto* t = mw->m_tabs.FindByPointer(tabRaw);
+                if (!t) return;
+                auto item = t->Item();
+                auto tv = mw->TabView();
+                uint32_t idx = 0;
+                if (tv.TabItems().IndexOf(item, idx)) {
+                    tv.TabItems().RemoveAt(idx);
+                }
+                DwmFlush();
+                mw->m_tabs.Remove(item);
+                if (tv.TabItems().Size() == 0) {
+                    mw->Close();
+                }
+            });
+        };
 
         m_ghostty = GhosttyApp::Create(rtConfig);
     }

--- a/GhosttyWin32App/MainWindow.xaml.cpp
+++ b/GhosttyWin32App/MainWindow.xaml.cpp
@@ -628,7 +628,7 @@ namespace winrt::GhosttyWin32::implementation
         // next UI tick to mirror the GHOSTTY_ACTION_CLOSE_TAB handler.
         rtConfig.close_surface_cb = [](void* userdata, bool /*process_alive*/) {
             if (!g_mainWindow || !userdata) return;
-            uint64_t id = static_cast<uint64_t>(reinterpret_cast<uintptr_t>(userdata));
+            TabId id = TabId::FromUserdata(userdata);
             auto mw = g_mainWindow;
             mw->DispatcherQueue().TryEnqueue([mw, id]() {
                 auto* t = mw->m_tabs.FindById(id);

--- a/GhosttyWin32App/MainWindow.xaml.cpp
+++ b/GhosttyWin32App/MainWindow.xaml.cpp
@@ -717,15 +717,16 @@ namespace winrt::GhosttyWin32::implementation
             muxc::TabViewItem const* item;
             ghostty_app_t app;
             HWND hwnd;
+            TabIdAllocator* idAllocator;
             std::function<void()> onActivated;
             uint32_t initialWidth;
             uint32_t initialHeight;
             std::unique_ptr<Tab> result;
         };
-        CreateCtx ctx{ &panel, &item, app, hwnd, std::move(onActivated), initialW, initialH, nullptr };
+        CreateCtx ctx{ &panel, &item, app, hwnd, &m_tabIds, std::move(onActivated), initialW, initialH, nullptr };
         int ok = RunSEHGuarded([](void* arg) noexcept {
             auto* c = static_cast<CreateCtx*>(arg);
-            c->result = Tab::Create(*c->panel, *c->item, c->app, c->hwnd, std::move(c->onActivated), c->initialWidth, c->initialHeight);
+            c->result = Tab::Create(*c->panel, *c->item, c->app, c->hwnd, *c->idAllocator, std::move(c->onActivated), c->initialWidth, c->initialHeight);
         }, &ctx);
 
         std::unique_ptr<Tab> tab = std::move(ctx.result);

--- a/GhosttyWin32App/MainWindow.xaml.cpp
+++ b/GhosttyWin32App/MainWindow.xaml.cpp
@@ -624,8 +624,8 @@ namespace winrt::GhosttyWin32::implementation
         };
         // Shell exited (e.g. user typed `exit`), or ghostty asked to close
         // the surface for any other reason. The userdata is the Tab ID
-        // we set in Tab::Create. Dispatch the TabView mutation to the
-        // next UI tick to mirror the GHOSTTY_ACTION_CLOSE_TAB handler.
+        // we set in TabFactory::Make. Dispatch the TabView mutation to
+        // the next UI tick to mirror the GHOSTTY_ACTION_CLOSE_TAB handler.
         rtConfig.close_surface_cb = [](void* userdata, bool /*process_alive*/) {
             if (!g_mainWindow || !userdata) return;
             TabId id = TabId::FromUserdata(userdata);
@@ -648,6 +648,9 @@ namespace winrt::GhosttyWin32::implementation
         };
 
         m_ghostty = GhosttyApp::Create(rtConfig);
+        if (m_ghostty && m_hwnd) {
+            m_tabFactory = std::make_unique<TabFactory>(m_ghostty->Handle(), m_hwnd, m_tabIds);
+        }
     }
 
     void MainWindow::CreateTab()
@@ -706,32 +709,30 @@ namespace winrt::GhosttyWin32::implementation
             initialH = static_cast<uint32_t>(prevPanel.ActualHeight());
         }
 
-        // Wrap Tab::Create in SEH guard so a hardware exception in the
-        // NVIDIA driver during ghostty_surface_new (e.g. dx_create_texture
-        // crash) doesn't kill the whole app and take every other tab
-        // with it. The C++ work happens inside the callback below.
-        auto app = m_ghostty->Handle();
-        auto hwnd = m_hwnd;
+        // Wrap TabFactory::Make in SEH guard so a hardware exception in
+        // the NVIDIA driver during ghostty_surface_new (e.g.
+        // dx_create_texture crash) doesn't kill the whole app and take
+        // every other tab with it. The C++ work happens inside the
+        // callback below.
+        if (!m_tabFactory) return;
         struct CreateCtx {
             muxc::SwapChainPanel const* panel;
             muxc::TabViewItem const* item;
-            ghostty_app_t app;
-            HWND hwnd;
-            TabIdAllocator* idAllocator;
+            TabFactory* factory;
             std::function<void()> onActivated;
             uint32_t initialWidth;
             uint32_t initialHeight;
             std::unique_ptr<Tab> result;
         };
-        CreateCtx ctx{ &panel, &item, app, hwnd, &m_tabIds, std::move(onActivated), initialW, initialH, nullptr };
+        CreateCtx ctx{ &panel, &item, m_tabFactory.get(), std::move(onActivated), initialW, initialH, nullptr };
         int ok = RunSEHGuarded([](void* arg) noexcept {
             auto* c = static_cast<CreateCtx*>(arg);
-            c->result = Tab::Create(*c->panel, *c->item, c->app, c->hwnd, *c->idAllocator, std::move(c->onActivated), c->initialWidth, c->initialHeight);
+            c->result = c->factory->Make(*c->panel, *c->item, std::move(c->onActivated), c->initialWidth, c->initialHeight);
         }, &ctx);
 
         std::unique_ptr<Tab> tab = std::move(ctx.result);
         if (!ok) {
-            // SEH caught a hardware exception inside Tab::Create — almost
+            // SEH caught a hardware exception inside TabFactory::Make — almost
             // always the NVIDIA driver memcpy crash. Process state is
             // unreliable from here (heap locks may be stuck, driver kernel
             // state corrupted, etc.) so don't try to continue.
@@ -754,7 +755,7 @@ namespace winrt::GhosttyWin32::implementation
             return;
         }
         if (!tab) {
-            // Tab::Create returned null cleanly (handle / attach / surface
+            // TabFactory::Make returned null cleanly (handle / attach / surface
             // creation failed but no hardware exception). Heap state is
             // intact, so just drop the orphan tab item and continue.
             auto items = tv.TabItems();

--- a/GhosttyWin32App/MainWindow.xaml.cpp
+++ b/GhosttyWin32App/MainWindow.xaml.cpp
@@ -622,23 +622,17 @@ namespace winrt::GhosttyWin32::implementation
             HWND hwnd = g_mainWindow ? g_mainWindow->m_hwnd : nullptr;
             Clipboard::write(hwnd, Encoding::toUtf16(content[0].data));
         };
-        // Shell exited (e.g. user typed `exit`). ghostty hands us back the
-        // Tab pointer slot we set in Tab::Create via cfg.userdata; we
-        // dispatch the actual TabView mutation to the next UI tick to
-        // mirror the GHOSTTY_ACTION_CLOSE_TAB handler — both end up
-        // doing the same teardown so they share the deferred shape.
+        // Shell exited (e.g. user typed `exit`), or ghostty asked to close
+        // the surface for any other reason. The userdata is the Tab ID
+        // we set in Tab::Create. Dispatch the TabView mutation to the
+        // next UI tick to mirror the GHOSTTY_ACTION_CLOSE_TAB handler.
         rtConfig.close_surface_cb = [](void* userdata, bool /*process_alive*/) {
             if (!g_mainWindow || !userdata) return;
-            auto* slot = static_cast<implementation::Tab**>(userdata);
-            auto* tabRaw = *slot;
-            if (!tabRaw) return; // Tab already torn down by the host
+            uint64_t id = static_cast<uint64_t>(reinterpret_cast<uintptr_t>(userdata));
             auto mw = g_mainWindow;
-            mw->DispatcherQueue().TryEnqueue([mw, tabRaw]() {
-                // Verify the Tab still exists — the user may have closed
-                // it via the UI between the callback firing and this
-                // dispatched lambda running.
-                auto* t = mw->m_tabs.FindByPointer(tabRaw);
-                if (!t) return;
+            mw->DispatcherQueue().TryEnqueue([mw, id]() {
+                auto* t = mw->m_tabs.FindById(id);
+                if (!t) return; // Tab already closed via the UI
                 auto item = t->Item();
                 auto tv = mw->TabView();
                 uint32_t idx = 0;

--- a/GhosttyWin32App/MainWindow.xaml.h
+++ b/GhosttyWin32App/MainWindow.xaml.h
@@ -5,6 +5,7 @@
 #include "GhosttyApp.h"
 #include "ImeBuffer.h"
 #include "Tab.h"
+#include "TabFactory.h"
 #include "TabIdAllocator.h"
 #include "Tabs.h"
 
@@ -47,6 +48,9 @@ namespace winrt::GhosttyWin32::implementation
         ImeBuffer m_ime;
         TabIdAllocator m_tabIds;
         Tabs m_tabs;
+        // Constructed once ghostty is initialized — needs the app handle
+        // and HWND, neither available until InitGhostty has run.
+        std::unique_ptr<TabFactory> m_tabFactory;
     };
 }
 

--- a/GhosttyWin32App/MainWindow.xaml.h
+++ b/GhosttyWin32App/MainWindow.xaml.h
@@ -5,6 +5,7 @@
 #include "GhosttyApp.h"
 #include "ImeBuffer.h"
 #include "Tab.h"
+#include "TabIdAllocator.h"
 #include "Tabs.h"
 
 namespace winrt::GhosttyWin32::implementation
@@ -44,6 +45,7 @@ namespace winrt::GhosttyWin32::implementation
         HWND m_hwnd = nullptr;
         winrt::Windows::UI::Text::Core::CoreTextEditContext m_editContext{ nullptr };
         ImeBuffer m_ime;
+        TabIdAllocator m_tabIds;
         Tabs m_tabs;
     };
 }

--- a/GhosttyWin32App/Tab.h
+++ b/GhosttyWin32App/Tab.h
@@ -56,13 +56,7 @@ public:
                 native2->SetSwapChainHandle(nullptr);
             }
         }
-        // Disarm the close-surface slot before freeing the surface so any
-        // late close_surface_cb fired by ghostty during teardown becomes a
-        // no-op. The slot itself outlives the Tab by exactly one delete
-        // call below.
-        if (m_closeSlot) *m_closeSlot = nullptr;
         if (m_surface) ghostty_surface_free(m_surface);
-        delete m_closeSlot;
         if (m_surfaceHandle) CloseHandle(m_surfaceHandle);
     }
 
@@ -75,6 +69,18 @@ public:
     Microsoft::UI::Xaml::Controls::SwapChainPanel const& Panel() const noexcept { return m_panel; }
     Microsoft::UI::Xaml::Controls::TabViewItem const& Item() const noexcept { return m_item; }
     HANDLE SurfaceHandle() const noexcept { return m_surfaceHandle; }
+    uint64_t Id() const noexcept { return m_id; }
+
+    // Process-wide monotonically increasing identifier for the close-surface
+    // callback path. ghostty hands the value we put in cfg.userdata back
+    // through close_surface_cb, and we look it up via Tabs::FindById to
+    // resolve to the current Tab*. Using a value (instead of Tab*) means a
+    // stale callback from a freed Tab safely returns nullptr from FindById
+    // — no slot, no disarm, no dangling pointer.
+    static uint64_t AllocateId() {
+        static std::atomic<uint64_t> s_nextId{1};  // 0 reserved as sentinel
+        return s_nextId.fetch_add(1, std::memory_order_relaxed);
+    }
 
     void Focus() {
         m_panel.Focus(Microsoft::UI::Xaml::FocusState::Programmatic);
@@ -123,14 +129,12 @@ public:
         // through OnSwapChainReady (or be deleted here if surface_new fails).
         auto* attachOwned = new std::shared_ptr<SwapChainAttachRequest>(attach);
 
-        // Heap slot for the future Tab pointer. ghostty stores cfg.userdata
-        // verbatim and hands it back through close_surface_cb when the
-        // shell process exits; we populate ->Tab* once the Tab object
-        // exists, and the Tab clears + deletes the slot in its destructor.
-        // Indirection is required because surface_new returns the surface
-        // that the Tab owns, so the Tab can't exist before the cfg is
-        // submitted.
-        Tab** closeSlot = new Tab*{nullptr};
+        // ID for the close-surface callback path. Generated before
+        // surface_new because cfg.userdata must be set up-front; the value
+        // is opaque to ghostty and travels back to us through
+        // close_surface_cb. uintptr_t hop keeps the cast portable on
+        // 32-bit (we're 64-bit Windows so it's identity).
+        uint64_t id = Tab::AllocateId();
 
         ghostty_surface_config_s cfg = ghostty_surface_config_new();
         cfg.platform_tag = GHOSTTY_PLATFORM_WINDOWS;
@@ -138,7 +142,7 @@ public:
         cfg.platform.windows.composition_surface_handle = handle;
         cfg.platform.windows.swap_chain_ready_cb = &OnSwapChainReady;
         cfg.platform.windows.swap_chain_ready_userdata = attachOwned;
-        cfg.userdata = closeSlot;
+        cfg.userdata = reinterpret_cast<void*>(static_cast<uintptr_t>(id));
         // Initial swap chain size: prefer the host's caller-supplied estimate
         // (typically the active tab's panel size, since the new panel will
         // land in the same TabView content area), then fall back to the
@@ -163,23 +167,19 @@ public:
             OutputDebugStringA("Tab::Create: ghostty_surface_new FAILED\n");
             // Callback won't fire — release the renderer's owning handle.
             delete attachOwned;
-            delete closeSlot;
             CloseHandle(handle);
             return nullptr;
         }
 
         try {
             // Private constructor — std::make_unique can't see it, so use new.
-            auto t = std::unique_ptr<Tab>(new Tab(std::move(panel), std::move(item), handle, surface, std::move(attach), closeSlot));
-            *closeSlot = t.get();
-            return t;
+            return std::unique_ptr<Tab>(new Tab(std::move(panel), std::move(item), handle, surface, std::move(attach), id));
         } catch (winrt::hresult_error const&) {
             // Tab construction failed but the renderer thread may already
             // have fired (or be about to fire) OnSwapChainReady. Cancel
             // first, then tear down what we have.
             attach->cancelled.store(true);
             ghostty_surface_free(surface);
-            delete closeSlot;
             CloseHandle(handle);
             return nullptr;
         }
@@ -194,13 +194,13 @@ private:
         HANDLE surfaceHandle,
         ghostty_surface_t surface,
         std::shared_ptr<SwapChainAttachRequest> attachRequest,
-        Tab** closeSlot)
+        uint64_t id)
         : m_panel(std::move(panel))
         , m_item(std::move(item))
         , m_surfaceHandle(surfaceHandle)
         , m_surface(surface)
         , m_attachRequest(std::move(attachRequest))
-        , m_closeSlot(closeSlot)
+        , m_id(id)
     {
         if (!m_panel || !m_item || !m_surfaceHandle || !m_surface) {
             throw winrt::hresult_error(E_INVALIDARG, L"Tab: missing resource");
@@ -250,10 +250,7 @@ private:
     ghostty_surface_t m_surface{ nullptr };
     winrt::event_token m_sizeChangedToken{};
     std::shared_ptr<SwapChainAttachRequest> m_attachRequest;
-    // Heap slot referenced by ghostty's cfg.userdata. Stays alive across
-    // the close_surface_cb dispatch and is freed in ~Tab after the surface
-    // is freed and any in-flight callback has had a chance to fire.
-    Tab** m_closeSlot{ nullptr };
+    uint64_t m_id{ 0 };
 };
 
 }  // namespace winrt::GhosttyWin32::implementation

--- a/GhosttyWin32App/Tab.h
+++ b/GhosttyWin32App/Tab.h
@@ -56,7 +56,13 @@ public:
                 native2->SetSwapChainHandle(nullptr);
             }
         }
+        // Disarm the close-surface slot before freeing the surface so any
+        // late close_surface_cb fired by ghostty during teardown becomes a
+        // no-op. The slot itself outlives the Tab by exactly one delete
+        // call below.
+        if (m_closeSlot) *m_closeSlot = nullptr;
         if (m_surface) ghostty_surface_free(m_surface);
+        delete m_closeSlot;
         if (m_surfaceHandle) CloseHandle(m_surfaceHandle);
     }
 
@@ -117,12 +123,22 @@ public:
         // through OnSwapChainReady (or be deleted here if surface_new fails).
         auto* attachOwned = new std::shared_ptr<SwapChainAttachRequest>(attach);
 
+        // Heap slot for the future Tab pointer. ghostty stores cfg.userdata
+        // verbatim and hands it back through close_surface_cb when the
+        // shell process exits; we populate ->Tab* once the Tab object
+        // exists, and the Tab clears + deletes the slot in its destructor.
+        // Indirection is required because surface_new returns the surface
+        // that the Tab owns, so the Tab can't exist before the cfg is
+        // submitted.
+        Tab** closeSlot = new Tab*{nullptr};
+
         ghostty_surface_config_s cfg = ghostty_surface_config_new();
         cfg.platform_tag = GHOSTTY_PLATFORM_WINDOWS;
         cfg.platform.windows.hwnd = hwnd;
         cfg.platform.windows.composition_surface_handle = handle;
         cfg.platform.windows.swap_chain_ready_cb = &OnSwapChainReady;
         cfg.platform.windows.swap_chain_ready_userdata = attachOwned;
+        cfg.userdata = closeSlot;
         // Initial swap chain size: prefer the host's caller-supplied estimate
         // (typically the active tab's panel size, since the new panel will
         // land in the same TabView content area), then fall back to the
@@ -147,19 +163,23 @@ public:
             OutputDebugStringA("Tab::Create: ghostty_surface_new FAILED\n");
             // Callback won't fire — release the renderer's owning handle.
             delete attachOwned;
+            delete closeSlot;
             CloseHandle(handle);
             return nullptr;
         }
 
         try {
             // Private constructor — std::make_unique can't see it, so use new.
-            return std::unique_ptr<Tab>(new Tab(std::move(panel), std::move(item), handle, surface, std::move(attach)));
+            auto t = std::unique_ptr<Tab>(new Tab(std::move(panel), std::move(item), handle, surface, std::move(attach), closeSlot));
+            *closeSlot = t.get();
+            return t;
         } catch (winrt::hresult_error const&) {
             // Tab construction failed but the renderer thread may already
             // have fired (or be about to fire) OnSwapChainReady. Cancel
             // first, then tear down what we have.
             attach->cancelled.store(true);
             ghostty_surface_free(surface);
+            delete closeSlot;
             CloseHandle(handle);
             return nullptr;
         }
@@ -173,12 +193,14 @@ private:
         Microsoft::UI::Xaml::Controls::TabViewItem item,
         HANDLE surfaceHandle,
         ghostty_surface_t surface,
-        std::shared_ptr<SwapChainAttachRequest> attachRequest)
+        std::shared_ptr<SwapChainAttachRequest> attachRequest,
+        Tab** closeSlot)
         : m_panel(std::move(panel))
         , m_item(std::move(item))
         , m_surfaceHandle(surfaceHandle)
         , m_surface(surface)
         , m_attachRequest(std::move(attachRequest))
+        , m_closeSlot(closeSlot)
     {
         if (!m_panel || !m_item || !m_surfaceHandle || !m_surface) {
             throw winrt::hresult_error(E_INVALIDARG, L"Tab: missing resource");
@@ -228,6 +250,10 @@ private:
     ghostty_surface_t m_surface{ nullptr };
     winrt::event_token m_sizeChangedToken{};
     std::shared_ptr<SwapChainAttachRequest> m_attachRequest;
+    // Heap slot referenced by ghostty's cfg.userdata. Stays alive across
+    // the close_surface_cb dispatch and is freed in ~Tab after the surface
+    // is freed and any in-flight callback has had a chance to fire.
+    Tab** m_closeSlot{ nullptr };
 };
 
 }  // namespace winrt::GhosttyWin32::implementation

--- a/GhosttyWin32App/Tab.h
+++ b/GhosttyWin32App/Tab.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "ghostty.h"
+#include "TabId.h"
 #include <microsoft.ui.xaml.media.dxinterop.h>
 #include <dcomp.h>
 #include <winrt/Microsoft.UI.Xaml.h>
@@ -69,7 +70,7 @@ public:
     Microsoft::UI::Xaml::Controls::SwapChainPanel const& Panel() const noexcept { return m_panel; }
     Microsoft::UI::Xaml::Controls::TabViewItem const& Item() const noexcept { return m_item; }
     HANDLE SurfaceHandle() const noexcept { return m_surfaceHandle; }
-    uint64_t Id() const noexcept { return m_id; }
+    TabId Id() const noexcept { return m_id; }
 
     // Process-wide monotonically increasing identifier for the close-surface
     // callback path. ghostty hands the value we put in cfg.userdata back
@@ -77,9 +78,9 @@ public:
     // resolve to the current Tab*. Using a value (instead of Tab*) means a
     // stale callback from a freed Tab safely returns nullptr from FindById
     // — no slot, no disarm, no dangling pointer.
-    static uint64_t AllocateId() {
+    static TabId AllocateId() {
         static std::atomic<uint64_t> s_nextId{1};  // 0 reserved as sentinel
-        return s_nextId.fetch_add(1, std::memory_order_relaxed);
+        return TabId{ s_nextId.fetch_add(1, std::memory_order_relaxed) };
     }
 
     void Focus() {
@@ -132,9 +133,8 @@ public:
         // ID for the close-surface callback path. Generated before
         // surface_new because cfg.userdata must be set up-front; the value
         // is opaque to ghostty and travels back to us through
-        // close_surface_cb. uintptr_t hop keeps the cast portable on
-        // 32-bit (we're 64-bit Windows so it's identity).
-        uint64_t id = Tab::AllocateId();
+        // close_surface_cb.
+        TabId id = Tab::AllocateId();
 
         ghostty_surface_config_s cfg = ghostty_surface_config_new();
         cfg.platform_tag = GHOSTTY_PLATFORM_WINDOWS;
@@ -142,7 +142,7 @@ public:
         cfg.platform.windows.composition_surface_handle = handle;
         cfg.platform.windows.swap_chain_ready_cb = &OnSwapChainReady;
         cfg.platform.windows.swap_chain_ready_userdata = attachOwned;
-        cfg.userdata = reinterpret_cast<void*>(static_cast<uintptr_t>(id));
+        cfg.userdata = id.ToUserdata();
         // Initial swap chain size: prefer the host's caller-supplied estimate
         // (typically the active tab's panel size, since the new panel will
         // land in the same TabView content area), then fall back to the
@@ -194,7 +194,7 @@ private:
         HANDLE surfaceHandle,
         ghostty_surface_t surface,
         std::shared_ptr<SwapChainAttachRequest> attachRequest,
-        uint64_t id)
+        TabId id)
         : m_panel(std::move(panel))
         , m_item(std::move(item))
         , m_surfaceHandle(surfaceHandle)
@@ -250,7 +250,7 @@ private:
     ghostty_surface_t m_surface{ nullptr };
     winrt::event_token m_sizeChangedToken{};
     std::shared_ptr<SwapChainAttachRequest> m_attachRequest;
-    uint64_t m_id{ 0 };
+    TabId m_id{};
 };
 
 }  // namespace winrt::GhosttyWin32::implementation

--- a/GhosttyWin32App/Tab.h
+++ b/GhosttyWin32App/Tab.h
@@ -2,6 +2,7 @@
 
 #include "ghostty.h"
 #include "TabId.h"
+#include "TabIdAllocator.h"
 #include <microsoft.ui.xaml.media.dxinterop.h>
 #include <dcomp.h>
 #include <winrt/Microsoft.UI.Xaml.h>
@@ -72,17 +73,6 @@ public:
     HANDLE SurfaceHandle() const noexcept { return m_surfaceHandle; }
     TabId Id() const noexcept { return m_id; }
 
-    // Process-wide monotonically increasing identifier for the close-surface
-    // callback path. ghostty hands the value we put in cfg.userdata back
-    // through close_surface_cb, and we look it up via Tabs::FindById to
-    // resolve to the current Tab*. Using a value (instead of Tab*) means a
-    // stale callback from a freed Tab safely returns nullptr from FindById
-    // — no slot, no disarm, no dangling pointer.
-    static TabId AllocateId() {
-        static std::atomic<uint64_t> s_nextId{1};  // 0 reserved as sentinel
-        return TabId{ s_nextId.fetch_add(1, std::memory_order_relaxed) };
-    }
-
     void Focus() {
         m_panel.Focus(Microsoft::UI::Xaml::FocusState::Programmatic);
     }
@@ -109,6 +99,7 @@ public:
         Microsoft::UI::Xaml::Controls::TabViewItem item,
         ghostty_app_t app,
         HWND hwnd,
+        TabIdAllocator& idAllocator,
         std::function<void()> onActivated = {},
         uint32_t initialWidth = 0,
         uint32_t initialHeight = 0)
@@ -130,11 +121,11 @@ public:
         // through OnSwapChainReady (or be deleted here if surface_new fails).
         auto* attachOwned = new std::shared_ptr<SwapChainAttachRequest>(attach);
 
-        // ID for the close-surface callback path. Generated before
+        // ID for the close-surface callback path. Allocated before
         // surface_new because cfg.userdata must be set up-front; the value
         // is opaque to ghostty and travels back to us through
         // close_surface_cb.
-        TabId id = Tab::AllocateId();
+        TabId id = idAllocator.Allocate();
 
         ghostty_surface_config_s cfg = ghostty_surface_config_new();
         cfg.platform_tag = GHOSTTY_PLATFORM_WINDOWS;

--- a/GhosttyWin32App/Tab.h
+++ b/GhosttyWin32App/Tab.h
@@ -2,9 +2,7 @@
 
 #include "ghostty.h"
 #include "TabId.h"
-#include "TabIdAllocator.h"
 #include <microsoft.ui.xaml.media.dxinterop.h>
-#include <dcomp.h>
 #include <winrt/Microsoft.UI.Xaml.h>
 #include <winrt/Microsoft.UI.Xaml.Controls.h>
 #include <winrt/Microsoft.UI.Dispatching.h>
@@ -12,16 +10,15 @@
 #include <functional>
 #include <memory>
 
-#pragma comment(lib, "dcomp.lib")
-
 namespace winrt::GhosttyWin32::implementation {
 
 // Pending UI-thread "attach this swap chain handle to the panel" request.
-// Created on the UI thread inside Tab::Create, kept alive by both the Tab
-// (so it can cancel on teardown) and the renderer-thread callback (so it
-// survives the cross-thread hop). The cancelled flag is the lifetime
-// interlock: ~Tab sets it before the swap chain is destroyed; the queued
-// SetSwapChainHandle bails on it before touching the (now dead) handle.
+// Created on the UI thread inside TabFactory::Make, kept alive by both
+// the Tab (so it can cancel on teardown) and the renderer-thread
+// callback (so it survives the cross-thread hop). The cancelled flag is
+// the lifetime interlock: ~Tab sets it before the swap chain is
+// destroyed; the queued SetSwapChainHandle bails on it before touching
+// the (now dead) handle.
 struct SwapChainAttachRequest {
     HANDLE handle{ nullptr };
     Microsoft::UI::Xaml::Controls::SwapChainPanel panel{ nullptr };
@@ -38,12 +35,45 @@ struct SwapChainAttachRequest {
 // One terminal tab. Existence implies fully-formed: panel attached to a
 // composition surface, ghostty surface created, SizeChanged hooked.
 //
-// Construction is just validation + member init — all failable work (creating
-// the surface handle, attaching it, calling ghostty_surface_new) lives in
-// the free factory `CreateTab` below. If you have a `Tab*`, you can operate
-// on it freely without worrying about half-built state.
+// Construction is just validation + member init — all failable work
+// (creating the surface handle, attaching it, calling ghostty_surface_new)
+// lives in TabFactory::Make. If you have a Tab*, you can operate on it
+// freely without worrying about half-built state.
 class Tab {
 public:
+    // Called by TabFactory::Make once all resources are acquired. Public
+    // so std::make_unique can see it; the constructor still validates
+    // its inputs and throws on missing resources, so callers outside the
+    // factory will get a loud failure rather than a silent half-built
+    // Tab.
+    Tab(Microsoft::UI::Xaml::Controls::SwapChainPanel panel,
+        Microsoft::UI::Xaml::Controls::TabViewItem item,
+        HANDLE surfaceHandle,
+        ghostty_surface_t surface,
+        std::shared_ptr<SwapChainAttachRequest> attachRequest,
+        TabId id)
+        : m_panel(std::move(panel))
+        , m_item(std::move(item))
+        , m_surfaceHandle(surfaceHandle)
+        , m_surface(surface)
+        , m_attachRequest(std::move(attachRequest))
+        , m_id(id)
+    {
+        if (!m_panel || !m_item || !m_surfaceHandle || !m_surface) {
+            throw winrt::hresult_error(E_INVALIDARG, L"Tab: missing resource");
+        }
+        ghostty_surface_t s = m_surface;
+        m_sizeChangedToken = m_panel.SizeChanged(
+            [s](auto&&, Microsoft::UI::Xaml::SizeChangedEventArgs const& args) {
+                auto sz = args.NewSize();
+                uint32_t w = static_cast<uint32_t>(sz.Width);
+                uint32_t h = static_cast<uint32_t>(sz.Height);
+                if (w > 0 && h > 0) {
+                    ghostty_surface_set_size(s, w, h);
+                }
+            });
+    }
+
     ~Tab() {
         // Cancel the pending SetSwapChainHandle dispatch before we tear
         // down the swap chain — otherwise the queued call could attach a
@@ -77,140 +107,11 @@ public:
         m_panel.Focus(Microsoft::UI::Xaml::FocusState::Programmatic);
     }
 
-    // Factory: given a panel + item, do the failable orchestration (handle
-    // creation, ghostty surface creation, swap-chain attach scheduling) and
-    // return a fully-formed Tab. Returns nullptr on failure (after cleaning
-    // up any partially-acquired resources). Call on the UI thread; the panel
-    // does NOT need to be in the visual tree yet — that's the whole point of
-    // issue #22, where making the panel visible before it had displayable
-    // content produced a flicker. The optional onActivated callback runs on
-    // the UI thread once ghostty has presented its first frame and we've
-    // bound the swap chain to the panel; the host uses it to switch the
-    // TabView so the panel becomes visible only with real content.
-    //
-    // Ordering: the DComp surface handle is bound to the panel only AFTER
-    // ghostty's renderer thread has presented at least one real frame —
-    // see OnSwapChainReady. ghostty fires the swap-chain-ready callback
-    // from drawFrameEnd (post first present), not from swap-chain creation,
-    // so the back buffer is guaranteed to have displayable content by the
-    // time we attach.
-    static std::unique_ptr<Tab> Create(
-        Microsoft::UI::Xaml::Controls::SwapChainPanel panel,
-        Microsoft::UI::Xaml::Controls::TabViewItem item,
-        ghostty_app_t app,
-        HWND hwnd,
-        TabIdAllocator& idAllocator,
-        std::function<void()> onActivated = {},
-        uint32_t initialWidth = 0,
-        uint32_t initialHeight = 0)
-    {
-        constexpr DWORD COMPOSITIONSURFACE_ALL_ACCESS = 0x0003L;
-
-        HANDLE handle = nullptr;
-        if (FAILED(DCompositionCreateSurfaceHandle(COMPOSITIONSURFACE_ALL_ACCESS, nullptr, &handle))) {
-            OutputDebugStringA("Tab::Create: DCompositionCreateSurfaceHandle FAILED\n");
-            return nullptr;
-        }
-
-        auto attach = std::make_shared<SwapChainAttachRequest>();
-        attach->handle = handle;
-        attach->panel = panel;
-        attach->dispatcher = panel.DispatcherQueue();
-        attach->onActivated = std::move(onActivated);
-        // Heap-allocated owning shared_ptr handed to ghostty; it'll come back
-        // through OnSwapChainReady (or be deleted here if surface_new fails).
-        auto* attachOwned = new std::shared_ptr<SwapChainAttachRequest>(attach);
-
-        // ID for the close-surface callback path. Allocated before
-        // surface_new because cfg.userdata must be set up-front; the value
-        // is opaque to ghostty and travels back to us through
-        // close_surface_cb.
-        TabId id = idAllocator.Allocate();
-
-        ghostty_surface_config_s cfg = ghostty_surface_config_new();
-        cfg.platform_tag = GHOSTTY_PLATFORM_WINDOWS;
-        cfg.platform.windows.hwnd = hwnd;
-        cfg.platform.windows.composition_surface_handle = handle;
-        cfg.platform.windows.swap_chain_ready_cb = &OnSwapChainReady;
-        cfg.platform.windows.swap_chain_ready_userdata = attachOwned;
-        cfg.userdata = id.ToUserdata();
-        // Initial swap chain size: prefer the host's caller-supplied estimate
-        // (typically the active tab's panel size, since the new panel will
-        // land in the same TabView content area), then fall back to the
-        // panel's own ActualWidth/Height. With deferred SelectedItem (issue
-        // #22) the panel isn't in the visual tree yet so its ActualWidth is
-        // 0 — without the host hint, ghostty would fall back further to the
-        // main window's full client rect, which is taller than the actual
-        // panel area by the tab strip height. That mismatch causes a
-        // visible "stretch then resize" when the panel becomes visible
-        // and SizeChanged fires.
-        uint32_t initW = initialWidth ? initialWidth
-                                      : static_cast<uint32_t>(panel.ActualWidth());
-        uint32_t initH = initialHeight ? initialHeight
-                                       : static_cast<uint32_t>(panel.ActualHeight());
-        cfg.platform.windows.initial_width = initW;
-        cfg.platform.windows.initial_height = initH;
-        UINT dpi = GetDpiForWindow(hwnd);
-        cfg.scale_factor = static_cast<double>(dpi) / 96.0;
-
-        ghostty_surface_t surface = ghostty_surface_new(app, &cfg);
-        if (!surface) {
-            OutputDebugStringA("Tab::Create: ghostty_surface_new FAILED\n");
-            // Callback won't fire — release the renderer's owning handle.
-            delete attachOwned;
-            CloseHandle(handle);
-            return nullptr;
-        }
-
-        try {
-            // Private constructor — std::make_unique can't see it, so use new.
-            return std::unique_ptr<Tab>(new Tab(std::move(panel), std::move(item), handle, surface, std::move(attach), id));
-        } catch (winrt::hresult_error const&) {
-            // Tab construction failed but the renderer thread may already
-            // have fired (or be about to fire) OnSwapChainReady. Cancel
-            // first, then tear down what we have.
-            attach->cancelled.store(true);
-            ghostty_surface_free(surface);
-            CloseHandle(handle);
-            return nullptr;
-        }
-    }
-
-private:
-    // Private — only Tab::Create can construct. Validates that all resources
-    // are present (Create has already checked, so this is a defense-in-depth
-    // assertion against future callers inside the class).
-    Tab(Microsoft::UI::Xaml::Controls::SwapChainPanel panel,
-        Microsoft::UI::Xaml::Controls::TabViewItem item,
-        HANDLE surfaceHandle,
-        ghostty_surface_t surface,
-        std::shared_ptr<SwapChainAttachRequest> attachRequest,
-        TabId id)
-        : m_panel(std::move(panel))
-        , m_item(std::move(item))
-        , m_surfaceHandle(surfaceHandle)
-        , m_surface(surface)
-        , m_attachRequest(std::move(attachRequest))
-        , m_id(id)
-    {
-        if (!m_panel || !m_item || !m_surfaceHandle || !m_surface) {
-            throw winrt::hresult_error(E_INVALIDARG, L"Tab: missing resource");
-        }
-        ghostty_surface_t s = m_surface;
-        m_sizeChangedToken = m_panel.SizeChanged(
-            [s](auto&&, Microsoft::UI::Xaml::SizeChangedEventArgs const& args) {
-                auto sz = args.NewSize();
-                uint32_t w = static_cast<uint32_t>(sz.Width);
-                uint32_t h = static_cast<uint32_t>(sz.Height);
-                if (w > 0 && h > 0) {
-                    ghostty_surface_set_size(s, w, h);
-                }
-            });
-    }
-
     // Renderer-thread callback from ghostty: the swap chain is now bound to
     // our surface handle, so it's safe to call SetSwapChainHandle. We only
     // hop to the UI thread and queue the actual API call — keep this fast.
+    // Public so TabFactory::Make can register it as cfg.swap_chain_ready_cb;
+    // ghostty calls it directly without going through any Tab instance.
     static void OnSwapChainReady(void* userdata) noexcept {
         auto* raw = reinterpret_cast<std::shared_ptr<SwapChainAttachRequest>*>(userdata);
         std::shared_ptr<SwapChainAttachRequest> req = *raw;
@@ -235,6 +136,7 @@ private:
         }
     }
 
+private:
     Microsoft::UI::Xaml::Controls::SwapChainPanel m_panel{ nullptr };
     Microsoft::UI::Xaml::Controls::TabViewItem m_item{ nullptr };
     HANDLE m_surfaceHandle{ nullptr };

--- a/GhosttyWin32App/TabFactory.h
+++ b/GhosttyWin32App/TabFactory.h
@@ -1,0 +1,135 @@
+#pragma once
+
+#include "Tab.h"
+#include "TabId.h"
+#include "TabIdAllocator.h"
+#include "ghostty.h"
+#include <microsoft.ui.xaml.media.dxinterop.h>
+#include <dcomp.h>
+#include <winrt/Microsoft.UI.Xaml.h>
+#include <winrt/Microsoft.UI.Xaml.Controls.h>
+#include <functional>
+#include <memory>
+
+#pragma comment(lib, "dcomp.lib")
+
+namespace winrt::GhosttyWin32::implementation {
+
+// Builds Tabs. Holds the cross-cutting context (ghostty app handle, the
+// HWND for DPI/initial-size, and the TabIdAllocator that produces fresh
+// IDs) so callers don't have to thread those through every Make() call.
+//
+// Stateless beyond the injected references — no mutable state of its
+// own. ID counter mutation lives in TabIdAllocator; the factory only
+// borrows it.
+class TabFactory {
+public:
+    TabFactory(ghostty_app_t app, HWND hwnd, TabIdAllocator& idAllocator) noexcept
+        : m_app(app), m_hwnd(hwnd), m_idAllocator(idAllocator) {}
+
+    TabFactory(const TabFactory&) = delete;
+    TabFactory& operator=(const TabFactory&) = delete;
+    TabFactory(TabFactory&&) = delete;
+    TabFactory& operator=(TabFactory&&) = delete;
+
+    // Build a fully-formed Tab from a panel + item. Returns nullptr on
+    // failure (after cleaning up any partially-acquired resources). Call
+    // on the UI thread; the panel does NOT need to be in the visual tree
+    // yet — see issue #22, where making the panel visible before it had
+    // displayable content produced a flicker. The optional onActivated
+    // callback runs on the UI thread once ghostty has presented its
+    // first frame and we've bound the swap chain to the panel; the host
+    // uses it to switch the TabView so the panel becomes visible only
+    // with real content.
+    //
+    // Ordering: the DComp surface handle is bound to the panel only AFTER
+    // ghostty's renderer thread has presented at least one real frame —
+    // see Tab::OnSwapChainReady. ghostty fires the swap-chain-ready
+    // callback from drawFrameEnd (post first present), not from swap-chain
+    // creation, so the back buffer is guaranteed to have displayable
+    // content by the time we attach.
+    std::unique_ptr<Tab> Make(
+        Microsoft::UI::Xaml::Controls::SwapChainPanel panel,
+        Microsoft::UI::Xaml::Controls::TabViewItem item,
+        std::function<void()> onActivated = {},
+        uint32_t initialWidth = 0,
+        uint32_t initialHeight = 0)
+    {
+        constexpr DWORD COMPOSITIONSURFACE_ALL_ACCESS = 0x0003L;
+
+        HANDLE handle = nullptr;
+        if (FAILED(DCompositionCreateSurfaceHandle(COMPOSITIONSURFACE_ALL_ACCESS, nullptr, &handle))) {
+            OutputDebugStringA("TabFactory::Make: DCompositionCreateSurfaceHandle FAILED\n");
+            return nullptr;
+        }
+
+        auto attach = std::make_shared<SwapChainAttachRequest>();
+        attach->handle = handle;
+        attach->panel = panel;
+        attach->dispatcher = panel.DispatcherQueue();
+        attach->onActivated = std::move(onActivated);
+        // Heap-allocated owning shared_ptr handed to ghostty; it'll come back
+        // through OnSwapChainReady (or be deleted here if surface_new fails).
+        auto* attachOwned = new std::shared_ptr<SwapChainAttachRequest>(attach);
+
+        // ID for the close-surface callback path. Allocated before
+        // surface_new because cfg.userdata must be set up-front; the value
+        // is opaque to ghostty and travels back to us through
+        // close_surface_cb.
+        TabId id = m_idAllocator.Allocate();
+
+        ghostty_surface_config_s cfg = ghostty_surface_config_new();
+        cfg.platform_tag = GHOSTTY_PLATFORM_WINDOWS;
+        cfg.platform.windows.hwnd = m_hwnd;
+        cfg.platform.windows.composition_surface_handle = handle;
+        cfg.platform.windows.swap_chain_ready_cb = &Tab::OnSwapChainReady;
+        cfg.platform.windows.swap_chain_ready_userdata = attachOwned;
+        cfg.userdata = id.ToUserdata();
+        // Initial swap chain size: prefer the host's caller-supplied estimate
+        // (typically the active tab's panel size, since the new panel will
+        // land in the same TabView content area), then fall back to the
+        // panel's own ActualWidth/Height. With deferred SelectedItem (issue
+        // #22) the panel isn't in the visual tree yet so its ActualWidth is
+        // 0 — without the host hint, ghostty would fall back further to the
+        // main window's full client rect, which is taller than the actual
+        // panel area by the tab strip height. That mismatch causes a
+        // visible "stretch then resize" when the panel becomes visible
+        // and SizeChanged fires.
+        uint32_t initW = initialWidth ? initialWidth
+                                      : static_cast<uint32_t>(panel.ActualWidth());
+        uint32_t initH = initialHeight ? initialHeight
+                                       : static_cast<uint32_t>(panel.ActualHeight());
+        cfg.platform.windows.initial_width = initW;
+        cfg.platform.windows.initial_height = initH;
+        UINT dpi = GetDpiForWindow(m_hwnd);
+        cfg.scale_factor = static_cast<double>(dpi) / 96.0;
+
+        ghostty_surface_t surface = ghostty_surface_new(m_app, &cfg);
+        if (!surface) {
+            OutputDebugStringA("TabFactory::Make: ghostty_surface_new FAILED\n");
+            // Callback won't fire — release the renderer's owning handle.
+            delete attachOwned;
+            CloseHandle(handle);
+            return nullptr;
+        }
+
+        try {
+            return std::make_unique<Tab>(std::move(panel), std::move(item), handle, surface, std::move(attach), id);
+        } catch (winrt::hresult_error const&) {
+            // Tab construction failed but the renderer thread may already
+            // have fired (or be about to fire) OnSwapChainReady. Cancel
+            // first, then tear down what we have.
+            attach->cancelled.store(true);
+            ghostty_surface_free(surface);
+            CloseHandle(handle);
+            return nullptr;
+        }
+    }
+
+private:
+    ghostty_app_t m_app;
+    HWND m_hwnd;
+    TabIdAllocator& m_idAllocator;
+};
+
+}  // namespace winrt::GhosttyWin32::implementation

--- a/GhosttyWin32App/TabId.h
+++ b/GhosttyWin32App/TabId.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <cstdint>
+
+namespace winrt::GhosttyWin32::implementation {
+
+// Strongly-typed tab identifier. Wraps a uint64_t so that
+//   - random uint64_t values (DPI, sizes, counts) can't be mistakenly
+//     passed as a TabId
+//   - the void* boundary with ghostty's cfg.userdata is centralized in
+//     ToUserdata / FromUserdata, instead of bare reinterpret_casts
+//     scattered through the host
+//
+// Value 0 is reserved as a sentinel meaning "no ID" (default-constructed
+// TabId converts to false).
+struct TabId {
+    uint64_t value{ 0 };
+
+    constexpr bool operator==(TabId const&) const noexcept = default;
+    explicit constexpr operator bool() const noexcept { return value != 0; }
+
+    // void* boundary helpers. cfg.userdata is opaque to ghostty — it
+    // hands the same bits back through close_surface_cb. uintptr_t hop
+    // is the portable cast path between integer and pointer.
+    void* ToUserdata() const noexcept {
+        return reinterpret_cast<void*>(static_cast<uintptr_t>(value));
+    }
+    static TabId FromUserdata(void* p) noexcept {
+        return TabId{ static_cast<uint64_t>(reinterpret_cast<uintptr_t>(p)) };
+    }
+};
+
+}  // namespace winrt::GhosttyWin32::implementation

--- a/GhosttyWin32App/TabIdAllocator.h
+++ b/GhosttyWin32App/TabIdAllocator.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "TabId.h"
+#include <atomic>
+
+namespace winrt::GhosttyWin32::implementation {
+
+// Issues monotonically increasing TabIds. One instance per MainWindow —
+// the counter is per-allocator (not process-global) so that test setups
+// or future multi-window scenarios get an isolated ID space without
+// having to clear hidden static state.
+//
+// Move-disabled: fixed location for the lifetime of MainWindow.
+class TabIdAllocator {
+public:
+    TabIdAllocator() = default;
+    TabIdAllocator(const TabIdAllocator&) = delete;
+    TabIdAllocator& operator=(const TabIdAllocator&) = delete;
+    TabIdAllocator(TabIdAllocator&&) = delete;
+    TabIdAllocator& operator=(TabIdAllocator&&) = delete;
+
+    TabId Allocate() noexcept {
+        return TabId{ m_next.fetch_add(1, std::memory_order_relaxed) };
+    }
+
+private:
+    std::atomic<uint64_t> m_next{ 1 };  // 0 reserved as sentinel by TabId
+};
+
+}  // namespace winrt::GhosttyWin32::implementation

--- a/GhosttyWin32App/Tabs.h
+++ b/GhosttyWin32App/Tabs.h
@@ -50,7 +50,7 @@ public:
     // the UI thread. Returns nullptr if the user already closed the tab
     // via the UI before the dispatched close arrived (or if the ID is
     // otherwise unknown), making stale callbacks a safe no-op.
-    Tab* FindById(uint64_t id) const {
+    Tab* FindById(TabId id) const {
         if (!id) return nullptr;
         for (auto& t : m_tabs) {
             if (t && t->Id() == id) return t.get();

--- a/GhosttyWin32App/Tabs.h
+++ b/GhosttyWin32App/Tabs.h
@@ -44,6 +44,20 @@ public:
         return nullptr;
     }
 
+    // Look up a Tab by its raw pointer. Used by the close_surface_cb
+    // callback path: ghostty's close callback hands us a userdata void*
+    // that was set to the Tab* at surface creation, and we need to verify
+    // the Tab still exists before touching it (the user might have
+    // already closed the tab via the UI before the dispatched close
+    // arrives).
+    Tab* FindByPointer(Tab* ptr) const {
+        if (!ptr) return nullptr;
+        for (auto& t : m_tabs) {
+            if (t.get() == ptr) return t.get();
+        }
+        return nullptr;
+    }
+
     // The Tab whose TabViewItem is currently selected in the given TabView,
     // or nullptr if there is no selection / no match. Encapsulates the
     // SelectedItem → TabViewItem → match dance the input handlers all need.

--- a/GhosttyWin32App/Tabs.h
+++ b/GhosttyWin32App/Tabs.h
@@ -44,16 +44,16 @@ public:
         return nullptr;
     }
 
-    // Look up a Tab by its raw pointer. Used by the close_surface_cb
-    // callback path: ghostty's close callback hands us a userdata void*
-    // that was set to the Tab* at surface creation, and we need to verify
-    // the Tab still exists before touching it (the user might have
-    // already closed the tab via the UI before the dispatched close
-    // arrives).
-    Tab* FindByPointer(Tab* ptr) const {
-        if (!ptr) return nullptr;
+    // Look up a Tab by the monotonic ID it was assigned at creation. Used
+    // by the close_surface_cb callback path: ghostty hands us back the ID
+    // we placed in cfg.userdata, and the dispatched lambda calls this on
+    // the UI thread. Returns nullptr if the user already closed the tab
+    // via the UI before the dispatched close arrived (or if the ID is
+    // otherwise unknown), making stale callbacks a safe no-op.
+    Tab* FindById(uint64_t id) const {
+        if (!id) return nullptr;
         for (auto& t : m_tabs) {
-            if (t.get() == ptr) return t.get();
+            if (t && t->Id() == id) return t.get();
         }
         return nullptr;
     }


### PR DESCRIPTION
## Summary

Fix [#8](https://github.com/i999rri/GhosttyWin32/issues/8): typing `exit` (or otherwise terminating the shell process) now closes the tab. When the last tab closes, the window closes too.

The host had a no-op `close_surface_cb` stub — ghostty has been firing the callback all along, we just weren't doing anything with it. The first commit fixes the bug; the rest clean up the structure exposed by the fix.

<details><summary>日本語</summary>

[#8](https://github.com/i999rri/GhosttyWin32/issues/8) の修正。`exit` でシェルプロセスが終了したときにタブが閉じるようにする。最後のタブが閉じるとウィンドウも閉じる。ホスト側の `close_surface_cb` が no-op スタブだっただけで、ghostty 側はずっと callback を発火していた。最初のコミットがバグ修正、残りは Tab 構築まわりの整理。

</details>

## Commits

1. **Close tab on shell exit (#8)** — wires up `close_surface_cb` using a heap-allocated `Tab**` slot for the userdata indirection. Fixes the bug.
2. **Identify tabs by ID instead of heap-slot pointer** — replaces the slot with a monotonic `uint64_t`. The slot solved two problems (timing of `cfg.userdata`, lifetime of the callback target) with one mechanism; splitting them cleans up the heap allocation and disarm dance.
3. **Wrap tab IDs in a TabId value object** — strongly-typed wrapper. Centralizes the `void*` boundary cast (`To/FromUserdata`) and prevents accidental mixing with raw `uint64_t`.
4. **Move tab ID counter into a TabIdAllocator owned by MainWindow** — pulls the function-local static atomic out into an explicit class. Ownership becomes visible; ID space is per-allocator instead of process-global.
5. **Extract tab construction into TabFactory** — `Tab::Create` had grown into a 100-line orchestration. `TabFactory` holds the cross-cutting context (app, hwnd, `&TabIdAllocator`); `Tab` becomes a pure value-ish class.

## Test plan

- [ ] Open a tab, type `exit`, tab closes
- [ ] With multiple tabs open, `exit` in one tab closes only that tab
- [ ] Close the last tab via `exit` — window closes
- [ ] Close a tab via the UI (X button) — no crash, no double-free
- [ ] Open + close many tabs rapidly — no leaks, no use-after-free

🤖 Generated with [Claude Code](https://claude.com/claude-code)