### PR TITLE
Require C++20 unconditionally

### DIFF
--- a/GhosttyWin32App/GhosttyWin32App.vcxproj
+++ b/GhosttyWin32App/GhosttyWin32App.vcxproj
@@ -92,8 +92,7 @@
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <PrecompiledHeaderOutputFile>$(IntDir)pch.pch</PrecompiledHeaderOutputFile>
       <WarningLevel>Level4</WarningLevel>
-      <LanguageStandard Condition="'$(VisualStudioVersion)' &gt;= '18.0'">stdcpp20</LanguageStandard>
-      <LanguageStandard Condition="'$(VisualStudioVersion)' &lt; '18.0'">stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
       <AdditionalOptions>%(AdditionalOptions) /bigobj</AdditionalOptions>
       <AdditionalIncludeDirectories>$(ProjectDir)..\ghostty;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>


### PR DESCRIPTION
## Summary

The vcxproj selected \`stdcpp20\` only when \`VisualStudioVersion >= 18.0\` and fell back to \`stdcpp17\` otherwise. The dev-build CI runner uses VS 2022 (17.x), which lands in the fallback. After #38 the host code uses C++20 features (defaulted \`operator==\` in \`TabId.h\`), so the fallback fails to compile:

\`\`\`
TabId.h(19,62): error C7589: defaulting comparison operators requires at least '/std:c++20'
\`\`\`

(Visible in run [25596728626](https://github.com/i999rri/GhosttyWin32/actions/runs/25596728626/job/75143838320).)

The conditional was speculative — there's no actual reason to keep a C++17 path — so collapse to plain \`stdcpp20\`. Local VS-18 builds were silently using \`stdcpp20\` and passing, which is why this didn't show up in the PR review.

## Test plan

- [ ] CI dev-build green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)