### PR TITLE
Extract per-tab terminal logic into a TerminalControl UserControl

### DIFF
--- a/GhosttyWin32App/GhosttyWin32App.vcxproj
+++ b/GhosttyWin32App/GhosttyWin32App.vcxproj
@@ -134,10 +134,14 @@
     <ClInclude Include="TabFactory.h" />
     <ClInclude Include="TabId.h" />
     <ClInclude Include="TabIdAllocator.h" />
+    <ClInclude Include="TerminalControl.xaml.h">
+      <DependentUpon>TerminalControl.xaml</DependentUpon>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ApplicationDefinition Include="App.xaml" />
     <Page Include="MainWindow.xaml" />
+    <Page Include="TerminalControl.xaml" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="pch.cpp">
@@ -149,12 +153,19 @@
     <ClCompile Include="MainWindow.xaml.cpp">
       <DependentUpon>MainWindow.xaml</DependentUpon>
     </ClCompile>
+    <ClCompile Include="TerminalControl.xaml.cpp">
+      <DependentUpon>TerminalControl.xaml</DependentUpon>
+    </ClCompile>
     <ClCompile Include="$(GeneratedFilesDir)module.g.cpp" />
   </ItemGroup>
   <ItemGroup>
     <Midl Include="MainWindow.idl">
       <SubType>Code</SubType>
       <DependentUpon>MainWindow.xaml</DependentUpon>
+    </Midl>
+    <Midl Include="TerminalControl.idl">
+      <SubType>Code</SubType>
+      <DependentUpon>TerminalControl.xaml</DependentUpon>
     </Midl>
   </ItemGroup>
   <ItemGroup>

--- a/GhosttyWin32App/GhosttyWin32App.vcxproj
+++ b/GhosttyWin32App/GhosttyWin32App.vcxproj
@@ -124,6 +124,7 @@
     <ClInclude Include="ImeBuffer.h" />
     <ClInclude Include="KeyModifiers.h" />
     <ClInclude Include="pch.h" />
+    <ClInclude Include="SEHGuard.h" />
     <ClInclude Include="App.xaml.h">
       <DependentUpon>App.xaml</DependentUpon>
     </ClInclude>
@@ -153,6 +154,7 @@
     <ClCompile Include="MainWindow.xaml.cpp">
       <DependentUpon>MainWindow.xaml</DependentUpon>
     </ClCompile>
+    <ClCompile Include="SEHGuard.cpp" />
     <ClCompile Include="TerminalControl.xaml.cpp">
       <DependentUpon>TerminalControl.xaml</DependentUpon>
     </ClCompile>

--- a/GhosttyWin32App/MainWindow.xaml
+++ b/GhosttyWin32App/MainWindow.xaml
@@ -49,6 +49,7 @@
                  SubtleFillColorSecondary/Tertiary follow OS light/dark. -->
             <Button x:Name="MinimizeButton" Width="46" Height="40"
                     Padding="0" BorderThickness="0" CornerRadius="0"
+                    IsTabStop="False" AllowFocusOnInteraction="False"
                     Click="OnMinimizeClick">
                 <Button.Resources>
                     <SolidColorBrush x:Key="ButtonBackground" Color="Transparent" />
@@ -64,6 +65,7 @@
             </Button>
             <Button x:Name="MaximizeButton" Width="46" Height="40"
                     Padding="0" BorderThickness="0" CornerRadius="0"
+                    IsTabStop="False" AllowFocusOnInteraction="False"
                     Click="OnMaximizeClick">
                 <Button.Resources>
                     <SolidColorBrush x:Key="ButtonBackground" Color="Transparent" />
@@ -83,6 +85,7 @@
                  transparent. -->
             <Button x:Name="CloseButton" Width="46" Height="40"
                     Padding="0" BorderThickness="0" CornerRadius="0"
+                    IsTabStop="False" AllowFocusOnInteraction="False"
                     Click="OnCloseClick">
                 <Button.Resources>
                     <SolidColorBrush x:Key="ButtonBackground" Color="Transparent" />

--- a/GhosttyWin32App/MainWindow.xaml.cpp
+++ b/GhosttyWin32App/MainWindow.xaml.cpp
@@ -356,6 +356,42 @@ namespace winrt::GhosttyWin32::implementation
                 CreateTab();
             });
 
+            // TabView's built-in AddTabButton (the "+") is focusable by
+            // default, and its Click cycle holds onto focus across the
+            // tab-creation sequence — so even after the new tab is
+            // selected and we Focus() the new TerminalControl, the +
+            // button retains keyboard focus and the next Enter press
+            // re-fires its Click (creating yet another tab). Walking
+            // TabView's template to flip IsTabStop/AllowFocusOnInteraction
+            // on the AddButton breaks that retention.
+            //
+            // The template only materialises after Loaded, so we hook
+            // TabView.Loaded and walk its visual tree once.
+            tv.Loaded([](winrt::Windows::Foundation::IInspectable const& sender, auto&&) {
+                auto tv = sender.try_as<muxc::TabView>();
+                if (!tv) return;
+                namespace mux = winrt::Microsoft::UI::Xaml;
+                std::function<bool(mux::DependencyObject const&)> walk =
+                    [&walk](mux::DependencyObject const& parent) -> bool {
+                        int count = mux::Media::VisualTreeHelper::GetChildrenCount(parent);
+                        for (int i = 0; i < count; ++i) {
+                            auto child = mux::Media::VisualTreeHelper::GetChild(parent, i);
+                            if (auto fe = child.try_as<mux::FrameworkElement>()) {
+                                if (fe.Name() == L"AddButton") {
+                                    if (auto button = child.try_as<muxc::Button>()) {
+                                        button.IsTabStop(false);
+                                        button.AllowFocusOnInteraction(false);
+                                    }
+                                    return true;
+                                }
+                            }
+                            if (walk(child)) return true;
+                        }
+                        return false;
+                    };
+                walk(tv);
+            });
+
             tv.TabCloseRequested([this](muxc::TabView const& sender, muxc::TabViewTabCloseRequestedEventArgs const& args) {
                 auto item = args.Tab();
                 uint32_t idx = 0;
@@ -366,6 +402,36 @@ namespace winrt::GhosttyWin32::implementation
                 m_tabs.Remove(item);     // Tab destructor handles teardown
                 if (sender.TabItems().Size() == 0) {
                     this->Close();
+                }
+            });
+
+            // Whenever the selected tab changes — explicit click on a
+            // header, AddTabButton creating a new tab, keybind switch,
+            // auto-reselect after a close — pull focus into the new
+            // active TerminalControl. Without this, focus stays on
+            // whatever element triggered the selection (most painfully:
+            // the AddTabButton, whose IsDefault-like Enter-handling
+            // would create yet another tab on the next Enter keystroke).
+            // TerminalControl is a UserControl with IsTabStop=true so
+            // the Focus call actually moves focus, unlike the bare
+            // SwapChainPanel from before the refactor.
+            //
+            // weak_ref instead of `this`: TabView fires SelectionChanged
+            // during shutdown as TabItems is cleared, after MainWindow
+            // has started disposing — a raw `this->TabView()` call then
+            // throws RO_E_CLOSED on the disposed window.
+            auto weakSelf = get_weak();
+            tv.SelectionChanged([weakSelf](auto&&, auto&&) {
+                auto self = weakSelf.get();
+                if (!self) return;
+                // weak_ref.get() can return non-null briefly while the
+                // window is mid-dispose, in which case TabView() throws
+                // RO_E_CLOSED. Swallow — focus restoration is moot then.
+                try {
+                    if (auto* tab = self->ActiveTab()) {
+                        tab->Focus();
+                    }
+                } catch (winrt::hresult_error const&) {
                 }
             });
 
@@ -632,6 +698,13 @@ namespace winrt::GhosttyWin32::implementation
         item.Header(box_value(kDefaultTabTitle));
         item.IsClosable(true);
         item.Content(control);
+        // Same focus-retention story as the AddTabButton: TabViewItem is
+        // a Control with IsTabStop=true by default, so clicking a tab
+        // header lands focus on the header itself rather than the inner
+        // TerminalControl. Selection still works without IsTabStop —
+        // it's driven by click, not keyboard tab order.
+        item.IsTabStop(false);
+        item.AllowFocusOnInteraction(false);
         tv.TabItems().Append(item);
         // Append-only — don't switch to the new tab yet. The SelectedItem
         // call (which is what makes the panel visible) is deferred to the
@@ -647,10 +720,12 @@ namespace winrt::GhosttyWin32::implementation
         auto onActivated = [weakThis, itemStrong, tvStrong]() {
             auto self = weakThis.get();
             if (!self) return;
+            // Setting SelectedItem fires SelectionChanged (which focuses
+            // the active tab) and realises the TerminalControl into the
+            // visual tree (which fires its Loaded → self-focus). Both
+            // paths land focus where we want it, so no explicit Focus()
+            // call is needed here.
             tvStrong.SelectedItem(itemStrong);
-            if (auto* tab = self->m_tabs.FindByItem(itemStrong)) {
-                tab->Focus();
-            }
             if (self->m_editContext) {
                 self->m_ime.reset();
                 self->m_editContext.NotifyFocusEnter();

--- a/GhosttyWin32App/MainWindow.xaml.cpp
+++ b/GhosttyWin32App/MainWindow.xaml.cpp
@@ -149,119 +149,10 @@ namespace winrt::GhosttyWin32::implementation
             auto tv = TabView();
             SetTitleBar(DragRegion());
 
-            // Window-level input handling (same approach as Windows Terminal)
-            auto root = Content().as<winrt::Microsoft::UI::Xaml::UIElement>();
-
-            root.KeyDown([this](auto&&, winrt::Microsoft::UI::Xaml::Input::KeyRoutedEventArgs const& args) {
-                auto* tc = ActiveControl();
-                if (!tc || !tc->Surface()) return;
-
-                int vk = static_cast<int>(args.Key());
-                UINT scanCode = args.KeyStatus().ScanCode;
-                bool ctrl = GetKeyState(VK_CONTROL) & 0x8000;
-                bool shift = GetKeyState(VK_SHIFT) & 0x8000;
-
-                // IME is processing this key
-                if (vk == VK_PROCESSKEY || tc->ImeComposing()) return;
-
-                // Ctrl+C: copy if selection exists, otherwise send SIGINT
-                if (ctrl && !shift && vk == 'C') {
-                    if (ghostty_surface_has_selection(tc->Surface())) {
-                        ghostty_text_s text = {};
-                        if (ghostty_surface_read_selection(tc->Surface(), &text) && text.text && text.text_len > 0) {
-                            Clipboard::write(m_hwnd, Encoding::toUtf16(text.text, static_cast<int>(text.text_len)));
-                            ghostty_surface_free_text(tc->Surface(), &text);
-                        }
-                        ghostty_surface_mouse_button(tc->Surface(), GHOSTTY_MOUSE_PRESS, GHOSTTY_MOUSE_LEFT, (ghostty_input_mods_e)0);
-                        ghostty_surface_mouse_button(tc->Surface(), GHOSTTY_MOUSE_RELEASE, GHOSTTY_MOUSE_LEFT, (ghostty_input_mods_e)0);
-                        args.Handled(true);
-                        return;
-                    }
-                }
-
-                // Ctrl+V: paste from clipboard
-                if (ctrl && !shift && vk == 'V') {
-                    auto utf8 = Encoding::toUtf8(Clipboard::read(m_hwnd));
-                    if (!utf8.empty()) {
-                        ghostty_surface_text(tc->Surface(), utf8.c_str(), utf8.size());
-                    }
-                    if (m_ghostty) m_ghostty->Tick();
-                    ghostty_surface_refresh(tc->Surface());
-                    args.Handled(true);
-                    return;
-                }
-
-                // Compute the unshifted codepoint (VK translated with no
-                // modifiers held) so unicode-keyed bindings can match.
-                // Without this, Binding.Set.getEvent() in
-                // input/Binding.zig:2622 falls through every lookup path
-                // for entries like `unicode = 't'` (ctrl+shift+t = new_tab,
-                // ctrl+shift+w = close_tab, etc.) and returns null. The
-                // physical-keyed bindings (ctrl+tab = next_tab,
-                // ctrl+shift+arrow_left = previous_tab) already match via
-                // keycode; this fixes the unicode ones.
-                //
-                // We keep text encoding on the separate ghostty_surface_text
-                // path below — passing a `text` field here would
-                // double-input because encodeKey also writes utf8 to the
-                // pty.
-                BYTE plainState[256] = {};
-                wchar_t unshiftedChars[4] = {};
-                int unshiftedCount = ToUnicode(vk, scanCode, plainState, unshiftedChars, 4, 0);
-                // Drain any dead-key state ToUnicode left in plainState so
-                // the next real keystroke isn't affected.
-                wchar_t drain[4] = {};
-                ToUnicode(VK_SPACE, 0x39, plainState, drain, 4, 0);
-
-                // Send key event to ghostty (binding match happens here)
-                ghostty_input_key_s keyEvent = {};
-                keyEvent.action = GHOSTTY_ACTION_PRESS;
-                keyEvent.keycode = scanCode;
-                if (args.KeyStatus().IsExtendedKey) keyEvent.keycode |= 0xE000;
-                keyEvent.mods = currentMods();
-                if (unshiftedCount > 0 && unshiftedChars[0] >= 0x20) {
-                    keyEvent.unshifted_codepoint = static_cast<uint32_t>(unshiftedChars[0]);
-                }
-                bool consumed = ghostty_surface_key(tc->Surface(), keyEvent);
-
-                // Translate to text using ToUnicode (replaces CharacterReceived).
-                // Skip when the binding consumed the key — otherwise
-                // ctrl+shift+t would type "T" into the pty in addition to
-                // opening a new tab.
-                if (!consumed) {
-                    BYTE kbState[256] = {};
-                    GetKeyboardState(kbState);
-                    wchar_t chars[4] = {};
-                    int charCount = ToUnicode(vk, scanCode, kbState, chars, 4, 0);
-                    if (charCount > 0 && chars[0] >= 0x20) {
-                        char utf8[16] = {};
-                        int len = WideCharToMultiByte(CP_UTF8, 0, chars, charCount, utf8, sizeof(utf8), nullptr, nullptr);
-                        if (len > 0) {
-                            ghostty_surface_text(tc->Surface(), utf8, len);
-                        }
-                    }
-                }
-
-                if (m_ghostty) m_ghostty->Tick();
-                ghostty_surface_refresh(tc->Surface());
-                args.Handled(true);
-            });
-
-            // Pointer routing now lives on TerminalControl — each
-            // instance hooks PointerMoved/Pressed/Released/Wheel on
+            // Pointer / keyboard / IME routing all live on
+            // TerminalControl — each instance hooks the events on
             // itself and forwards directly to its own ghostty surface.
-            // No window-level pointer handler is needed.
-
-            root.KeyUp([this](auto&&, winrt::Microsoft::UI::Xaml::Input::KeyRoutedEventArgs const& args) {
-                auto* tc = ActiveControl();
-                if (!tc || !tc->Surface()) return;
-                ghostty_input_key_s keyEvent = {};
-                keyEvent.action = GHOSTTY_ACTION_RELEASE;
-                keyEvent.keycode = args.KeyStatus().ScanCode;
-                if (args.KeyStatus().IsExtendedKey) keyEvent.keycode |= 0xE000;
-                keyEvent.mods = currentMods();
-                ghostty_surface_key(tc->Surface(), keyEvent);
-            });
+            // No window-level input handler is needed here.
 
             // DPI change handling (deferred until XamlRoot is available)
             Content().as<winrt::Microsoft::UI::Xaml::FrameworkElement>().Loaded([this](auto&&, auto&&) {
@@ -699,12 +590,22 @@ namespace winrt::GhosttyWin32::implementation
             // the visual tree, which fires its Loaded handler. Loaded
             // builds the per-control CoreTextEditContext (deferred
             // there because EditContext registration only takes hold
-            // for an element that's actually in the live tree),
-            // grants self-focus, and the resulting GotFocus calls
-            // NotifyFocusEnter — so IME engages without any explicit
-            // routing from this lambda.
+            // for an element that's actually in the live tree).
             tvStrong.SelectedItem(itemStrong);
             if (self->m_hwnd) ShowWindow(self->m_hwnd, SW_SHOW);
+            // Focus has to be (re)taken AFTER ShowWindow for the very
+            // first tab. Loaded fires synchronously inside SelectedItem
+            // while the window is still hidden, and Focus(Programmatic)
+            // can't bind OS-level keyboard focus to an element of an
+            // invisible window — the call silently no-ops, KeyDown
+            // never fires, and plain typing goes nowhere. Subsequent
+            // tabs reach onActivated with the window already shown so
+            // their Loaded → Focus succeeds; the explicit re-focus
+            // below is a no-op for them but the load-bearing fix for
+            // the first tab.
+            if (auto* tab = self->m_tabs.FindByItem(itemStrong)) {
+                tab->Focus();
+            }
         };
 
         // Estimate the new panel's eventual size from the currently active

--- a/GhosttyWin32App/MainWindow.xaml.cpp
+++ b/GhosttyWin32App/MainWindow.xaml.cpp
@@ -95,15 +95,33 @@ namespace winrt::GhosttyWin32::implementation
                 this->SystemBackdrop(backdrop);
             }
 
-            // Re-attach IME when window regains activation. XAML's
-            // GotFocus/LostFocus on TerminalControl don't fire on
-            // window de/activation (focus is logically retained on the
-            // focused element across alt-tab), so we forward window
-            // state changes to the active control's EditContext
-            // directly. Without this, switching focus to another window
-            // and back leaves the OS-side text-services manager
-            // pointing at a detached EditContext and IME stays off
-            // even if the OS-level IME toggle is on.
+            // On every window (re)activation: pull keyboard focus onto
+            // the active terminal and re-attach IME. Two reasons to
+            // anchor both jobs on this event:
+            //
+            //   * Focus on initial show. The first tab's onActivated
+            //     callback calls ShowWindow(SW_SHOW), which only posts
+            //     WM_ACTIVATE — WinUI's own activation logic runs later
+            //     in the message pump and assigns default focus to its
+            //     internal first-focusable element. Calling Focus
+            //     directly inside onActivated (or through a Low-priority
+            //     dispatcher tick) races against that and loses
+            //     intermittently. The Activated event itself is signalled
+            //     after WinUI has finished its default-focus pass, so a
+            //     Focus call here is the last write and reliably sticks.
+            //     Subsequent alt-tab returns ride the same path: focus
+            //     comes back to the terminal, which is what users expect
+            //     of a terminal app where there's nothing else to focus.
+            //
+            //   * IME re-attach. XAML's GotFocus/LostFocus on
+            //     TerminalControl don't fire on window de/activation
+            //     (focus is logically retained on the focused element
+            //     across alt-tab), so we forward window state changes to
+            //     the active control's EditContext directly. Without
+            //     this, switching focus to another window and back leaves
+            //     the OS-side text-services manager pointing at a
+            //     detached EditContext and IME stays off even if the
+            //     OS-level IME toggle is on.
             //
             // weak_ref + try/catch instead of `[this]`: WindowActivated
             // fires during shutdown after MainWindow has started
@@ -119,13 +137,18 @@ namespace winrt::GhosttyWin32::implementation
                 auto self = weakActivated.get();
                 if (!self) return;
                 try {
-                    auto* tc = self->ActiveControl();
-                    if (!tc) return;
                     using State = winrt::Microsoft::UI::Xaml::WindowActivationState;
                     if (args.WindowActivationState() == State::Deactivated) {
-                        tc->NotifyImeFocusLeave();
+                        if (auto* tc = self->ActiveControl()) {
+                            tc->NotifyImeFocusLeave();
+                        }
                     } else {
-                        tc->NotifyImeFocusEnter();
+                        if (auto* tab = self->ActiveTab()) {
+                            tab->Focus();
+                        }
+                        if (auto* tc = self->ActiveControl()) {
+                            tc->NotifyImeFocusEnter();
+                        }
                     }
                 } catch (winrt::hresult_error const&) {
                 }
@@ -578,19 +601,10 @@ namespace winrt::GhosttyWin32::implementation
             // for an element that's actually in the live tree).
             tvStrong.SelectedItem(itemStrong);
             if (self->m_hwnd) ShowWindow(self->m_hwnd, SW_SHOW);
-            // Focus has to be (re)taken AFTER ShowWindow for the very
-            // first tab. Loaded fires synchronously inside SelectedItem
-            // while the window is still hidden, and Focus(Programmatic)
-            // can't bind OS-level keyboard focus to an element of an
-            // invisible window — the call silently no-ops, KeyDown
-            // never fires, and plain typing goes nowhere. Subsequent
-            // tabs reach onActivated with the window already shown so
-            // their Loaded → Focus succeeds; the explicit re-focus
-            // below is a no-op for them but the load-bearing fix for
-            // the first tab.
-            if (auto* tab = self->m_tabs.FindByItem(itemStrong)) {
-                tab->Focus();
-            }
+            // Focus is taken in the Activated event handler that fires
+            // from the WM_ACTIVATE this ShowWindow posts. See the
+            // comment on that handler for why anchoring focus there is
+            // race-free, while a direct Focus() call here is not.
         };
 
         // Estimate the new panel's eventual size from the currently active

--- a/GhosttyWin32App/MainWindow.xaml.cpp
+++ b/GhosttyWin32App/MainWindow.xaml.cpp
@@ -133,20 +133,20 @@ namespace winrt::GhosttyWin32::implementation
                     m_ime.applyTextUpdate(range.StartCaretPosition, range.EndCaretPosition,
                                           newText.c_str(), newText.size());
 
-                    auto* tab = ActiveTab();
-                    if (!tab || !tab->Surface()) return;
+                    auto* tc = ActiveControl();
+                    if (!tc || !tc->Surface()) return;
 
                     if (m_ime.composing()) {
                         if (m_ime.text().empty()) {
-                            ghostty_surface_preedit(tab->Surface(), nullptr, 0);
+                            ghostty_surface_preedit(tc->Surface(), nullptr, 0);
                         } else {
                             auto utf8 = Encoding::toUtf8(m_ime.text());
                             if (!utf8.empty())
-                                ghostty_surface_preedit(tab->Surface(), utf8.c_str(), utf8.size());
+                                ghostty_surface_preedit(tc->Surface(), utf8.c_str(), utf8.size());
                         }
                     }
                     if (m_ghostty) m_ghostty->Tick();
-                    ghostty_surface_refresh(tab->Surface());
+                    ghostty_surface_refresh(tc->Surface());
                 });
 
                 m_editContext.CompositionStarted([this](txtCore::CoreTextEditContext const&, txtCore::CoreTextCompositionStartedEventArgs const&) {
@@ -154,24 +154,24 @@ namespace winrt::GhosttyWin32::implementation
                 });
 
                 m_editContext.CompositionCompleted([this](txtCore::CoreTextEditContext const&, txtCore::CoreTextCompositionCompletedEventArgs const&) {
-                    auto* tab = ActiveTab();
-                    if (tab && tab->Surface()) {
-                        ghostty_surface_preedit(tab->Surface(), nullptr, 0);
+                    auto* tc = ActiveControl();
+                    if (tc && tc->Surface()) {
+                        ghostty_surface_preedit(tc->Surface(), nullptr, 0);
                         auto utf8 = Encoding::toUtf8(m_ime.text());
                         if (!utf8.empty()) {
-                            ghostty_surface_text(tab->Surface(), utf8.c_str(), utf8.size());
+                            ghostty_surface_text(tc->Surface(), utf8.c_str(), utf8.size());
                         }
                         if (m_ghostty) m_ghostty->Tick();
-                        ghostty_surface_refresh(tab->Surface());
+                        ghostty_surface_refresh(tc->Surface());
                     }
                     m_ime.compositionCompleted();
                 });
 
                 m_editContext.LayoutRequested([this](txtCore::CoreTextEditContext const&, txtCore::CoreTextLayoutRequestedEventArgs const& args) {
-                    auto* tab = ActiveTab();
-                    if (!tab || !tab->Surface() || !m_hwnd) return;
+                    auto* tc = ActiveControl();
+                    if (!tc || !tc->Surface() || !m_hwnd) return;
                     double x = 0, y = 0, w = 0, h = 0;
-                    ghostty_surface_ime_point(tab->Surface(), &x, &y, &w, &h);
+                    ghostty_surface_ime_point(tc->Surface(), &x, &y, &w, &h);
                     POINT screenPt = { (LONG)x, (LONG)y };
                     ClientToScreen(m_hwnd, &screenPt);
                     winrt::Windows::Foundation::Rect bounds{
@@ -183,9 +183,9 @@ namespace winrt::GhosttyWin32::implementation
                 m_editContext.FocusRemoved([this](txtCore::CoreTextEditContext const&, auto&&) {
                     if (m_ime.composing()) {
                         m_ime.reset();
-                        auto* tab = ActiveTab();
-                        if (tab && tab->Surface())
-                            ghostty_surface_preedit(tab->Surface(), nullptr, 0);
+                        auto* tc = ActiveControl();
+                        if (tc && tc->Surface())
+                            ghostty_surface_preedit(tc->Surface(), nullptr, 0);
                     }
                 });
             }
@@ -213,8 +213,8 @@ namespace winrt::GhosttyWin32::implementation
             auto root = Content().as<winrt::Microsoft::UI::Xaml::UIElement>();
 
             root.KeyDown([this](auto&&, winrt::Microsoft::UI::Xaml::Input::KeyRoutedEventArgs const& args) {
-                auto* tab = ActiveTab();
-                if (!tab || !tab->Surface()) return;
+                auto* tc = ActiveControl();
+                if (!tc || !tc->Surface()) return;
 
                 int vk = static_cast<int>(args.Key());
                 UINT scanCode = args.KeyStatus().ScanCode;
@@ -226,14 +226,14 @@ namespace winrt::GhosttyWin32::implementation
 
                 // Ctrl+C: copy if selection exists, otherwise send SIGINT
                 if (ctrl && !shift && vk == 'C') {
-                    if (ghostty_surface_has_selection(tab->Surface())) {
+                    if (ghostty_surface_has_selection(tc->Surface())) {
                         ghostty_text_s text = {};
-                        if (ghostty_surface_read_selection(tab->Surface(), &text) && text.text && text.text_len > 0) {
+                        if (ghostty_surface_read_selection(tc->Surface(), &text) && text.text && text.text_len > 0) {
                             Clipboard::write(m_hwnd, Encoding::toUtf16(text.text, static_cast<int>(text.text_len)));
-                            ghostty_surface_free_text(tab->Surface(), &text);
+                            ghostty_surface_free_text(tc->Surface(), &text);
                         }
-                        ghostty_surface_mouse_button(tab->Surface(), GHOSTTY_MOUSE_PRESS, GHOSTTY_MOUSE_LEFT, (ghostty_input_mods_e)0);
-                        ghostty_surface_mouse_button(tab->Surface(), GHOSTTY_MOUSE_RELEASE, GHOSTTY_MOUSE_LEFT, (ghostty_input_mods_e)0);
+                        ghostty_surface_mouse_button(tc->Surface(), GHOSTTY_MOUSE_PRESS, GHOSTTY_MOUSE_LEFT, (ghostty_input_mods_e)0);
+                        ghostty_surface_mouse_button(tc->Surface(), GHOSTTY_MOUSE_RELEASE, GHOSTTY_MOUSE_LEFT, (ghostty_input_mods_e)0);
                         args.Handled(true);
                         return;
                     }
@@ -243,10 +243,10 @@ namespace winrt::GhosttyWin32::implementation
                 if (ctrl && !shift && vk == 'V') {
                     auto utf8 = Encoding::toUtf8(Clipboard::read(m_hwnd));
                     if (!utf8.empty()) {
-                        ghostty_surface_text(tab->Surface(), utf8.c_str(), utf8.size());
+                        ghostty_surface_text(tc->Surface(), utf8.c_str(), utf8.size());
                     }
                     if (m_ghostty) m_ghostty->Tick();
-                    ghostty_surface_refresh(tab->Surface());
+                    ghostty_surface_refresh(tc->Surface());
                     args.Handled(true);
                     return;
                 }
@@ -282,7 +282,7 @@ namespace winrt::GhosttyWin32::implementation
                 if (unshiftedCount > 0 && unshiftedChars[0] >= 0x20) {
                     keyEvent.unshifted_codepoint = static_cast<uint32_t>(unshiftedChars[0]);
                 }
-                bool consumed = ghostty_surface_key(tab->Surface(), keyEvent);
+                bool consumed = ghostty_surface_key(tc->Surface(), keyEvent);
 
                 // Translate to text using ToUnicode (replaces CharacterReceived).
                 // Skip when the binding consumed the key — otherwise
@@ -297,77 +297,77 @@ namespace winrt::GhosttyWin32::implementation
                         char utf8[16] = {};
                         int len = WideCharToMultiByte(CP_UTF8, 0, chars, charCount, utf8, sizeof(utf8), nullptr, nullptr);
                         if (len > 0) {
-                            ghostty_surface_text(tab->Surface(), utf8, len);
+                            ghostty_surface_text(tc->Surface(), utf8, len);
                         }
                     }
                 }
 
                 if (m_ghostty) m_ghostty->Tick();
-                ghostty_surface_refresh(tab->Surface());
+                ghostty_surface_refresh(tc->Surface());
                 args.Handled(true);
             });
 
             // Mouse input on root
             root.PointerMoved([this](auto&&, winrt::Microsoft::UI::Xaml::Input::PointerRoutedEventArgs const& args) {
-                auto* tab = ActiveTab();
-                if (!tab || !tab->Surface()) return;
-                winrt::Microsoft::UI::Input::PointerPoint point = args.GetCurrentPoint(tab->Panel());
+                auto* tc = ActiveControl();
+                if (!tc || !tc->Surface()) return;
+                winrt::Microsoft::UI::Input::PointerPoint point = args.GetCurrentPoint(tc->InnerPanel());
                 winrt::Windows::Foundation::Point pos = point.Position();
-                ghostty_surface_mouse_pos(tab->Surface(), pos.X, pos.Y, currentMods());
+                ghostty_surface_mouse_pos(tc->Surface(), pos.X, pos.Y, currentMods());
             });
 
             root.PointerPressed([this](auto&&, winrt::Microsoft::UI::Xaml::Input::PointerRoutedEventArgs const& args) {
-                auto* tab = ActiveTab();
-                if (!tab || !tab->Surface()) return;
-                winrt::Microsoft::UI::Input::PointerPoint point = args.GetCurrentPoint(tab->Panel());
+                auto* tc = ActiveControl();
+                if (!tc || !tc->Surface()) return;
+                winrt::Microsoft::UI::Input::PointerPoint point = args.GetCurrentPoint(tc->InnerPanel());
                 winrt::Microsoft::UI::Input::PointerPointProperties props = point.Properties();
                 ghostty_input_mouse_button_e btn;
                 if (props.IsLeftButtonPressed()) btn = GHOSTTY_MOUSE_LEFT;
                 else if (props.IsRightButtonPressed()) {
                     // Right-click: copy selection if exists
-                    if (ghostty_surface_has_selection(tab->Surface())) {
+                    if (ghostty_surface_has_selection(tc->Surface())) {
                         ghostty_text_s text = {};
-                        if (ghostty_surface_read_selection(tab->Surface(), &text) && text.text && text.text_len > 0) {
+                        if (ghostty_surface_read_selection(tc->Surface(), &text) && text.text && text.text_len > 0) {
                             Clipboard::write(m_hwnd, Encoding::toUtf16(text.text, static_cast<int>(text.text_len)));
-                            ghostty_surface_free_text(tab->Surface(), &text);
+                            ghostty_surface_free_text(tc->Surface(), &text);
                         }
-                        ghostty_surface_mouse_button(tab->Surface(), GHOSTTY_MOUSE_PRESS, GHOSTTY_MOUSE_LEFT, (ghostty_input_mods_e)0);
-                        ghostty_surface_mouse_button(tab->Surface(), GHOSTTY_MOUSE_RELEASE, GHOSTTY_MOUSE_LEFT, (ghostty_input_mods_e)0);
+                        ghostty_surface_mouse_button(tc->Surface(), GHOSTTY_MOUSE_PRESS, GHOSTTY_MOUSE_LEFT, (ghostty_input_mods_e)0);
+                        ghostty_surface_mouse_button(tc->Surface(), GHOSTTY_MOUSE_RELEASE, GHOSTTY_MOUSE_LEFT, (ghostty_input_mods_e)0);
                         return;
                     }
                     btn = GHOSTTY_MOUSE_RIGHT;
                 }
                 else return; // Ignore middle-click and others
-                ghostty_surface_mouse_button(tab->Surface(), GHOSTTY_MOUSE_PRESS, btn, currentMods());
+                ghostty_surface_mouse_button(tc->Surface(), GHOSTTY_MOUSE_PRESS, btn, currentMods());
             });
 
             root.PointerReleased([this](auto&&, winrt::Microsoft::UI::Xaml::Input::PointerRoutedEventArgs const&) {
-                auto* tab = ActiveTab();
-                if (!tab || !tab->Surface()) return;
-                ghostty_surface_mouse_button(tab->Surface(), GHOSTTY_MOUSE_RELEASE, GHOSTTY_MOUSE_LEFT, currentMods());
+                auto* tc = ActiveControl();
+                if (!tc || !tc->Surface()) return;
+                ghostty_surface_mouse_button(tc->Surface(), GHOSTTY_MOUSE_RELEASE, GHOSTTY_MOUSE_LEFT, currentMods());
             });
 
             root.PointerWheelChanged([this](auto&&, winrt::Microsoft::UI::Xaml::Input::PointerRoutedEventArgs const& args) {
-                auto* tab = ActiveTab();
-                if (!tab || !tab->Surface()) return;
-                winrt::Microsoft::UI::Input::PointerPoint point = args.GetCurrentPoint(tab->Panel());
+                auto* tc = ActiveControl();
+                if (!tc || !tc->Surface()) return;
+                winrt::Microsoft::UI::Input::PointerPoint point = args.GetCurrentPoint(tc->InnerPanel());
                 winrt::Microsoft::UI::Input::PointerPointProperties props = point.Properties();
                 int delta = props.MouseWheelDelta();
                 double scrollY = (double)delta / 120.0;
                 ghostty_input_scroll_mods_t smods = {};
-                ghostty_surface_mouse_scroll(tab->Surface(), 0, scrollY, smods);
+                ghostty_surface_mouse_scroll(tc->Surface(), 0, scrollY, smods);
                 args.Handled(true);
             });
 
             root.KeyUp([this](auto&&, winrt::Microsoft::UI::Xaml::Input::KeyRoutedEventArgs const& args) {
-                auto* tab = ActiveTab();
-                if (!tab || !tab->Surface()) return;
+                auto* tc = ActiveControl();
+                if (!tc || !tc->Surface()) return;
                 ghostty_input_key_s keyEvent = {};
                 keyEvent.action = GHOSTTY_ACTION_RELEASE;
                 keyEvent.keycode = args.KeyStatus().ScanCode;
                 if (args.KeyStatus().IsExtendedKey) keyEvent.keycode |= 0xE000;
                 keyEvent.mods = currentMods();
-                ghostty_surface_key(tab->Surface(), keyEvent);
+                ghostty_surface_key(tc->Surface(), keyEvent);
             });
 
             // DPI change handling (deferred until XamlRoot is available)
@@ -376,9 +376,12 @@ namespace winrt::GhosttyWin32::implementation
                     if (!m_hwnd) return;
                     UINT dpi = GetDpiForWindow(m_hwnd);
                     double scale = (double)dpi / 96.0;
+                    // Today every tab has a single TerminalControl. With
+                    // future pane support this would walk each tab's
+                    // pane tree and apply the scale to every leaf.
                     for (auto& t : m_tabs) {
-                        if (t->Surface()) {
-                            ghostty_surface_set_content_scale(t->Surface(), scale, scale);
+                        if (auto* tc = t->ActiveControl(); tc && tc->Surface()) {
+                            ghostty_surface_set_content_scale(tc->Surface(), scale, scale);
                         }
                     }
                 });
@@ -442,8 +445,10 @@ namespace winrt::GhosttyWin32::implementation
             if (g_mainWindow->m_hwnd) ShowWindow(g_mainWindow->m_hwnd, SW_HIDE);
             for (auto& tab : g_mainWindow->m_tabs) {
                 if (!tab) continue;
-                HANDLE h = tab->SurfaceHandle();
-                if (h) CloseHandle(h);
+                if (auto* tc = tab->ActiveControl()) {
+                    HANDLE h = tc->CompositionHandle();
+                    if (h) CloseHandle(h);
+                }
             }
         }
         MessageBoxW(nullptr,
@@ -458,6 +463,12 @@ namespace winrt::GhosttyWin32::implementation
     Tab* MainWindow::ActiveTab()
     {
         return m_tabs.Active(TabView());
+    }
+
+    TerminalControl* MainWindow::ActiveControl()
+    {
+        auto* tab = ActiveTab();
+        return tab ? tab->ActiveControl() : nullptr;
     }
 
     void MainWindow::InitGhostty()
@@ -601,19 +612,19 @@ namespace winrt::GhosttyWin32::implementation
         };
         rtConfig.read_clipboard_cb = [](void*, ghostty_clipboard_e, void* state) -> bool {
             if (!g_mainWindow) return false;
-            auto* tab = g_mainWindow->ActiveTab();
-            if (!tab || !tab->Surface()) return false;
+            auto* tc = g_mainWindow->ActiveControl();
+            if (!tc || !tc->Surface()) return false;
             auto utf8 = Encoding::toUtf8(Clipboard::read(g_mainWindow->m_hwnd));
             if (utf8.empty()) return false;
-            ghostty_surface_complete_clipboard_request(tab->Surface(), utf8.c_str(), state, false);
+            ghostty_surface_complete_clipboard_request(tc->Surface(), utf8.c_str(), state, false);
             return true;
         };
         rtConfig.confirm_read_clipboard_cb = [](void*, const char* content, void* state, ghostty_clipboard_request_e) {
             // Auto-confirm clipboard reads
             if (g_mainWindow) {
-                auto* tab = g_mainWindow->ActiveTab();
-                if (tab && tab->Surface()) {
-                    ghostty_surface_complete_clipboard_request(tab->Surface(), content, state, true);
+                auto* tc = g_mainWindow->ActiveControl();
+                if (tc && tc->Surface()) {
+                    ghostty_surface_complete_clipboard_request(tc->Surface(), content, state, true);
                 }
             }
         };
@@ -658,16 +669,16 @@ namespace winrt::GhosttyWin32::implementation
         if (!m_ghostty || !m_hwnd) return;
         auto tv = TabView();
 
-        auto panel = muxc::SwapChainPanel();
-        panel.IsTabStop(true);
-        panel.IsHitTestVisible(true);
-        panel.AllowFocusOnInteraction(true);
+        // Each tab is a TerminalControl (UserControl wrapping a
+        // SwapChainPanel). Focus/IsTabStop/etc. are set in the XAML
+        // template, so no per-instance setup is needed here.
+        auto control = winrt::GhosttyWin32::TerminalControl();
 
         auto item = muxc::TabViewItem();
         static constexpr wchar_t kDefaultTabTitle[] = L" ";
         item.Header(box_value(kDefaultTabTitle));
         item.IsClosable(true);
-        item.Content(panel);
+        item.Content(control);
         tv.TabItems().Append(item);
         // Append-only — don't switch to the new tab yet. The SelectedItem
         // call (which is what makes the panel visible) is deferred to the
@@ -703,8 +714,8 @@ namespace winrt::GhosttyWin32::implementation
         // SelectedItem) and ghostty falls back to the main window's full
         // client rect, which is too tall by the tab strip height.
         uint32_t initialW = 0, initialH = 0;
-        if (auto* prev = ActiveTab()) {
-            auto const& prevPanel = prev->Panel();
+        if (auto* prevControl = ActiveControl()) {
+            auto prevPanel = prevControl->InnerPanel();
             initialW = static_cast<uint32_t>(prevPanel.ActualWidth());
             initialH = static_cast<uint32_t>(prevPanel.ActualHeight());
         }
@@ -716,7 +727,7 @@ namespace winrt::GhosttyWin32::implementation
         // callback below.
         if (!m_tabFactory) return;
         struct CreateCtx {
-            muxc::SwapChainPanel const* panel;
+            winrt::GhosttyWin32::TerminalControl const* control;
             muxc::TabViewItem const* item;
             TabFactory* factory;
             std::function<void()> onActivated;
@@ -724,10 +735,10 @@ namespace winrt::GhosttyWin32::implementation
             uint32_t initialHeight;
             std::unique_ptr<Tab> result;
         };
-        CreateCtx ctx{ &panel, &item, m_tabFactory.get(), std::move(onActivated), initialW, initialH, nullptr };
+        CreateCtx ctx{ &control, &item, m_tabFactory.get(), std::move(onActivated), initialW, initialH, nullptr };
         int ok = RunSEHGuarded([](void* arg) noexcept {
             auto* c = static_cast<CreateCtx*>(arg);
-            c->result = c->factory->Make(*c->panel, *c->item, std::move(c->onActivated), c->initialWidth, c->initialHeight);
+            c->result = c->factory->Make(*c->control, *c->item, std::move(c->onActivated), c->initialWidth, c->initialHeight);
         }, &ctx);
 
         std::unique_ptr<Tab> tab = std::move(ctx.result);

--- a/GhosttyWin32App/MainWindow.xaml.cpp
+++ b/GhosttyWin32App/MainWindow.xaml.cpp
@@ -3,6 +3,7 @@
 #include "Clipboard.h"
 #include "KeyModifiers.h"
 #include "Encoding.h"
+#include "SEHGuard.h"
 #if __has_include("MainWindow.g.cpp")
 #include "MainWindow.g.cpp"
 #endif
@@ -22,22 +23,6 @@ namespace {
         DWORD len = GetTempPathW(MAX_PATH, buf);
         if (len == 0) return L"GhosttyWin32_running.flag";
         return std::filesystem::path(buf) / L"GhosttyWin32_running.flag";
-    }
-
-    // SEH "trampoline": isolates a callable invocation behind __try/__except.
-    // MSVC's /EHsc refuses __try in any function that has C++ unwinding
-    // (i.e. anything dealing with C++ objects). This helper has only raw
-    // C types in its frame, so it compiles. The C++ work lives in the
-    // callback we invoke through a function pointer — if that callback
-    // raises a hardware exception, we swallow it here.
-    extern "C" int RunSEHGuarded(void (*fn)(void*), void* ctx) noexcept {
-        __try {
-            fn(ctx);
-            return 1;
-        } __except (EXCEPTION_EXECUTE_HANDLER) {
-            OutputDebugStringA("SEH caught hardware exception inside guarded call\n");
-            return 0;
-        }
     }
 }
 

--- a/GhosttyWin32App/MainWindow.xaml.cpp
+++ b/GhosttyWin32App/MainWindow.xaml.cpp
@@ -110,99 +110,39 @@ namespace winrt::GhosttyWin32::implementation
                 this->SystemBackdrop(backdrop);
             }
 
-            // IME via CoreTextEditContext
-            {
-                namespace txtCore = winrt::Windows::UI::Text::Core;
-                auto manager = txtCore::CoreTextServicesManager::GetForCurrentView();
-                m_editContext = manager.CreateEditContext();
-                m_editContext.InputPaneDisplayPolicy(txtCore::CoreTextInputPaneDisplayPolicy::Manual);
-                m_editContext.InputScope(txtCore::CoreTextInputScope::Default);
-
-                m_editContext.TextRequested([this](txtCore::CoreTextEditContext const&, txtCore::CoreTextTextRequestedEventArgs const& args) {
-                    args.Request().Text(winrt::hstring(m_ime.paddedText()));
-                });
-
-                m_editContext.SelectionRequested([this](txtCore::CoreTextEditContext const&, txtCore::CoreTextSelectionRequestedEventArgs const& args) {
-                    int32_t pos = m_ime.selectionPosition();
-                    args.Request().Selection({ pos, pos });
-                });
-
-                m_editContext.TextUpdating([this](txtCore::CoreTextEditContext const&, txtCore::CoreTextTextUpdatingEventArgs const& args) {
-                    auto range = args.Range();
-                    auto newText = args.Text();
-                    m_ime.applyTextUpdate(range.StartCaretPosition, range.EndCaretPosition,
-                                          newText.c_str(), newText.size());
-
-                    auto* tc = ActiveControl();
-                    if (!tc || !tc->Surface()) return;
-
-                    if (m_ime.composing()) {
-                        if (m_ime.text().empty()) {
-                            ghostty_surface_preedit(tc->Surface(), nullptr, 0);
-                        } else {
-                            auto utf8 = Encoding::toUtf8(m_ime.text());
-                            if (!utf8.empty())
-                                ghostty_surface_preedit(tc->Surface(), utf8.c_str(), utf8.size());
-                        }
-                    }
-                    if (m_ghostty) m_ghostty->Tick();
-                    ghostty_surface_refresh(tc->Surface());
-                });
-
-                m_editContext.CompositionStarted([this](txtCore::CoreTextEditContext const&, txtCore::CoreTextCompositionStartedEventArgs const&) {
-                    m_ime.compositionStarted();
-                });
-
-                m_editContext.CompositionCompleted([this](txtCore::CoreTextEditContext const&, txtCore::CoreTextCompositionCompletedEventArgs const&) {
-                    auto* tc = ActiveControl();
-                    if (tc && tc->Surface()) {
-                        ghostty_surface_preedit(tc->Surface(), nullptr, 0);
-                        auto utf8 = Encoding::toUtf8(m_ime.text());
-                        if (!utf8.empty()) {
-                            ghostty_surface_text(tc->Surface(), utf8.c_str(), utf8.size());
-                        }
-                        if (m_ghostty) m_ghostty->Tick();
-                        ghostty_surface_refresh(tc->Surface());
-                    }
-                    m_ime.compositionCompleted();
-                });
-
-                m_editContext.LayoutRequested([this](txtCore::CoreTextEditContext const&, txtCore::CoreTextLayoutRequestedEventArgs const& args) {
-                    auto* tc = ActiveControl();
-                    if (!tc || !tc->Surface() || !m_hwnd) return;
-                    double x = 0, y = 0, w = 0, h = 0;
-                    ghostty_surface_ime_point(tc->Surface(), &x, &y, &w, &h);
-                    POINT screenPt = { (LONG)x, (LONG)y };
-                    ClientToScreen(m_hwnd, &screenPt);
-                    winrt::Windows::Foundation::Rect bounds{
-                        (float)screenPt.x, (float)screenPt.y, (float)w, (float)h };
-                    args.Request().LayoutBounds().ControlBounds(bounds);
-                    args.Request().LayoutBounds().TextBounds(bounds);
-                });
-
-                m_editContext.FocusRemoved([this](txtCore::CoreTextEditContext const&, auto&&) {
-                    if (m_ime.composing()) {
-                        m_ime.reset();
-                        auto* tc = ActiveControl();
-                        if (tc && tc->Surface())
-                            ghostty_surface_preedit(tc->Surface(), nullptr, 0);
-                    }
-                });
-            }
-
-            // Re-attach IME when window regains activation. The init handler
-            // above runs once and calls NotifyFocusEnter only after the first
-            // tab is created; without this, switching focus to another window
-            // and back leaves CoreTextEditContext detached, so IME stays off
+            // Re-attach IME when window regains activation. XAML's
+            // GotFocus/LostFocus on TerminalControl don't fire on
+            // window de/activation (focus is logically retained on the
+            // focused element across alt-tab), so we forward window
+            // state changes to the active control's EditContext
+            // directly. Without this, switching focus to another window
+            // and back leaves the OS-side text-services manager
+            // pointing at a detached EditContext and IME stays off
             // even if the OS-level IME toggle is on.
-            Activated([this](winrt::Windows::Foundation::IInspectable const&,
-                             winrt::Microsoft::UI::Xaml::WindowActivatedEventArgs const& args) {
-                if (!m_editContext) return;
-                using State = winrt::Microsoft::UI::Xaml::WindowActivationState;
-                if (args.WindowActivationState() == State::Deactivated) {
-                    m_editContext.NotifyFocusLeave();
-                } else if (ActiveTab()) {
-                    m_editContext.NotifyFocusEnter();
+            //
+            // weak_ref + try/catch instead of `[this]`: WindowActivated
+            // fires during shutdown after MainWindow has started
+            // disposing — m_tabs is mid-destruction and ActiveControl()
+            // can return a dangling TerminalControl pointer. Calling
+            // NotifyImeFocusLeave on it AVs at the m_editContext
+            // member offset inside microsoft.ui.xaml.dll. The weak_ref
+            // path bails cleanly; the catch covers RO_E_CLOSED if
+            // TabView() is hit on a torn-down window.
+            auto weakActivated = get_weak();
+            Activated([weakActivated](winrt::Windows::Foundation::IInspectable const&,
+                                      winrt::Microsoft::UI::Xaml::WindowActivatedEventArgs const& args) {
+                auto self = weakActivated.get();
+                if (!self) return;
+                try {
+                    auto* tc = self->ActiveControl();
+                    if (!tc) return;
+                    using State = winrt::Microsoft::UI::Xaml::WindowActivationState;
+                    if (args.WindowActivationState() == State::Deactivated) {
+                        tc->NotifyImeFocusLeave();
+                    } else {
+                        tc->NotifyImeFocusEnter();
+                    }
+                } catch (winrt::hresult_error const&) {
                 }
             });
 
@@ -222,7 +162,7 @@ namespace winrt::GhosttyWin32::implementation
                 bool shift = GetKeyState(VK_SHIFT) & 0x8000;
 
                 // IME is processing this key
-                if (vk == VK_PROCESSKEY || m_ime.composing()) return;
+                if (vk == VK_PROCESSKEY || tc->ImeComposing()) return;
 
                 // Ctrl+C: copy if selection exists, otherwise send SIGINT
                 if (ctrl && !shift && vk == 'C') {
@@ -394,14 +334,40 @@ namespace winrt::GhosttyWin32::implementation
 
             tv.TabCloseRequested([this](muxc::TabView const& sender, muxc::TabViewTabCloseRequestedEventArgs const& args) {
                 auto item = args.Tab();
+                // Detach the control BEFORE removing it from TabView.
+                // Detach calls ISwapChainPanelNative2::SetSwapChainHandle(nullptr)
+                // on the inner panel, and that call AVs at +0x1F8 inside
+                // microsoft.ui.xaml.dll if the panel has already been
+                // unparented from the live visual tree (reproducer:
+                // Ctrl+Shift+W long-press across multiple tabs, where
+                // XAML hasn't finished processing the previous RemoveAt
+                // when the next Detach kicks in). Doing it pre-RemoveAt
+                // keeps the panel in the live tree for the duration of
+                // SetSwapChainHandle. Detach is idempotent, so the
+                // ~Tab → ~TerminalControl path runs it again as a no-op.
+                if (auto* t = m_tabs.FindByItem(item)) {
+                    if (auto* tc = t->ActiveControl()) {
+                        tc->Detach();
+                    }
+                }
                 uint32_t idx = 0;
                 if (sender.TabItems().IndexOf(item, idx)) {
                     sender.TabItems().RemoveAt(idx);
                 }
                 DwmFlush();              // wait for compositor to release
-                m_tabs.Remove(item);     // Tab destructor handles teardown
                 if (sender.TabItems().Size() == 0) {
+                    // Last tab: defer Tab object destruction to
+                    // ~MainWindow's m_tabs.Clear. Tearing down the
+                    // focused control synchronously here leaves XAML's
+                    // focus subsystem holding a stale pointer that AVs
+                    // at +0x1F8 once mw->Close() kicks off window
+                    // teardown — same path as a normal title-bar X
+                    // close, which works fine precisely because XAML
+                    // finishes its own focus cleanup before our
+                    // destructors run.
                     this->Close();
+                } else {
+                    m_tabs.Remove(item);
                 }
             });
 
@@ -529,23 +495,26 @@ namespace winrt::GhosttyWin32::implementation
                 if (g_mainWindow && surface) {
                     auto mw = g_mainWindow;
                     mw->DispatcherQueue().TryEnqueue([mw, surface]() {
-                        // Mirror the TabCloseRequested handler: pull the
-                        // TabViewItem out of the TabView, DwmFlush so the
-                        // compositor releases its reference, then drop the
-                        // owning Tab. The Tab destructor frees the ghostty
-                        // surface and closes the composition handle.
+                        // Mirror the TabCloseRequested handler — see
+                        // there for why Detach runs before RemoveAt and
+                        // why the last tab's Tab destruction is deferred
+                        // to ~MainWindow.
                         auto* t = mw->m_tabs.FindBySurface(surface);
                         if (!t) return;
                         auto item = t->Item();
+                        if (auto* tc = t->ActiveControl()) {
+                            tc->Detach();
+                        }
                         auto tv = mw->TabView();
                         uint32_t idx = 0;
                         if (tv.TabItems().IndexOf(item, idx)) {
                             tv.TabItems().RemoveAt(idx);
                         }
                         DwmFlush();
-                        mw->m_tabs.Remove(item);
                         if (tv.TabItems().Size() == 0) {
                             mw->Close();
+                        } else {
+                            mw->m_tabs.Remove(item);
                         }
                     });
                 }
@@ -664,15 +633,21 @@ namespace winrt::GhosttyWin32::implementation
                 auto* t = mw->m_tabs.FindById(id);
                 if (!t) return; // Tab already closed via the UI
                 auto item = t->Item();
+                // Same Detach-before-RemoveAt pattern as the other
+                // close paths — see TabCloseRequested.
+                if (auto* tc = t->ActiveControl()) {
+                    tc->Detach();
+                }
                 auto tv = mw->TabView();
                 uint32_t idx = 0;
                 if (tv.TabItems().IndexOf(item, idx)) {
                     tv.TabItems().RemoveAt(idx);
                 }
                 DwmFlush();
-                mw->m_tabs.Remove(item);
                 if (tv.TabItems().Size() == 0) {
                     mw->Close();
+                } else {
+                    mw->m_tabs.Remove(item);
                 }
             });
         };
@@ -720,16 +695,15 @@ namespace winrt::GhosttyWin32::implementation
         auto onActivated = [weakThis, itemStrong, tvStrong]() {
             auto self = weakThis.get();
             if (!self) return;
-            // Setting SelectedItem fires SelectionChanged (which focuses
-            // the active tab) and realises the TerminalControl into the
-            // visual tree (which fires its Loaded → self-focus). Both
-            // paths land focus where we want it, so no explicit Focus()
-            // call is needed here.
+            // Setting SelectedItem realises the TerminalControl into
+            // the visual tree, which fires its Loaded handler. Loaded
+            // builds the per-control CoreTextEditContext (deferred
+            // there because EditContext registration only takes hold
+            // for an element that's actually in the live tree),
+            // grants self-focus, and the resulting GotFocus calls
+            // NotifyFocusEnter — so IME engages without any explicit
+            // routing from this lambda.
             tvStrong.SelectedItem(itemStrong);
-            if (self->m_editContext) {
-                self->m_ime.reset();
-                self->m_editContext.NotifyFocusEnter();
-            }
             if (self->m_hwnd) ShowWindow(self->m_hwnd, SW_SHOW);
         };
 
@@ -803,9 +777,10 @@ namespace winrt::GhosttyWin32::implementation
             return;
         }
 
-        // Focus / SW_SHOW / SelectedItem / NotifyFocusEnter are deferred
-        // to the onActivated callback fired from Tab once ghostty has
-        // presented its first frame.
+        // SelectedItem / SW_SHOW are deferred to the onActivated
+        // callback fired from Tab once ghostty has presented its first
+        // frame; focus + IME activation chain off SelectedItem via the
+        // TerminalControl's Loaded → Focus → GotFocus path.
         m_tabs.Add(std::move(tab));
     }
 

--- a/GhosttyWin32App/MainWindow.xaml.cpp
+++ b/GhosttyWin32App/MainWindow.xaml.cpp
@@ -307,57 +307,10 @@ namespace winrt::GhosttyWin32::implementation
                 args.Handled(true);
             });
 
-            // Mouse input on root
-            root.PointerMoved([this](auto&&, winrt::Microsoft::UI::Xaml::Input::PointerRoutedEventArgs const& args) {
-                auto* tc = ActiveControl();
-                if (!tc || !tc->Surface()) return;
-                winrt::Microsoft::UI::Input::PointerPoint point = args.GetCurrentPoint(tc->InnerPanel());
-                winrt::Windows::Foundation::Point pos = point.Position();
-                ghostty_surface_mouse_pos(tc->Surface(), pos.X, pos.Y, currentMods());
-            });
-
-            root.PointerPressed([this](auto&&, winrt::Microsoft::UI::Xaml::Input::PointerRoutedEventArgs const& args) {
-                auto* tc = ActiveControl();
-                if (!tc || !tc->Surface()) return;
-                winrt::Microsoft::UI::Input::PointerPoint point = args.GetCurrentPoint(tc->InnerPanel());
-                winrt::Microsoft::UI::Input::PointerPointProperties props = point.Properties();
-                ghostty_input_mouse_button_e btn;
-                if (props.IsLeftButtonPressed()) btn = GHOSTTY_MOUSE_LEFT;
-                else if (props.IsRightButtonPressed()) {
-                    // Right-click: copy selection if exists
-                    if (ghostty_surface_has_selection(tc->Surface())) {
-                        ghostty_text_s text = {};
-                        if (ghostty_surface_read_selection(tc->Surface(), &text) && text.text && text.text_len > 0) {
-                            Clipboard::write(m_hwnd, Encoding::toUtf16(text.text, static_cast<int>(text.text_len)));
-                            ghostty_surface_free_text(tc->Surface(), &text);
-                        }
-                        ghostty_surface_mouse_button(tc->Surface(), GHOSTTY_MOUSE_PRESS, GHOSTTY_MOUSE_LEFT, (ghostty_input_mods_e)0);
-                        ghostty_surface_mouse_button(tc->Surface(), GHOSTTY_MOUSE_RELEASE, GHOSTTY_MOUSE_LEFT, (ghostty_input_mods_e)0);
-                        return;
-                    }
-                    btn = GHOSTTY_MOUSE_RIGHT;
-                }
-                else return; // Ignore middle-click and others
-                ghostty_surface_mouse_button(tc->Surface(), GHOSTTY_MOUSE_PRESS, btn, currentMods());
-            });
-
-            root.PointerReleased([this](auto&&, winrt::Microsoft::UI::Xaml::Input::PointerRoutedEventArgs const&) {
-                auto* tc = ActiveControl();
-                if (!tc || !tc->Surface()) return;
-                ghostty_surface_mouse_button(tc->Surface(), GHOSTTY_MOUSE_RELEASE, GHOSTTY_MOUSE_LEFT, currentMods());
-            });
-
-            root.PointerWheelChanged([this](auto&&, winrt::Microsoft::UI::Xaml::Input::PointerRoutedEventArgs const& args) {
-                auto* tc = ActiveControl();
-                if (!tc || !tc->Surface()) return;
-                winrt::Microsoft::UI::Input::PointerPoint point = args.GetCurrentPoint(tc->InnerPanel());
-                winrt::Microsoft::UI::Input::PointerPointProperties props = point.Properties();
-                int delta = props.MouseWheelDelta();
-                double scrollY = (double)delta / 120.0;
-                ghostty_input_scroll_mods_t smods = {};
-                ghostty_surface_mouse_scroll(tc->Surface(), 0, scrollY, smods);
-                args.Handled(true);
-            });
+            // Pointer routing now lives on TerminalControl — each
+            // instance hooks PointerMoved/Pressed/Released/Wheel on
+            // itself and forwards directly to its own ghostty surface.
+            // No window-level pointer handler is needed.
 
             root.KeyUp([this](auto&&, winrt::Microsoft::UI::Xaml::Input::KeyRoutedEventArgs const& args) {
                 auto* tc = ActiveControl();

--- a/GhosttyWin32App/MainWindow.xaml.h
+++ b/GhosttyWin32App/MainWindow.xaml.h
@@ -38,6 +38,10 @@ namespace winrt::GhosttyWin32::implementation
         void InitGhostty();
         void CreateTab();
         Tab* ActiveTab();
+        // Convenience wrapper around ActiveTab()->ActiveControl(). Most
+        // input/IME paths only care about the focused TerminalControl,
+        // not the surrounding Tab — this skips the double deref.
+        TerminalControl* ActiveControl();
         // Swaps MaximizeGlyph between Maximize (E922) and Restore (E923)
         // depending on the current OverlappedPresenter state.
         void UpdateMaximizeGlyph();

--- a/GhosttyWin32App/MainWindow.xaml.h
+++ b/GhosttyWin32App/MainWindow.xaml.h
@@ -3,7 +3,6 @@
 #include "MainWindow.g.h"
 #include "ghostty.h"
 #include "GhosttyApp.h"
-#include "ImeBuffer.h"
 #include "Tab.h"
 #include "TabFactory.h"
 #include "TabIdAllocator.h"
@@ -48,8 +47,6 @@ namespace winrt::GhosttyWin32::implementation
 
         std::unique_ptr<GhosttyApp> m_ghostty;
         HWND m_hwnd = nullptr;
-        winrt::Windows::UI::Text::Core::CoreTextEditContext m_editContext{ nullptr };
-        ImeBuffer m_ime;
         TabIdAllocator m_tabIds;
         Tabs m_tabs;
         // Constructed once ghostty is initialized — needs the app handle

--- a/GhosttyWin32App/SEHGuard.cpp
+++ b/GhosttyWin32App/SEHGuard.cpp
@@ -1,0 +1,12 @@
+#include "pch.h"
+#include "SEHGuard.h"
+
+extern "C" int RunSEHGuarded(void (*fn)(void*), void* ctx) noexcept {
+    __try {
+        fn(ctx);
+        return 1;
+    } __except (EXCEPTION_EXECUTE_HANDLER) {
+        OutputDebugStringA("SEH caught hardware exception inside guarded call\n");
+        return 0;
+    }
+}

--- a/GhosttyWin32App/SEHGuard.h
+++ b/GhosttyWin32App/SEHGuard.h
@@ -1,0 +1,19 @@
+#pragma once
+
+// SEH "trampoline": isolates a callable invocation behind __try/__except.
+// MSVC's /EHsc refuses __try in any function that has C++ unwinding
+// (i.e. anything dealing with C++ objects), so the unsafe call has to
+// be reached through a function pointer from a frame that holds only
+// raw C types. The C++ work lives in the callback we invoke through
+// `fn` — if that callback raises a hardware exception (AV, illegal
+// instruction, etc.) it's swallowed here and `0` is returned.
+//
+// Use case: wrap calls into known-buggy XAML internals (e.g. rapid-
+// teardown SetSwapChainHandle) or third-party drivers (NVIDIA
+// Present-time AVs) where the alternative is the whole process going
+// down for an exception we have no way to fix.
+//
+// Returns 1 on normal completion, 0 if the SEH handler caught a
+// hardware exception. Either way the caller proceeds — the trampoline
+// itself never throws.
+extern "C" int RunSEHGuarded(void (*fn)(void*), void* ctx) noexcept;

--- a/GhosttyWin32App/Tab.h
+++ b/GhosttyWin32App/Tab.h
@@ -78,14 +78,14 @@ public:
     Microsoft::UI::Xaml::Controls::TabViewItem const& Item() const noexcept { return m_item; }
     TabId Id() const noexcept { return m_id; }
 
-    void Focus() {
-        // TerminalControl is a UserControl with IsTabStop=true, so
-        // unlike a bare SwapChainPanel this Focus call actually moves
-        // focus reliably. Future: focus the active leaf of the pane
-        // tree, not just the single control.
-        if (m_control) {
-            m_control.Focus(Microsoft::UI::Xaml::FocusState::Programmatic);
-        }
+    // Returns whether XAML accepted the focus request (used in
+    // diagnostics for the tab-switch focus path). TerminalControl is a
+    // UserControl with IsTabStop=true, so unlike a bare SwapChainPanel
+    // this Focus call actually moves focus reliably. Future: focus the
+    // active leaf of the pane tree, not just the single control.
+    bool Focus() {
+        if (!m_control) return false;
+        return m_control.Focus(Microsoft::UI::Xaml::FocusState::Programmatic);
     }
 
 private:

--- a/GhosttyWin32App/Tab.h
+++ b/GhosttyWin32App/Tab.h
@@ -1,95 +1,63 @@
 #pragma once
 
-#include "ghostty.h"
 #include "TabId.h"
-#include <microsoft.ui.xaml.media.dxinterop.h>
+#include "TerminalControl.xaml.h"
 #include <winrt/Microsoft.UI.Xaml.h>
 #include <winrt/Microsoft.UI.Xaml.Controls.h>
-#include <winrt/Microsoft.UI.Dispatching.h>
-#include <atomic>
-#include <functional>
-#include <memory>
 
 namespace winrt::GhosttyWin32::implementation {
 
-// Pending UI-thread "attach this swap chain handle to the panel" request.
-// Created on the UI thread inside TabFactory::Make, kept alive by both
-// the Tab (so it can cancel on teardown) and the renderer-thread
-// callback (so it survives the cross-thread hop). The cancelled flag is
-// the lifetime interlock: ~Tab sets it before the swap chain is
-// destroyed; the queued SetSwapChainHandle bails on it before touching
-// the (now dead) handle.
-struct SwapChainAttachRequest {
-    HANDLE handle{ nullptr };
-    Microsoft::UI::Xaml::Controls::SwapChainPanel panel{ nullptr };
-    Microsoft::UI::Dispatching::DispatcherQueue dispatcher{ nullptr };
-    std::atomic<bool> cancelled{ false };
-    // Called on the UI thread after SetSwapChainHandle has bound the swap
-    // chain (which now has its first frame presented) to the panel. The
-    // host uses this to switch the TabView, focus the panel, etc., so
-    // the panel only becomes visible once it actually has content
-    // (issue #22).
-    std::function<void()> onActivated;
-};
-
-// One terminal tab. Existence implies fully-formed: panel attached to a
-// composition surface, ghostty surface created, SizeChanged hooked.
+// One tab in the window's TabView.
+//
+// Conceptually a tab is the *root of a pane tree*: a container holding
+// one or more TerminalControls (one per pane) plus the splitter
+// metadata that describes how they're laid out. Every other terminal
+// emulator that supports split panes (Windows Terminal, Alacritty,
+// macOS Terminal, GTK Ghostty) follows this shape:
+//
+//   Tab
+//    └── PaneTree
+//          ├── Leaf: TerminalControl
+//          └── Branch: split{H/V, child1, child2}
+//                ├── Leaf: TerminalControl
+//                └── Leaf: TerminalControl
+//
+// Today we don't yet implement splits, so each Tab holds exactly one
+// TerminalControl directly. The class deliberately exposes only the
+// "tab-level" API (active control, focus, id, item) and avoids
+// delegating per-control accessors like Surface() — once panes land,
+// those would silently change meaning ("the surface" becomes "which
+// surface?") and every caller would need re-auditing. By forcing
+// callers to go through ActiveControl() now, the eventual switch to
+// "the focused leaf in the pane tree" is mechanical: only ActiveControl
+// changes implementation, no caller-side audit needed.
 //
 // Construction is just validation + member init — all failable work
-// (creating the surface handle, attaching it, calling ghostty_surface_new)
-// lives in TabFactory::Make. If you have a Tab*, you can operate on it
-// freely without worrying about half-built state.
+// (creating the surface handle, attaching it, calling
+// ghostty_surface_new) lives in TabFactory::Make. If you have a Tab*,
+// you can operate on it freely without worrying about half-built state.
 class Tab {
 public:
-    // Called by TabFactory::Make once all resources are acquired. Public
-    // so std::make_unique can see it; the constructor still validates
-    // its inputs and throws on missing resources, so callers outside the
-    // factory will get a loud failure rather than a silent half-built
-    // Tab.
-    Tab(Microsoft::UI::Xaml::Controls::SwapChainPanel panel,
+    Tab(winrt::GhosttyWin32::TerminalControl control,
         Microsoft::UI::Xaml::Controls::TabViewItem item,
-        HANDLE surfaceHandle,
-        ghostty_surface_t surface,
-        std::shared_ptr<SwapChainAttachRequest> attachRequest,
         TabId id)
-        : m_panel(std::move(panel))
+        : m_control(std::move(control))
         , m_item(std::move(item))
-        , m_surfaceHandle(surfaceHandle)
-        , m_surface(surface)
-        , m_attachRequest(std::move(attachRequest))
         , m_id(id)
     {
-        if (!m_panel || !m_item || !m_surfaceHandle || !m_surface) {
+        if (!m_control || !m_item) {
             throw winrt::hresult_error(E_INVALIDARG, L"Tab: missing resource");
         }
-        ghostty_surface_t s = m_surface;
-        m_sizeChangedToken = m_panel.SizeChanged(
-            [s](auto&&, Microsoft::UI::Xaml::SizeChangedEventArgs const& args) {
-                auto sz = args.NewSize();
-                uint32_t w = static_cast<uint32_t>(sz.Width);
-                uint32_t h = static_cast<uint32_t>(sz.Height);
-                if (w > 0 && h > 0) {
-                    ghostty_surface_set_size(s, w, h);
-                }
-            });
     }
 
     ~Tab() {
-        // Cancel the pending SetSwapChainHandle dispatch before we tear
-        // down the swap chain — otherwise the queued call could attach a
-        // freed handle to the panel after we've destroyed everything.
-        if (m_attachRequest) m_attachRequest->cancelled.store(true);
-
-        if (m_panel) {
-            if (m_sizeChangedToken.value != 0) {
-                m_panel.SizeChanged(m_sizeChangedToken);
-            }
-            if (auto native2 = m_panel.try_as<ISwapChainPanelNative2>()) {
-                native2->SetSwapChainHandle(nullptr);
-            }
+        // Detach every TerminalControl in the tab — surface free, swap
+        // chain release, composition handle close, SizeChanged unhook
+        // all live on the control. Today there's a single control;
+        // when pane support lands this becomes a tree walk.
+        if (auto* c = ActiveControl()) {
+            c->Detach();
         }
-        if (m_surface) ghostty_surface_free(m_surface);
-        if (m_surfaceHandle) CloseHandle(m_surfaceHandle);
     }
 
     Tab(const Tab&) = delete;
@@ -97,52 +65,35 @@ public:
     Tab(Tab&&) = delete;
     Tab& operator=(Tab&&) = delete;
 
-    ghostty_surface_t Surface() const noexcept { return m_surface; }
-    Microsoft::UI::Xaml::Controls::SwapChainPanel const& Panel() const noexcept { return m_panel; }
+    // Returns the currently-focused TerminalControl in this tab. Right
+    // now that's the single control; once panes land it'll be the
+    // focused leaf in the pane tree. Callers that need the surface,
+    // composition handle, or inner SwapChainPanel should go through
+    // here so they keep working when the tree gains additional leaves.
+    implementation::TerminalControl* ActiveControl() const noexcept {
+        if (!m_control) return nullptr;
+        return winrt::get_self<implementation::TerminalControl>(m_control);
+    }
+
     Microsoft::UI::Xaml::Controls::TabViewItem const& Item() const noexcept { return m_item; }
-    HANDLE SurfaceHandle() const noexcept { return m_surfaceHandle; }
     TabId Id() const noexcept { return m_id; }
 
     void Focus() {
-        m_panel.Focus(Microsoft::UI::Xaml::FocusState::Programmatic);
-    }
-
-    // Renderer-thread callback from ghostty: the swap chain is now bound to
-    // our surface handle, so it's safe to call SetSwapChainHandle. We only
-    // hop to the UI thread and queue the actual API call — keep this fast.
-    // Public so TabFactory::Make can register it as cfg.swap_chain_ready_cb;
-    // ghostty calls it directly without going through any Tab instance.
-    static void OnSwapChainReady(void* userdata) noexcept {
-        auto* raw = reinterpret_cast<std::shared_ptr<SwapChainAttachRequest>*>(userdata);
-        std::shared_ptr<SwapChainAttachRequest> req = *raw;
-        delete raw;
-        if (!req || !req->dispatcher) return;
-        try {
-            req->dispatcher.TryEnqueue([req]() {
-                if (req->cancelled.load()) return;
-                // Bind the swap chain (which now has at least one presented
-                // frame) to the panel, then run the host's activation work.
-                // Order: handle attach → onActivated. Host's onActivated
-                // typically calls SelectedItem to make the panel visible
-                // — by then the panel already has displayable content,
-                // closing the flicker window of issue #22.
-                if (auto native2 = req->panel.try_as<ISwapChainPanelNative2>()) {
-                    native2->SetSwapChainHandle(req->handle);
-                }
-                if (req->onActivated) req->onActivated();
-            });
-        } catch (...) {
-            // Window torn down — request is implicitly cancelled.
+        // TerminalControl is a UserControl with IsTabStop=true, so
+        // unlike a bare SwapChainPanel this Focus call actually moves
+        // focus reliably. Future: focus the active leaf of the pane
+        // tree, not just the single control.
+        if (m_control) {
+            m_control.Focus(Microsoft::UI::Xaml::FocusState::Programmatic);
         }
     }
 
 private:
-    Microsoft::UI::Xaml::Controls::SwapChainPanel m_panel{ nullptr };
+    // Today: the single TerminalControl that fills the tab content.
+    // Future: the root of a pane tree (variant<TerminalControl, Pane>),
+    // where Pane itself holds two children + split orientation.
+    winrt::GhosttyWin32::TerminalControl m_control{ nullptr };
     Microsoft::UI::Xaml::Controls::TabViewItem m_item{ nullptr };
-    HANDLE m_surfaceHandle{ nullptr };
-    ghostty_surface_t m_surface{ nullptr };
-    winrt::event_token m_sizeChangedToken{};
-    std::shared_ptr<SwapChainAttachRequest> m_attachRequest;
     TabId m_id{};
 };
 

--- a/GhosttyWin32App/TabFactory.h
+++ b/GhosttyWin32App/TabFactory.h
@@ -134,7 +134,7 @@ public:
         // Hand surface ownership to the control. From here on the
         // control's Detach() (called from Tab::~Tab) is responsible for
         // freeing the surface and closing the handle.
-        controlImpl->Attach(surface, handle, attach);
+        controlImpl->Attach(surface, handle, m_hwnd, attach);
 
         try {
             return std::make_unique<Tab>(std::move(control), std::move(item), id);

--- a/GhosttyWin32App/TabFactory.h
+++ b/GhosttyWin32App/TabFactory.h
@@ -133,8 +133,10 @@ public:
 
         // Hand surface ownership to the control. From here on the
         // control's Detach() (called from Tab::~Tab) is responsible for
-        // freeing the surface and closing the handle.
-        controlImpl->Attach(surface, handle, m_hwnd, attach);
+        // freeing the surface and closing the handle. The app handle
+        // is needed inside the control to drive ghostty_app_tick after
+        // IME / keyboard input commits.
+        controlImpl->Attach(m_app, surface, handle, m_hwnd, attach);
 
         try {
             return std::make_unique<Tab>(std::move(control), std::move(item), id);

--- a/GhosttyWin32App/TabFactory.h
+++ b/GhosttyWin32App/TabFactory.h
@@ -3,6 +3,7 @@
 #include "Tab.h"
 #include "TabId.h"
 #include "TabIdAllocator.h"
+#include "TerminalControl.xaml.h"
 #include "ghostty.h"
 #include <microsoft.ui.xaml.media.dxinterop.h>
 #include <dcomp.h>
@@ -32,30 +33,45 @@ public:
     TabFactory(TabFactory&&) = delete;
     TabFactory& operator=(TabFactory&&) = delete;
 
-    // Build a fully-formed Tab from a panel + item. Returns nullptr on
-    // failure (after cleaning up any partially-acquired resources). Call
-    // on the UI thread; the panel does NOT need to be in the visual tree
-    // yet — see issue #22, where making the panel visible before it had
-    // displayable content produced a flicker. The optional onActivated
-    // callback runs on the UI thread once ghostty has presented its
-    // first frame and we've bound the swap chain to the panel; the host
-    // uses it to switch the TabView so the panel becomes visible only
-    // with real content.
+    // Build a fully-formed Tab from a pre-created TerminalControl + item.
+    // The caller is expected to have already wired the control into the
+    // visual tree (item.Content(control) + tv.TabItems().Append(item))
+    // so the inner panel's DispatcherQueue is reachable.
     //
-    // Ordering: the DComp surface handle is bound to the panel only AFTER
-    // ghostty's renderer thread has presented at least one real frame —
-    // see Tab::OnSwapChainReady. ghostty fires the swap-chain-ready
-    // callback from drawFrameEnd (post first present), not from swap-chain
-    // creation, so the back buffer is guaranteed to have displayable
-    // content by the time we attach.
+    // Returns nullptr on failure (after cleaning up any partially-
+    // acquired resources). Call on the UI thread; the panel does NOT
+    // need to be in the visual tree yet — see issue #22, where making
+    // the panel visible before it had displayable content produced a
+    // flicker. The optional onActivated callback runs on the UI thread
+    // once ghostty has presented its first frame and we've bound the
+    // swap chain to the panel; the host uses it to switch the TabView
+    // so the panel becomes visible only with real content.
+    //
+    // Ordering: the DComp surface handle is bound to the panel only
+    // AFTER ghostty's renderer thread has presented at least one real
+    // frame — see TerminalControl::OnSwapChainReady. ghostty fires the
+    // swap-chain-ready callback from drawFrameEnd (post first present),
+    // not from swap-chain creation, so the back buffer is guaranteed to
+    // have displayable content by the time we attach.
     std::unique_ptr<Tab> Make(
-        Microsoft::UI::Xaml::Controls::SwapChainPanel panel,
+        winrt::GhosttyWin32::TerminalControl control,
         Microsoft::UI::Xaml::Controls::TabViewItem item,
         std::function<void()> onActivated = {},
         uint32_t initialWidth = 0,
         uint32_t initialHeight = 0)
     {
         constexpr DWORD COMPOSITIONSURFACE_ALL_ACCESS = 0x0003L;
+
+        auto* controlImpl = winrt::get_self<implementation::TerminalControl>(control);
+        if (!controlImpl) {
+            OutputDebugStringA("TabFactory::Make: get_self<TerminalControl> FAILED\n");
+            return nullptr;
+        }
+        auto panel = controlImpl->InnerPanel();
+        if (!panel) {
+            OutputDebugStringA("TabFactory::Make: TerminalControl has no inner panel\n");
+            return nullptr;
+        }
 
         HANDLE handle = nullptr;
         if (FAILED(DCompositionCreateSurfaceHandle(COMPOSITIONSURFACE_ALL_ACCESS, nullptr, &handle))) {
@@ -68,13 +84,14 @@ public:
         attach->panel = panel;
         attach->dispatcher = panel.DispatcherQueue();
         attach->onActivated = std::move(onActivated);
-        // Heap-allocated owning shared_ptr handed to ghostty; it'll come back
-        // through OnSwapChainReady (or be deleted here if surface_new fails).
+        // Heap-allocated owning shared_ptr handed to ghostty; it'll
+        // come back through OnSwapChainReady (or be deleted here if
+        // surface_new fails).
         auto* attachOwned = new std::shared_ptr<SwapChainAttachRequest>(attach);
 
         // ID for the close-surface callback path. Allocated before
-        // surface_new because cfg.userdata must be set up-front; the value
-        // is opaque to ghostty and travels back to us through
+        // surface_new because cfg.userdata must be set up-front; the
+        // value is opaque to ghostty and travels back to us through
         // close_surface_cb.
         TabId id = m_idAllocator.Allocate();
 
@@ -82,19 +99,20 @@ public:
         cfg.platform_tag = GHOSTTY_PLATFORM_WINDOWS;
         cfg.platform.windows.hwnd = m_hwnd;
         cfg.platform.windows.composition_surface_handle = handle;
-        cfg.platform.windows.swap_chain_ready_cb = &Tab::OnSwapChainReady;
+        cfg.platform.windows.swap_chain_ready_cb = &TerminalControl::OnSwapChainReady;
         cfg.platform.windows.swap_chain_ready_userdata = attachOwned;
         cfg.userdata = id.ToUserdata();
-        // Initial swap chain size: prefer the host's caller-supplied estimate
-        // (typically the active tab's panel size, since the new panel will
-        // land in the same TabView content area), then fall back to the
-        // panel's own ActualWidth/Height. With deferred SelectedItem (issue
-        // #22) the panel isn't in the visual tree yet so its ActualWidth is
-        // 0 — without the host hint, ghostty would fall back further to the
-        // main window's full client rect, which is taller than the actual
-        // panel area by the tab strip height. That mismatch causes a
-        // visible "stretch then resize" when the panel becomes visible
-        // and SizeChanged fires.
+        // Initial swap chain size: prefer the host's caller-supplied
+        // estimate (typically the active tab's panel size, since the
+        // new panel will land in the same TabView content area), then
+        // fall back to the panel's own ActualWidth/Height. With
+        // deferred SelectedItem (issue #22) the panel isn't in the
+        // visual tree yet so its ActualWidth is 0 — without the host
+        // hint, ghostty would fall back further to the main window's
+        // full client rect, which is taller than the actual panel area
+        // by the tab strip height. That mismatch causes a visible
+        // "stretch then resize" when the panel becomes visible and
+        // SizeChanged fires.
         uint32_t initW = initialWidth ? initialWidth
                                       : static_cast<uint32_t>(panel.ActualWidth());
         uint32_t initH = initialHeight ? initialHeight
@@ -113,15 +131,17 @@ public:
             return nullptr;
         }
 
+        // Hand surface ownership to the control. From here on the
+        // control's Detach() (called from Tab::~Tab) is responsible for
+        // freeing the surface and closing the handle.
+        controlImpl->Attach(surface, handle, attach);
+
         try {
-            return std::make_unique<Tab>(std::move(panel), std::move(item), handle, surface, std::move(attach), id);
+            return std::make_unique<Tab>(std::move(control), std::move(item), id);
         } catch (winrt::hresult_error const&) {
-            // Tab construction failed but the renderer thread may already
-            // have fired (or be about to fire) OnSwapChainReady. Cancel
-            // first, then tear down what we have.
-            attach->cancelled.store(true);
-            ghostty_surface_free(surface);
-            CloseHandle(handle);
+            // Tab construction validation failed. Detach synchronously
+            // so the surface/handle don't leak.
+            controlImpl->Detach();
             return nullptr;
         }
     }

--- a/GhosttyWin32App/Tabs.h
+++ b/GhosttyWin32App/Tabs.h
@@ -36,10 +36,16 @@ public:
         return nullptr;
     }
 
+    // O(N) over tabs; with future pane support this would walk the
+    // pane tree of each tab. Today every tab has at most one
+    // TerminalControl, so it's a flat scan.
     Tab* FindBySurface(ghostty_surface_t surface) const {
         if (!surface) return nullptr;
         for (auto& t : m_tabs) {
-            if (t && t->Surface() == surface) return t.get();
+            if (!t) continue;
+            if (auto* c = t->ActiveControl(); c && c->Surface() == surface) {
+                return t.get();
+            }
         }
         return nullptr;
     }

--- a/GhosttyWin32App/TerminalControl.idl
+++ b/GhosttyWin32App/TerminalControl.idl
@@ -1,0 +1,8 @@
+namespace GhosttyWin32
+{
+    [default_interface]
+    runtimeclass TerminalControl : Microsoft.UI.Xaml.Controls.UserControl
+    {
+        TerminalControl();
+    }
+}

--- a/GhosttyWin32App/TerminalControl.xaml
+++ b/GhosttyWin32App/TerminalControl.xaml
@@ -9,5 +9,7 @@
     IsTabStop="True"
     AllowFocusOnInteraction="True"
     IsHitTestVisible="True">
-    <SwapChainPanel x:Name="Panel" />
+    <SwapChainPanel x:Name="Panel"
+                    IsTabStop="False"
+                    AllowFocusOnInteraction="False" />
 </UserControl>

--- a/GhosttyWin32App/TerminalControl.xaml
+++ b/GhosttyWin32App/TerminalControl.xaml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<UserControl
+    x:Class="GhosttyWin32.TerminalControl"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    IsTabStop="True"
+    AllowFocusOnInteraction="True"
+    IsHitTestVisible="True">
+    <SwapChainPanel x:Name="Panel" />
+</UserControl>

--- a/GhosttyWin32App/TerminalControl.xaml.cpp
+++ b/GhosttyWin32App/TerminalControl.xaml.cpp
@@ -97,6 +97,17 @@ namespace winrt::GhosttyWin32::implementation
         PointerPressed([weakSelf](auto&&, muxi::PointerRoutedEventArgs const& args) {
             auto self = weakSelf.get();
             if (!self || !self->m_surface) return;
+            // Mark Handled up front so the event doesn't bubble into
+            // ancestor focus-management code (TabViewItem / TabView /
+            // root content presenter, depending on layout). Without
+            // this, after our explicit Focus(Pointer) call XAML's
+            // default routed-event handling on the bubble path moves
+            // logical focus off the TerminalControl, LostFocus fires,
+            // and KeyDown stops being delivered until focus is restored
+            // some other way (alt-tab, Tab key, new tab). Calling Focus
+            // here covers initial focus claim; Handled(true) keeps it.
+            self->Focus(Microsoft::UI::Xaml::FocusState::Pointer);
+            args.Handled(true);
             muix::PointerPoint point = args.GetCurrentPoint(self->Panel());
             muix::PointerPointProperties props = point.Properties();
             ghostty_input_mouse_button_e btn;
@@ -124,10 +135,11 @@ namespace winrt::GhosttyWin32::implementation
             ghostty_surface_mouse_button(self->m_surface, GHOSTTY_MOUSE_PRESS, btn, currentMods());
         });
 
-        PointerReleased([weakSelf](auto&&, muxi::PointerRoutedEventArgs const&) {
+        PointerReleased([weakSelf](auto&&, muxi::PointerRoutedEventArgs const& args) {
             auto self = weakSelf.get();
             if (!self || !self->m_surface) return;
             ghostty_surface_mouse_button(self->m_surface, GHOSTTY_MOUSE_RELEASE, GHOSTTY_MOUSE_LEFT, currentMods());
+            args.Handled(true);
         });
 
         PointerWheelChanged([weakSelf](auto&&, muxi::PointerRoutedEventArgs const& args) {

--- a/GhosttyWin32App/TerminalControl.xaml.cpp
+++ b/GhosttyWin32App/TerminalControl.xaml.cpp
@@ -33,16 +33,57 @@ namespace winrt::GhosttyWin32::implementation
 
         auto weakSelf = get_weak();
 
-        // Self-focus on Loaded. SelectedItem-driven focus from the
-        // outside (MainWindow's SelectionChanged handler) fires while
-        // TabView's content presenter is still swapping us in, and
-        // Focus() returns false before layout completes. Loaded fires
-        // only once the control is actually in the live visual tree
-        // and measured — at that point Focus succeeds without retry.
+        // Set up IME + self-focus on Loaded. Three reasons this all
+        // happens here rather than in Attach or the ctor:
+        //
+        //   * SelectedItem-driven focus from the outside (MainWindow's
+        //     SelectionChanged handler) fires while TabView's content
+        //     presenter is still swapping us in, and Focus() returns
+        //     false before layout completes. Loaded fires only once
+        //     the control is actually in the live visual tree and
+        //     measured — at that point Focus succeeds without retry.
+        //
+        //   * CoreTextEditContext registration with the OS-side text-
+        //     services manager only takes effect when the EditContext
+        //     is created against an element that's in the live visual
+        //     tree. Creating it earlier (in Attach, before
+        //     TabView.SelectedItem realises us) silently fails to
+        //     register, so NotifyFocusEnter doesn't engage IME — the
+        //     symptom was "first tab can't toggle 半角/全角 until a
+        //     second tab is created."
+        //
+        //   * Loaded fires once per control, after both of the above
+        //     conditions are true, so the setup is naturally a single
+        //     idempotent step.
         Loaded([weakSelf](auto&&, auto&&) {
             auto self = weakSelf.get();
             if (!self) return;
+            if (!self->m_editContext) {
+                self->SetupImeContext();
+            }
             self->Focus(Microsoft::UI::Xaml::FocusState::Programmatic);
+        });
+
+        // Mirror keyboard-focus state into the EditContext. Tab
+        // switches inside the same window trip these (the losing tab's
+        // TerminalControl LostFocus, the gaining tab's GotFocus) so
+        // IME composition is naturally scoped to the focused tab. A
+        // composition in flight on tab A pauses at LostFocus and the
+        // OS does not deliver further updates until tab A's
+        // EditContext is reactivated. Window-level activation crosses
+        // the boundary without firing these events; MainWindow's
+        // Activated handler routes through NotifyImeFocusEnter/Leave
+        // for that case.
+        GotFocus([weakSelf](auto&&, auto&&) {
+            auto self = weakSelf.get();
+            if (!self || !self->m_editContext) return;
+            self->m_editContext.NotifyFocusEnter();
+        });
+
+        LostFocus([weakSelf](auto&&, auto&&) {
+            auto self = weakSelf.get();
+            if (!self || !self->m_editContext) return;
+            self->m_editContext.NotifyFocusLeave();
         });
 
         PointerMoved([weakSelf](auto&&, muxi::PointerRoutedEventArgs const& args) {
@@ -110,15 +151,22 @@ namespace winrt::GhosttyWin32::implementation
         Detach();
     }
 
-    void TerminalControl::Attach(ghostty_surface_t surface,
+    void TerminalControl::Attach(ghostty_app_t app,
+                                 ghostty_surface_t surface,
                                  HANDLE compositionHandle,
                                  HWND hostHwnd,
                                  std::shared_ptr<SwapChainAttachRequest> attachRequest)
     {
+        m_app = app;
         m_surface = surface;
         m_compositionHandle = compositionHandle;
         m_hostHwnd = hostHwnd;
         m_attachRequest = std::move(attachRequest);
+        // IME setup is deferred to Loaded — see the Loaded handler
+        // comment in the ctor. CreateEditContext only registers
+        // properly when the owning element is in the live visual
+        // tree, which doesn't happen until TabView.SelectedItem
+        // realises us.
 
         // Capture a weak_ref to self instead of `this` or the raw
         // surface pointer. Detach unhooks SizeChanged before
@@ -150,14 +198,30 @@ namespace winrt::GhosttyWin32::implementation
             m_attachRequest.reset();
         }
 
+        if (m_editContext) {
+            // Best-effort: tell the OS the EditContext is leaving focus
+            // before we drop our reference. Skipping this leaves the
+            // text-services manager holding a stale focus pointer until
+            // GC catches up.
+            m_editContext.NotifyFocusLeave();
+            m_editContext = nullptr;
+        }
+
         if (auto panel = Panel()) {
             if (m_sizeChangedToken.value != 0) {
                 panel.SizeChanged(m_sizeChangedToken);
                 m_sizeChangedToken = {};
             }
-            if (auto native2 = panel.try_as<ISwapChainPanelNative2>()) {
-                native2->SetSwapChainHandle(nullptr);
-            }
+            // We deliberately skip the symmetric
+            // ISwapChainPanelNative2::SetSwapChainHandle(nullptr) that
+            // mirrors the attach in OnSwapChainReady. Calling it
+            // during rapid Ctrl+Shift+W tab teardown reads a null
+            // compositor visual at +0x1F8 inside microsoft.ui.xaml.dll
+            // and AVs. The panel keeps a reference to the (about-to-
+            // be-closed) composition handle until the impl is
+            // released; XAML's own panel-cleanup path runs at that
+            // point with the kernel handle already invalid, which it
+            // tolerates without faulting.
         }
         if (m_surface) {
             ghostty_surface_free(m_surface);
@@ -167,6 +231,125 @@ namespace winrt::GhosttyWin32::implementation
             CloseHandle(m_compositionHandle);
             m_compositionHandle = nullptr;
         }
+        m_app = nullptr;
+    }
+
+    void TerminalControl::SetupImeContext()
+    {
+        namespace txtCore = winrt::Windows::UI::Text::Core;
+        // CoreTextServicesManager.GetForCurrentView lives at the view
+        // (~window) level, but CreateEditContext spins up an
+        // independent context — multiple controls in the same window
+        // each get their own. The OS arbitrates which one receives
+        // input via NotifyFocusEnter/Leave; we drive those on tab
+        // switch (GotFocus/LostFocus) and on window activation
+        // (forwarded from MainWindow via NotifyImeFocusEnter/Leave).
+        auto manager = txtCore::CoreTextServicesManager::GetForCurrentView();
+        m_editContext = manager.CreateEditContext();
+        m_editContext.InputPaneDisplayPolicy(txtCore::CoreTextInputPaneDisplayPolicy::Manual);
+        m_editContext.InputScope(txtCore::CoreTextInputScope::Default);
+
+        auto weakSelf = get_weak();
+
+        m_editContext.TextRequested([weakSelf](
+            txtCore::CoreTextEditContext const&,
+            txtCore::CoreTextTextRequestedEventArgs const& args) {
+            auto self = weakSelf.get();
+            if (!self) return;
+            args.Request().Text(winrt::hstring(self->m_ime.paddedText()));
+        });
+
+        m_editContext.SelectionRequested([weakSelf](
+            txtCore::CoreTextEditContext const&,
+            txtCore::CoreTextSelectionRequestedEventArgs const& args) {
+            auto self = weakSelf.get();
+            if (!self) return;
+            int32_t pos = self->m_ime.selectionPosition();
+            args.Request().Selection({ pos, pos });
+        });
+
+        m_editContext.TextUpdating([weakSelf](
+            txtCore::CoreTextEditContext const&,
+            txtCore::CoreTextTextUpdatingEventArgs const& args) {
+            auto self = weakSelf.get();
+            if (!self || !self->m_surface) return;
+            auto range = args.Range();
+            auto newText = args.Text();
+            self->m_ime.applyTextUpdate(range.StartCaretPosition, range.EndCaretPosition,
+                                        newText.c_str(), newText.size());
+            if (self->m_ime.composing()) {
+                if (self->m_ime.text().empty()) {
+                    ghostty_surface_preedit(self->m_surface, nullptr, 0);
+                } else {
+                    auto utf8 = Encoding::toUtf8(self->m_ime.text());
+                    if (!utf8.empty())
+                        ghostty_surface_preedit(self->m_surface, utf8.c_str(), utf8.size());
+                }
+            }
+            if (self->m_app) ghostty_app_tick(self->m_app);
+            ghostty_surface_refresh(self->m_surface);
+        });
+
+        m_editContext.CompositionStarted([weakSelf](
+            txtCore::CoreTextEditContext const&,
+            txtCore::CoreTextCompositionStartedEventArgs const&) {
+            auto self = weakSelf.get();
+            if (!self) return;
+            self->m_ime.compositionStarted();
+        });
+
+        m_editContext.CompositionCompleted([weakSelf](
+            txtCore::CoreTextEditContext const&,
+            txtCore::CoreTextCompositionCompletedEventArgs const&) {
+            auto self = weakSelf.get();
+            if (!self) return;
+            if (self->m_surface) {
+                ghostty_surface_preedit(self->m_surface, nullptr, 0);
+                auto utf8 = Encoding::toUtf8(self->m_ime.text());
+                if (!utf8.empty()) {
+                    ghostty_surface_text(self->m_surface, utf8.c_str(), utf8.size());
+                }
+                if (self->m_app) ghostty_app_tick(self->m_app);
+                ghostty_surface_refresh(self->m_surface);
+            }
+            self->m_ime.compositionCompleted();
+        });
+
+        m_editContext.LayoutRequested([weakSelf](
+            txtCore::CoreTextEditContext const&,
+            txtCore::CoreTextLayoutRequestedEventArgs const& args) {
+            auto self = weakSelf.get();
+            if (!self || !self->m_surface || !self->m_hostHwnd) return;
+            double x = 0, y = 0, w = 0, h = 0;
+            ghostty_surface_ime_point(self->m_surface, &x, &y, &w, &h);
+            POINT screenPt = { (LONG)x, (LONG)y };
+            ClientToScreen(self->m_hostHwnd, &screenPt);
+            winrt::Windows::Foundation::Rect bounds{
+                (float)screenPt.x, (float)screenPt.y, (float)w, (float)h };
+            args.Request().LayoutBounds().ControlBounds(bounds);
+            args.Request().LayoutBounds().TextBounds(bounds);
+        });
+
+        m_editContext.FocusRemoved([weakSelf](
+            txtCore::CoreTextEditContext const&, auto&&) {
+            auto self = weakSelf.get();
+            if (!self) return;
+            if (self->m_ime.composing()) {
+                self->m_ime.reset();
+                if (self->m_surface)
+                    ghostty_surface_preedit(self->m_surface, nullptr, 0);
+            }
+        });
+    }
+
+    void TerminalControl::NotifyImeFocusEnter()
+    {
+        if (m_editContext) m_editContext.NotifyFocusEnter();
+    }
+
+    void TerminalControl::NotifyImeFocusLeave()
+    {
+        if (m_editContext) m_editContext.NotifyFocusLeave();
     }
 
     void TerminalControl::OnSwapChainReady(void* userdata) noexcept

--- a/GhosttyWin32App/TerminalControl.xaml.cpp
+++ b/GhosttyWin32App/TerminalControl.xaml.cpp
@@ -19,19 +19,44 @@ namespace winrt::GhosttyWin32::implementation
         // taken relative to the inner panel (== this UserControl's
         // dimensions today, but Panel() is the explicit truth) so they
         // match what ghostty's renderer expects.
+        //
+        // The lambdas capture a weak_ref instead of `this`. XAML can
+        // route a final pointer event during window/control teardown
+        // after the impl has started destructing — a raw `this` capture
+        // would dereference a dangling pointer (the AV symptom we hit:
+        // microsoft.ui.xaml.dll reading near-null at the m_surface
+        // offset). The weak_ref short-circuits cleanly when the impl is
+        // gone; weakSelf.get() returns a strong impl com_ptr that
+        // exposes private members directly via operator->.
         namespace muxi = winrt::Microsoft::UI::Xaml::Input;
         namespace muix = winrt::Microsoft::UI::Input;
 
-        PointerMoved([this](auto&&, muxi::PointerRoutedEventArgs const& args) {
-            if (!m_surface) return;
-            muix::PointerPoint point = args.GetCurrentPoint(Panel());
-            auto pos = point.Position();
-            ghostty_surface_mouse_pos(m_surface, pos.X, pos.Y, currentMods());
+        auto weakSelf = get_weak();
+
+        // Self-focus on Loaded. SelectedItem-driven focus from the
+        // outside (MainWindow's SelectionChanged handler) fires while
+        // TabView's content presenter is still swapping us in, and
+        // Focus() returns false before layout completes. Loaded fires
+        // only once the control is actually in the live visual tree
+        // and measured — at that point Focus succeeds without retry.
+        Loaded([weakSelf](auto&&, auto&&) {
+            auto self = weakSelf.get();
+            if (!self) return;
+            self->Focus(Microsoft::UI::Xaml::FocusState::Programmatic);
         });
 
-        PointerPressed([this](auto&&, muxi::PointerRoutedEventArgs const& args) {
-            if (!m_surface) return;
-            muix::PointerPoint point = args.GetCurrentPoint(Panel());
+        PointerMoved([weakSelf](auto&&, muxi::PointerRoutedEventArgs const& args) {
+            auto self = weakSelf.get();
+            if (!self || !self->m_surface) return;
+            muix::PointerPoint point = args.GetCurrentPoint(self->Panel());
+            auto pos = point.Position();
+            ghostty_surface_mouse_pos(self->m_surface, pos.X, pos.Y, currentMods());
+        });
+
+        PointerPressed([weakSelf](auto&&, muxi::PointerRoutedEventArgs const& args) {
+            auto self = weakSelf.get();
+            if (!self || !self->m_surface) return;
+            muix::PointerPoint point = args.GetCurrentPoint(self->Panel());
             muix::PointerPointProperties props = point.Properties();
             ghostty_input_mouse_button_e btn;
             if (props.IsLeftButtonPressed()) {
@@ -39,38 +64,40 @@ namespace winrt::GhosttyWin32::implementation
             } else if (props.IsRightButtonPressed()) {
                 // Right-click: copy selection if there is one,
                 // otherwise treat as a normal right button press.
-                if (ghostty_surface_has_selection(m_surface)) {
+                if (ghostty_surface_has_selection(self->m_surface)) {
                     ghostty_text_s text = {};
-                    if (ghostty_surface_read_selection(m_surface, &text) && text.text && text.text_len > 0) {
-                        Clipboard::write(m_hostHwnd, Encoding::toUtf16(text.text, static_cast<int>(text.text_len)));
-                        ghostty_surface_free_text(m_surface, &text);
+                    if (ghostty_surface_read_selection(self->m_surface, &text) && text.text && text.text_len > 0) {
+                        Clipboard::write(self->m_hostHwnd, Encoding::toUtf16(text.text, static_cast<int>(text.text_len)));
+                        ghostty_surface_free_text(self->m_surface, &text);
                     }
                     // Click-then-release without modifiers clears the
                     // selection in ghostty, matching the macOS gesture.
-                    ghostty_surface_mouse_button(m_surface, GHOSTTY_MOUSE_PRESS, GHOSTTY_MOUSE_LEFT, (ghostty_input_mods_e)0);
-                    ghostty_surface_mouse_button(m_surface, GHOSTTY_MOUSE_RELEASE, GHOSTTY_MOUSE_LEFT, (ghostty_input_mods_e)0);
+                    ghostty_surface_mouse_button(self->m_surface, GHOSTTY_MOUSE_PRESS, GHOSTTY_MOUSE_LEFT, (ghostty_input_mods_e)0);
+                    ghostty_surface_mouse_button(self->m_surface, GHOSTTY_MOUSE_RELEASE, GHOSTTY_MOUSE_LEFT, (ghostty_input_mods_e)0);
                     return;
                 }
                 btn = GHOSTTY_MOUSE_RIGHT;
             } else {
                 return;
             }
-            ghostty_surface_mouse_button(m_surface, GHOSTTY_MOUSE_PRESS, btn, currentMods());
+            ghostty_surface_mouse_button(self->m_surface, GHOSTTY_MOUSE_PRESS, btn, currentMods());
         });
 
-        PointerReleased([this](auto&&, muxi::PointerRoutedEventArgs const&) {
-            if (!m_surface) return;
-            ghostty_surface_mouse_button(m_surface, GHOSTTY_MOUSE_RELEASE, GHOSTTY_MOUSE_LEFT, currentMods());
+        PointerReleased([weakSelf](auto&&, muxi::PointerRoutedEventArgs const&) {
+            auto self = weakSelf.get();
+            if (!self || !self->m_surface) return;
+            ghostty_surface_mouse_button(self->m_surface, GHOSTTY_MOUSE_RELEASE, GHOSTTY_MOUSE_LEFT, currentMods());
         });
 
-        PointerWheelChanged([this](auto&&, muxi::PointerRoutedEventArgs const& args) {
-            if (!m_surface) return;
-            muix::PointerPoint point = args.GetCurrentPoint(Panel());
+        PointerWheelChanged([weakSelf](auto&&, muxi::PointerRoutedEventArgs const& args) {
+            auto self = weakSelf.get();
+            if (!self || !self->m_surface) return;
+            muix::PointerPoint point = args.GetCurrentPoint(self->Panel());
             muix::PointerPointProperties props = point.Properties();
             int delta = props.MouseWheelDelta();
             double scrollY = (double)delta / 120.0;
             ghostty_input_scroll_mods_t smods = {};
-            ghostty_surface_mouse_scroll(m_surface, 0, scrollY, smods);
+            ghostty_surface_mouse_scroll(self->m_surface, 0, scrollY, smods);
             args.Handled(true);
         });
     }
@@ -93,17 +120,22 @@ namespace winrt::GhosttyWin32::implementation
         m_hostHwnd = hostHwnd;
         m_attachRequest = std::move(attachRequest);
 
-        // Capture the surface by value so the lambda doesn't dereference
-        // `this` after Detach() nulls m_surface — Detach unhooks the
-        // event so further fires are impossible, but defense in depth.
-        ghostty_surface_t s = m_surface;
+        // Capture a weak_ref to self instead of `this` or the raw
+        // surface pointer. Detach unhooks SizeChanged before
+        // ghostty_surface_free, so in steady state the handler never
+        // fires on a dead surface — but XAML can deliver a queued
+        // SizeChanged after Detach during teardown, so we recheck
+        // m_surface inside the handler under a strong lock.
+        auto weakSelf = get_weak();
         m_sizeChangedToken = Panel().SizeChanged(
-            [s](auto&&, Microsoft::UI::Xaml::SizeChangedEventArgs const& args) {
+            [weakSelf](auto&&, Microsoft::UI::Xaml::SizeChangedEventArgs const& args) {
+                auto self = weakSelf.get();
+                if (!self || !self->m_surface) return;
                 auto sz = args.NewSize();
                 uint32_t w = static_cast<uint32_t>(sz.Width);
                 uint32_t h = static_cast<uint32_t>(sz.Height);
                 if (w > 0 && h > 0) {
-                    ghostty_surface_set_size(s, w, h);
+                    ghostty_surface_set_size(self->m_surface, w, h);
                 }
             });
     }

--- a/GhosttyWin32App/TerminalControl.xaml.cpp
+++ b/GhosttyWin32App/TerminalControl.xaml.cpp
@@ -10,4 +10,90 @@ namespace winrt::GhosttyWin32::implementation
     {
         InitializeComponent();
     }
+
+    TerminalControl::~TerminalControl()
+    {
+        // Belt-and-suspenders: Tab's destructor normally calls Detach
+        // first, but if construction failed mid-way we still want the
+        // surface/handle to be freed. Detach is idempotent.
+        Detach();
+    }
+
+    void TerminalControl::Attach(ghostty_surface_t surface,
+                                 HANDLE compositionHandle,
+                                 std::shared_ptr<SwapChainAttachRequest> attachRequest)
+    {
+        m_surface = surface;
+        m_compositionHandle = compositionHandle;
+        m_attachRequest = std::move(attachRequest);
+
+        // Capture the surface by value so the lambda doesn't dereference
+        // `this` after Detach() nulls m_surface — Detach unhooks the
+        // event so further fires are impossible, but defense in depth.
+        ghostty_surface_t s = m_surface;
+        m_sizeChangedToken = Panel().SizeChanged(
+            [s](auto&&, Microsoft::UI::Xaml::SizeChangedEventArgs const& args) {
+                auto sz = args.NewSize();
+                uint32_t w = static_cast<uint32_t>(sz.Width);
+                uint32_t h = static_cast<uint32_t>(sz.Height);
+                if (w > 0 && h > 0) {
+                    ghostty_surface_set_size(s, w, h);
+                }
+            });
+    }
+
+    void TerminalControl::Detach()
+    {
+        // Cancel the pending SetSwapChainHandle dispatch before we tear
+        // down the swap chain — otherwise the queued call could attach
+        // a freed handle to the panel after we've destroyed everything.
+        if (m_attachRequest) {
+            m_attachRequest->cancelled.store(true);
+            m_attachRequest.reset();
+        }
+
+        if (auto panel = Panel()) {
+            if (m_sizeChangedToken.value != 0) {
+                panel.SizeChanged(m_sizeChangedToken);
+                m_sizeChangedToken = {};
+            }
+            if (auto native2 = panel.try_as<ISwapChainPanelNative2>()) {
+                native2->SetSwapChainHandle(nullptr);
+            }
+        }
+        if (m_surface) {
+            ghostty_surface_free(m_surface);
+            m_surface = nullptr;
+        }
+        if (m_compositionHandle) {
+            CloseHandle(m_compositionHandle);
+            m_compositionHandle = nullptr;
+        }
+    }
+
+    void TerminalControl::OnSwapChainReady(void* userdata) noexcept
+    {
+        auto* raw = reinterpret_cast<std::shared_ptr<SwapChainAttachRequest>*>(userdata);
+        std::shared_ptr<SwapChainAttachRequest> req = *raw;
+        delete raw;
+        if (!req || !req->dispatcher) return;
+        try {
+            req->dispatcher.TryEnqueue([req]() {
+                if (req->cancelled.load()) return;
+                // Bind the swap chain (which now has at least one
+                // presented frame) to the panel, then run the host's
+                // activation work. Order: handle attach → onActivated.
+                // Host's onActivated typically calls SelectedItem to
+                // make the panel visible — by then the panel already
+                // has displayable content, closing the flicker window
+                // of issue #22.
+                if (auto native2 = req->panel.try_as<ISwapChainPanelNative2>()) {
+                    native2->SetSwapChainHandle(req->handle);
+                }
+                if (req->onActivated) req->onActivated();
+            });
+        } catch (...) {
+            // Window torn down — request is implicitly cancelled.
+        }
+    }
 }

--- a/GhosttyWin32App/TerminalControl.xaml.cpp
+++ b/GhosttyWin32App/TerminalControl.xaml.cpp
@@ -1,0 +1,13 @@
+#include "pch.h"
+#include "TerminalControl.xaml.h"
+#if __has_include("TerminalControl.g.cpp")
+#include "TerminalControl.g.cpp"
+#endif
+
+namespace winrt::GhosttyWin32::implementation
+{
+    TerminalControl::TerminalControl()
+    {
+        InitializeComponent();
+    }
+}

--- a/GhosttyWin32App/TerminalControl.xaml.cpp
+++ b/GhosttyWin32App/TerminalControl.xaml.cpp
@@ -1,5 +1,8 @@
 #include "pch.h"
 #include "TerminalControl.xaml.h"
+#include "Clipboard.h"
+#include "Encoding.h"
+#include "KeyModifiers.h"
 #if __has_include("TerminalControl.g.cpp")
 #include "TerminalControl.g.cpp"
 #endif
@@ -9,6 +12,67 @@ namespace winrt::GhosttyWin32::implementation
     TerminalControl::TerminalControl()
     {
         InitializeComponent();
+
+        // Pointer routing: the handlers early-return if no surface is
+        // attached yet, so it's safe to register them in the
+        // constructor before TabFactory calls Attach(). Coordinates are
+        // taken relative to the inner panel (== this UserControl's
+        // dimensions today, but Panel() is the explicit truth) so they
+        // match what ghostty's renderer expects.
+        namespace muxi = winrt::Microsoft::UI::Xaml::Input;
+        namespace muix = winrt::Microsoft::UI::Input;
+
+        PointerMoved([this](auto&&, muxi::PointerRoutedEventArgs const& args) {
+            if (!m_surface) return;
+            muix::PointerPoint point = args.GetCurrentPoint(Panel());
+            auto pos = point.Position();
+            ghostty_surface_mouse_pos(m_surface, pos.X, pos.Y, currentMods());
+        });
+
+        PointerPressed([this](auto&&, muxi::PointerRoutedEventArgs const& args) {
+            if (!m_surface) return;
+            muix::PointerPoint point = args.GetCurrentPoint(Panel());
+            muix::PointerPointProperties props = point.Properties();
+            ghostty_input_mouse_button_e btn;
+            if (props.IsLeftButtonPressed()) {
+                btn = GHOSTTY_MOUSE_LEFT;
+            } else if (props.IsRightButtonPressed()) {
+                // Right-click: copy selection if there is one,
+                // otherwise treat as a normal right button press.
+                if (ghostty_surface_has_selection(m_surface)) {
+                    ghostty_text_s text = {};
+                    if (ghostty_surface_read_selection(m_surface, &text) && text.text && text.text_len > 0) {
+                        Clipboard::write(m_hostHwnd, Encoding::toUtf16(text.text, static_cast<int>(text.text_len)));
+                        ghostty_surface_free_text(m_surface, &text);
+                    }
+                    // Click-then-release without modifiers clears the
+                    // selection in ghostty, matching the macOS gesture.
+                    ghostty_surface_mouse_button(m_surface, GHOSTTY_MOUSE_PRESS, GHOSTTY_MOUSE_LEFT, (ghostty_input_mods_e)0);
+                    ghostty_surface_mouse_button(m_surface, GHOSTTY_MOUSE_RELEASE, GHOSTTY_MOUSE_LEFT, (ghostty_input_mods_e)0);
+                    return;
+                }
+                btn = GHOSTTY_MOUSE_RIGHT;
+            } else {
+                return;
+            }
+            ghostty_surface_mouse_button(m_surface, GHOSTTY_MOUSE_PRESS, btn, currentMods());
+        });
+
+        PointerReleased([this](auto&&, muxi::PointerRoutedEventArgs const&) {
+            if (!m_surface) return;
+            ghostty_surface_mouse_button(m_surface, GHOSTTY_MOUSE_RELEASE, GHOSTTY_MOUSE_LEFT, currentMods());
+        });
+
+        PointerWheelChanged([this](auto&&, muxi::PointerRoutedEventArgs const& args) {
+            if (!m_surface) return;
+            muix::PointerPoint point = args.GetCurrentPoint(Panel());
+            muix::PointerPointProperties props = point.Properties();
+            int delta = props.MouseWheelDelta();
+            double scrollY = (double)delta / 120.0;
+            ghostty_input_scroll_mods_t smods = {};
+            ghostty_surface_mouse_scroll(m_surface, 0, scrollY, smods);
+            args.Handled(true);
+        });
     }
 
     TerminalControl::~TerminalControl()
@@ -21,10 +85,12 @@ namespace winrt::GhosttyWin32::implementation
 
     void TerminalControl::Attach(ghostty_surface_t surface,
                                  HANDLE compositionHandle,
+                                 HWND hostHwnd,
                                  std::shared_ptr<SwapChainAttachRequest> attachRequest)
     {
         m_surface = surface;
         m_compositionHandle = compositionHandle;
+        m_hostHwnd = hostHwnd;
         m_attachRequest = std::move(attachRequest);
 
         // Capture the surface by value so the lambda doesn't dereference

--- a/GhosttyWin32App/TerminalControl.xaml.cpp
+++ b/GhosttyWin32App/TerminalControl.xaml.cpp
@@ -141,6 +141,120 @@ namespace winrt::GhosttyWin32::implementation
             ghostty_surface_mouse_scroll(self->m_surface, 0, scrollY, smods);
             args.Handled(true);
         });
+
+        // KeyDown / KeyUp on the control itself: the events fire only
+        // while focus is inside us, so the handlers feed directly into
+        // m_surface without an ActiveControl() lookup. Args.Handled(true)
+        // suppresses bubbling, which in particular prevents the
+        // TabView's built-in keybindings from also acting on the
+        // already-routed key.
+        KeyDown([weakSelf](auto&&, muxi::KeyRoutedEventArgs const& args) {
+            auto self = weakSelf.get();
+            if (!self || !self->m_surface) return;
+
+            int vk = static_cast<int>(args.Key());
+            UINT scanCode = args.KeyStatus().ScanCode;
+            bool ctrl = GetKeyState(VK_CONTROL) & 0x8000;
+            bool shift = GetKeyState(VK_SHIFT) & 0x8000;
+
+            // IME is processing this key — let the EditContext handlers
+            // own the composition lifecycle, and don't double-encode
+            // into the pty.
+            if (vk == VK_PROCESSKEY || self->m_ime.composing()) return;
+
+            // Ctrl+C: copy selection if any, otherwise fall through to
+            // ghostty_surface_key so the SIGINT path runs.
+            if (ctrl && !shift && vk == 'C') {
+                if (ghostty_surface_has_selection(self->m_surface)) {
+                    ghostty_text_s text = {};
+                    if (ghostty_surface_read_selection(self->m_surface, &text) && text.text && text.text_len > 0) {
+                        Clipboard::write(self->m_hostHwnd, Encoding::toUtf16(text.text, static_cast<int>(text.text_len)));
+                        ghostty_surface_free_text(self->m_surface, &text);
+                    }
+                    ghostty_surface_mouse_button(self->m_surface, GHOSTTY_MOUSE_PRESS, GHOSTTY_MOUSE_LEFT, (ghostty_input_mods_e)0);
+                    ghostty_surface_mouse_button(self->m_surface, GHOSTTY_MOUSE_RELEASE, GHOSTTY_MOUSE_LEFT, (ghostty_input_mods_e)0);
+                    args.Handled(true);
+                    return;
+                }
+            }
+
+            // Ctrl+V: paste from clipboard.
+            if (ctrl && !shift && vk == 'V') {
+                auto utf8 = Encoding::toUtf8(Clipboard::read(self->m_hostHwnd));
+                if (!utf8.empty()) {
+                    ghostty_surface_text(self->m_surface, utf8.c_str(), utf8.size());
+                }
+                if (self->m_app) ghostty_app_tick(self->m_app);
+                ghostty_surface_refresh(self->m_surface);
+                args.Handled(true);
+                return;
+            }
+
+            // Compute the unshifted codepoint (VK translated with no
+            // modifiers held) so unicode-keyed bindings can match.
+            // Without this, Binding.Set.getEvent() in
+            // input/Binding.zig:2622 falls through every lookup path
+            // for entries like `unicode = 't'` (ctrl+shift+t = new_tab,
+            // ctrl+shift+w = close_tab, etc.) and returns null. The
+            // physical-keyed bindings (ctrl+tab = next_tab,
+            // ctrl+shift+arrow_left = previous_tab) already match via
+            // keycode; this fixes the unicode ones.
+            //
+            // Text encoding stays on the separate ghostty_surface_text
+            // path below — passing a `text` field into the key event
+            // would double-input because encodeKey also writes utf8 to
+            // the pty.
+            BYTE plainState[256] = {};
+            wchar_t unshiftedChars[4] = {};
+            int unshiftedCount = ToUnicode(vk, scanCode, plainState, unshiftedChars, 4, 0);
+            // Drain any dead-key state ToUnicode left in plainState so
+            // the next real keystroke isn't affected.
+            wchar_t drain[4] = {};
+            ToUnicode(VK_SPACE, 0x39, plainState, drain, 4, 0);
+
+            ghostty_input_key_s keyEvent = {};
+            keyEvent.action = GHOSTTY_ACTION_PRESS;
+            keyEvent.keycode = scanCode;
+            if (args.KeyStatus().IsExtendedKey) keyEvent.keycode |= 0xE000;
+            keyEvent.mods = currentMods();
+            if (unshiftedCount > 0 && unshiftedChars[0] >= 0x20) {
+                keyEvent.unshifted_codepoint = static_cast<uint32_t>(unshiftedChars[0]);
+            }
+            bool consumed = ghostty_surface_key(self->m_surface, keyEvent);
+
+            // Translate to text using ToUnicode (replaces
+            // CharacterReceived). Skip when the binding consumed the
+            // key — otherwise ctrl+shift+t would type "T" into the pty
+            // in addition to opening a new tab.
+            if (!consumed) {
+                BYTE kbState[256] = {};
+                GetKeyboardState(kbState);
+                wchar_t chars[4] = {};
+                int charCount = ToUnicode(vk, scanCode, kbState, chars, 4, 0);
+                if (charCount > 0 && chars[0] >= 0x20) {
+                    char utf8[16] = {};
+                    int len = WideCharToMultiByte(CP_UTF8, 0, chars, charCount, utf8, sizeof(utf8), nullptr, nullptr);
+                    if (len > 0) {
+                        ghostty_surface_text(self->m_surface, utf8, len);
+                    }
+                }
+            }
+
+            if (self->m_app) ghostty_app_tick(self->m_app);
+            ghostty_surface_refresh(self->m_surface);
+            args.Handled(true);
+        });
+
+        KeyUp([weakSelf](auto&&, muxi::KeyRoutedEventArgs const& args) {
+            auto self = weakSelf.get();
+            if (!self || !self->m_surface) return;
+            ghostty_input_key_s keyEvent = {};
+            keyEvent.action = GHOSTTY_ACTION_RELEASE;
+            keyEvent.keycode = args.KeyStatus().ScanCode;
+            if (args.KeyStatus().IsExtendedKey) keyEvent.keycode |= 0xE000;
+            keyEvent.mods = currentMods();
+            ghostty_surface_key(self->m_surface, keyEvent);
+        });
     }
 
     TerminalControl::~TerminalControl()

--- a/GhosttyWin32App/TerminalControl.xaml.h
+++ b/GhosttyWin32App/TerminalControl.xaml.h
@@ -2,39 +2,92 @@
 
 #include "TerminalControl.g.h"
 #include "ghostty.h"
+#include <microsoft.ui.xaml.media.dxinterop.h>
+#include <atomic>
+#include <functional>
+#include <memory>
 
 namespace winrt::GhosttyWin32::implementation
 {
+    // Pending UI-thread "attach this swap chain handle to the panel"
+    // request. Created on the UI thread inside TabFactory::Make, kept
+    // alive by both the TerminalControl (so it can cancel on teardown)
+    // and the renderer-thread callback (so it survives the cross-thread
+    // hop). The cancelled flag is the lifetime interlock: Detach() sets
+    // it before the swap chain is destroyed; the queued
+    // SetSwapChainHandle bails on it before touching the (now dead)
+    // handle.
+    struct SwapChainAttachRequest {
+        HANDLE handle{ nullptr };
+        Microsoft::UI::Xaml::Controls::SwapChainPanel panel{ nullptr };
+        Microsoft::UI::Dispatching::DispatcherQueue dispatcher{ nullptr };
+        std::atomic<bool> cancelled{ false };
+        // Called on the UI thread after SetSwapChainHandle has bound the
+        // swap chain (which now has at least one presented frame) to the
+        // panel. The host uses this to switch the TabView, focus the
+        // panel, etc., so the panel only becomes visible once it
+        // actually has content (issue #22).
+        std::function<void()> onActivated;
+    };
+
     // UserControl wrapper around a SwapChainPanel for one terminal surface.
     //
-    // Why a UserControl? SwapChainPanel inherits from Grid (not Control)
-    // and is not a default tab stop, so SwapChainPanel.Focus() returns
-    // false in many normal contexts (the WinUI focus walker only finds
-    // focusable descendants, of which there are none). Wrapping it in a
-    // UserControl with IsTabStop=true gives us a real focus target —
-    // Tab::Focus() can then call control.Focus(Programmatic) reliably,
-    // matching the pattern Windows Terminal uses around its TermControl.
+    // SwapChainPanel inherits from Grid (not Control) and is not a
+    // default tab stop, so SwapChainPanel.Focus() returns false in many
+    // normal contexts. Wrapping it in a UserControl with IsTabStop=true
+    // gives Tab::Focus() a target that programmatic focus moves
+    // actually stick to — same pattern Windows Terminal uses around
+    // its TermControl.
     //
-    // Skeleton: holds the surface + composition handle pointers and
-    // exposes the inner panel via the auto-generated x:Name accessor.
-    // Input handlers (KeyDown / IME / Pointer) and resize handling will
-    // move in here in subsequent commits — see the migration plan in
-    // refactor/terminal-control branch history.
+    // This control owns the ghostty_surface_t and composition-handle
+    // lifetimes for one tab: TabFactory::Make() calls Attach() once
+    // surface_new succeeds, and Tab's destructor calls Detach() to tear
+    // everything down in the right order.
     struct TerminalControl : TerminalControlT<TerminalControl>
     {
         TerminalControl();
+        ~TerminalControl();
 
-        // Implementation-only accessors. These can't go through IDL
-        // because ghostty_surface_t / HANDLE don't have WinRT projections.
-        // Callers reach them via winrt::get_self<implementation::TerminalControl>.
+        // Re-exposes the x:Name accessor publicly so external code (Tab,
+        // TabFactory, MainWindow's pointer handlers) can reach the inner
+        // SwapChainPanel without going through the impl class's name
+        // resolution rules. Implementation-only — not in IDL.
+        //
+        // Not const: the auto-generated Panel() x:Name accessor on the
+        // T<TerminalControl> base is non-const, so calling it from a
+        // const method fails to convert `this`.
+        Microsoft::UI::Xaml::Controls::SwapChainPanel InnerPanel() { return Panel(); }
+
+        // Wire a freshly-created ghostty surface to this control. Hooks
+        // SizeChanged on the inner panel so layout changes flow into
+        // ghostty_surface_set_size. The attachRequest is kept so
+        // Detach() can cancel a queued SetSwapChainHandle that hasn't
+        // run yet.
+        void Attach(ghostty_surface_t surface,
+                    HANDLE compositionHandle,
+                    std::shared_ptr<SwapChainAttachRequest> attachRequest);
+
+        // Tear-down counterpart of Attach. Idempotent — calling twice
+        // (e.g. once from Tab::~Tab and once from ~TerminalControl) is
+        // safe.
+        void Detach();
+
+        // Renderer-thread callback registered with ghostty as
+        // cfg.swap_chain_ready_cb. Hops to the UI thread and binds the
+        // swap chain handle to the panel via ISwapChainPanelNative2.
+        // Called as a free function with the SwapChainAttachRequest
+        // pointer as userdata — no `this` involved.
+        static void OnSwapChainReady(void* userdata) noexcept;
+
+        // Implementation-only accessors used by Tab.
         ghostty_surface_t Surface() const noexcept { return m_surface; }
         HANDLE CompositionHandle() const noexcept { return m_compositionHandle; }
-        void SetSurface(ghostty_surface_t s) noexcept { m_surface = s; }
-        void SetCompositionHandle(HANDLE h) noexcept { m_compositionHandle = h; }
 
     private:
         ghostty_surface_t m_surface{ nullptr };
         HANDLE m_compositionHandle{ nullptr };
+        winrt::event_token m_sizeChangedToken{};
+        std::shared_ptr<SwapChainAttachRequest> m_attachRequest;
     };
 }
 

--- a/GhosttyWin32App/TerminalControl.xaml.h
+++ b/GhosttyWin32App/TerminalControl.xaml.h
@@ -1,8 +1,10 @@
 #pragma once
 
 #include "TerminalControl.g.h"
+#include "ImeBuffer.h"
 #include "ghostty.h"
 #include <microsoft.ui.xaml.media.dxinterop.h>
+#include <winrt/Windows.UI.Text.Core.h>
 #include <atomic>
 #include <functional>
 #include <memory>
@@ -60,14 +62,32 @@ namespace winrt::GhosttyWin32::implementation
 
         // Wire a freshly-created ghostty surface to this control. Hooks
         // SizeChanged on the inner panel so layout changes flow into
-        // ghostty_surface_set_size. The attachRequest is kept so
-        // Detach() can cancel a queued SetSwapChainHandle that hasn't
-        // run yet. The host HWND is stashed for Win32 APIs that need a
-        // window owner (clipboard read/write, IME positioning, etc.).
-        void Attach(ghostty_surface_t surface,
+        // ghostty_surface_set_size, and creates a CoreTextEditContext
+        // bound to this control's surface so IME composition stays
+        // per-tab. The attachRequest is kept so Detach() can cancel a
+        // queued SetSwapChainHandle that hasn't run yet. The host HWND
+        // is stashed for Win32 APIs that need a window owner (clipboard
+        // read/write, IME bounds in screen coordinates). The ghostty
+        // app handle is needed to drive ghostty_app_tick after IME
+        // commits so the renderer wakes promptly.
+        void Attach(ghostty_app_t app,
+                    ghostty_surface_t surface,
                     HANDLE compositionHandle,
                     HWND hostHwnd,
                     std::shared_ptr<SwapChainAttachRequest> attachRequest);
+
+        // Forwarded by MainWindow's window-Activated handler. XAML's
+        // GotFocus / LostFocus don't fire on window de/activation
+        // (focus is logically retained on the focused element across
+        // alt-tab), so the host has to ping the active control whenever
+        // the window crosses the activation boundary.
+        void NotifyImeFocusEnter();
+        void NotifyImeFocusLeave();
+
+        // True while a CoreTextEditContext composition is in progress.
+        // KeyDown handlers (currently in MainWindow, moving here in a
+        // follow-up) must skip key encoding while the IME owns the key.
+        bool ImeComposing() const noexcept { return m_ime.composing(); }
 
         // Tear-down counterpart of Attach. Idempotent — calling twice
         // (e.g. once from Tab::~Tab and once from ~TerminalControl) is
@@ -86,16 +106,34 @@ namespace winrt::GhosttyWin32::implementation
         HANDLE CompositionHandle() const noexcept { return m_compositionHandle; }
 
     private:
+        // Builds the per-control CoreTextEditContext and wires its
+        // seven event handlers (TextRequested / SelectionRequested /
+        // TextUpdating / CompositionStarted / CompositionCompleted /
+        // LayoutRequested / FocusRemoved). Called from Attach once the
+        // surface and HWND are both valid.
+        void SetupImeContext();
+
+        ghostty_app_t m_app{ nullptr };
         ghostty_surface_t m_surface{ nullptr };
         HANDLE m_compositionHandle{ nullptr };
         // Host window HWND — used for Win32 APIs that need a window
-        // owner (clipboard read/write today, IME bounds in a future
-        // commit). Same value across every TerminalControl in this
-        // window; stored locally to avoid reaching into MainWindow
-        // globals from input handlers.
+        // owner (clipboard read/write, IME bounds in screen coords).
+        // Same value across every TerminalControl in this window;
+        // stored locally to avoid reaching into MainWindow globals
+        // from input handlers.
         HWND m_hostHwnd{ nullptr };
         winrt::event_token m_sizeChangedToken{};
         std::shared_ptr<SwapChainAttachRequest> m_attachRequest;
+
+        // IME plumbing. Each TerminalControl gets its own EditContext
+        // so a composition started in one tab doesn't leak preedit
+        // updates to another tab's surface when the user switches.
+        // CoreTextServicesManager allows multiple EditContexts in a
+        // single view; only one receives input at a time, controlled
+        // via NotifyFocusEnter/Leave on tab switches and window
+        // activation.
+        ImeBuffer m_ime;
+        winrt::Windows::UI::Text::Core::CoreTextEditContext m_editContext{ nullptr };
     };
 }
 

--- a/GhosttyWin32App/TerminalControl.xaml.h
+++ b/GhosttyWin32App/TerminalControl.xaml.h
@@ -84,11 +84,6 @@ namespace winrt::GhosttyWin32::implementation
         void NotifyImeFocusEnter();
         void NotifyImeFocusLeave();
 
-        // True while a CoreTextEditContext composition is in progress.
-        // KeyDown handlers (currently in MainWindow, moving here in a
-        // follow-up) must skip key encoding while the IME owns the key.
-        bool ImeComposing() const noexcept { return m_ime.composing(); }
-
         // Tear-down counterpart of Attach. Idempotent — calling twice
         // (e.g. once from Tab::~Tab and once from ~TerminalControl) is
         // safe.

--- a/GhosttyWin32App/TerminalControl.xaml.h
+++ b/GhosttyWin32App/TerminalControl.xaml.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include "TerminalControl.g.h"
+#include "ghostty.h"
+
+namespace winrt::GhosttyWin32::implementation
+{
+    // UserControl wrapper around a SwapChainPanel for one terminal surface.
+    //
+    // Why a UserControl? SwapChainPanel inherits from Grid (not Control)
+    // and is not a default tab stop, so SwapChainPanel.Focus() returns
+    // false in many normal contexts (the WinUI focus walker only finds
+    // focusable descendants, of which there are none). Wrapping it in a
+    // UserControl with IsTabStop=true gives us a real focus target —
+    // Tab::Focus() can then call control.Focus(Programmatic) reliably,
+    // matching the pattern Windows Terminal uses around its TermControl.
+    //
+    // Skeleton: holds the surface + composition handle pointers and
+    // exposes the inner panel via the auto-generated x:Name accessor.
+    // Input handlers (KeyDown / IME / Pointer) and resize handling will
+    // move in here in subsequent commits — see the migration plan in
+    // refactor/terminal-control branch history.
+    struct TerminalControl : TerminalControlT<TerminalControl>
+    {
+        TerminalControl();
+
+        // Implementation-only accessors. These can't go through IDL
+        // because ghostty_surface_t / HANDLE don't have WinRT projections.
+        // Callers reach them via winrt::get_self<implementation::TerminalControl>.
+        ghostty_surface_t Surface() const noexcept { return m_surface; }
+        HANDLE CompositionHandle() const noexcept { return m_compositionHandle; }
+        void SetSurface(ghostty_surface_t s) noexcept { m_surface = s; }
+        void SetCompositionHandle(HANDLE h) noexcept { m_compositionHandle = h; }
+
+    private:
+        ghostty_surface_t m_surface{ nullptr };
+        HANDLE m_compositionHandle{ nullptr };
+    };
+}
+
+namespace winrt::GhosttyWin32::factory_implementation
+{
+    struct TerminalControl : TerminalControlT<TerminalControl, implementation::TerminalControl>
+    {
+    };
+}

--- a/GhosttyWin32App/TerminalControl.xaml.h
+++ b/GhosttyWin32App/TerminalControl.xaml.h
@@ -62,9 +62,11 @@ namespace winrt::GhosttyWin32::implementation
         // SizeChanged on the inner panel so layout changes flow into
         // ghostty_surface_set_size. The attachRequest is kept so
         // Detach() can cancel a queued SetSwapChainHandle that hasn't
-        // run yet.
+        // run yet. The host HWND is stashed for Win32 APIs that need a
+        // window owner (clipboard read/write, IME positioning, etc.).
         void Attach(ghostty_surface_t surface,
                     HANDLE compositionHandle,
+                    HWND hostHwnd,
                     std::shared_ptr<SwapChainAttachRequest> attachRequest);
 
         // Tear-down counterpart of Attach. Idempotent — calling twice
@@ -86,6 +88,12 @@ namespace winrt::GhosttyWin32::implementation
     private:
         ghostty_surface_t m_surface{ nullptr };
         HANDLE m_compositionHandle{ nullptr };
+        // Host window HWND — used for Win32 APIs that need a window
+        // owner (clipboard read/write today, IME bounds in a future
+        // commit). Same value across every TerminalControl in this
+        // window; stored locally to avoid reaching into MainWindow
+        // globals from input handlers.
+        HWND m_hostHwnd{ nullptr };
         winrt::event_token m_sizeChangedToken{};
         std::shared_ptr<SwapChainAttachRequest> m_attachRequest;
     };


### PR DESCRIPTION
## Summary

Move the per-tab terminal state (ghostty surface, composition handle, IME EditContext, pointer / keyboard handlers, focus) out of `MainWindow` and into a new `TerminalControl` UserControl that owns one terminal surface. `MainWindow` becomes a host that routes window-level events (Activated, DPI, action callbacks) to the active control.

This is the architectural prerequisite for split-pane: a Tab can grow from \"single TerminalControl\" to \"tree of TerminalControls + splitter nodes\" without changes to `MainWindow` or the Tab API.

Built on top of #37 — when that merges, GitHub will rebase this PR's base to main automatically.

## What changed

**New per-tab control** (`TerminalControl.xaml{,.cpp,.h}`)
- UserControl wrapping a SwapChainPanel; `IsTabStop=true` so programmatic focus actually sticks
- Owns: surface handle, composition handle, host HWND reference, SwapChainAttachRequest, ImeBuffer, CoreTextEditContext
- Owns the seven EditContext callbacks (TextRequested / SelectionRequested / TextUpdating / CompositionStarted / CompositionCompleted / LayoutRequested / FocusRemoved)
- Owns Pointer{Pressed,Released,Moved,WheelChanged} and KeyDown / KeyUp handlers, all forwarded directly to its own surface

**MainWindow slim-down**
- No more surface / IME / pointer / keyboard state on the window itself
- Activated handler now dispatches focus + IME enter/leave to the active TerminalControl
- DPI / color-change action callbacks walk live tabs and apply per-control

**Focus correctness fixes discovered along the way**
- First-show focus race: `ShowWindow(SW_SHOW)` only posts `WM_ACTIVATE`; WinUI's default-focus pass runs later and overwrites our Focus. Anchored Focus on the Activated event so we are the last write (`439b4cf`)
- Clicks stealing focus: PointerPressed bubbled past us into ancestor focus management, which moved focus off the TerminalControl after our own Focus call. Mark `Handled(true)` to suppress the default-focus pass on the bubble path (`7626459`)

**Smaller cleanup**
- `RunSEHGuarded` extracted to `SEHGuard.h/cpp` so multiple TUs can call the same trampoline without `extern \"C\"` colliding with anonymous-namespace internal linkage (`c8cecfc`)

## Test plan

- [ ] First-tab cold start: keyboard input works immediately on every launch (10+ runs)
- [ ] alt-tab away and back: focus returns to the active terminal, IME re-attaches
- [ ] Click anywhere in the terminal panel: typing keeps working, no focus loss
- [ ] Right-click selection copy still works; subsequent typing unaffected
- [ ] Open a 2nd / 3rd tab: each gets a fresh surface and independent IME state; switching tabs preserves per-tab IME composition state
- [ ] Ctrl+Shift+W repeated rapidly across multiple tabs: clean exit, no AV
- [ ] Close last tab: window shuts down cleanly via `~MainWindow`

🤖 Generated with [Claude Code](https://claude.com/claude-code)