### PR TITLE
Extract MSIX build into a composite action; add ci.yml

### DIFF
--- a/.github/actions/build-signed-msix/action.yml
+++ b/.github/actions/build-signed-msix/action.yml
@@ -1,0 +1,222 @@
+name: Build (and optionally sign) the GhosttyWin32 MSIX
+description: |
+  Sets up Zig + MSBuild, builds ghostty.dll, restores NuGet packages,
+  patches the appx manifest with the given version, optionally decodes
+  the signing PFX, and produces a sideload MSIX. The caller is
+  responsible for the prior actions/checkout of the GhosttyWin32 repo
+  and for whatever publish/upload happens after this action returns.
+
+inputs:
+  msix-version:
+    description: '4-part numeric version string for the appx manifest (e.g. "0.3.0.42").'
+    required: true
+  sign:
+    description: |
+      Set to "true" to sign with the provided PFX. When "false", the
+      MSIX is built unsigned (useful for PR-time compile verification
+      without exposing the signing secret).
+    required: true
+  pfx-base64:
+    description: 'Base64-encoded signing PFX. Required when `sign` is "true".'
+    required: false
+    default: ''
+  pfx-password:
+    description: 'Password for the PFX. Required when `sign` is "true".'
+    required: false
+    default: ''
+  ghostty-repo:
+    description: 'GitHub `owner/repo` of the ghostty fork to build ghostty.dll from.'
+    required: false
+    default: 'i999rri/ghostty'
+  ghostty-ref:
+    description: 'Branch / tag / sha of the ghostty fork to check out.'
+    required: false
+    default: 'windows-port'
+  zig-version:
+    description: 'Zig toolchain version to install via mlugg/setup-zig.'
+    required: false
+    default: '0.15.2'
+
+outputs:
+  msix-path:
+    description: 'Absolute path to the produced MSIX. The caller usually renames or copies this before uploading.'
+    value: ${{ steps.locate.outputs.msix_path }}
+  cer-path:
+    description: 'Path to the public certificate derived from the PFX. Empty when `sign` is "false".'
+    value: ${{ steps.decode.outputs.cer_path }}
+
+runs:
+  using: composite
+  steps:
+    - name: Checkout ghostty fork
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ inputs.ghostty-repo }}
+        ref: ${{ inputs.ghostty-ref }}
+        path: ghostty
+
+    - name: Setup Zig
+      uses: mlugg/setup-zig@v2
+      with:
+        version: ${{ inputs.zig-version }}
+
+    - name: Build ghostty.dll
+      shell: pwsh
+      run: |
+        $ErrorActionPreference = 'Stop'
+        $PSNativeCommandUseErrorActionPreference = $true
+        cd ghostty
+        zig build -Doptimize=ReleaseSafe -Drenderer=directx
+        # upstream renamed the install artifact: zig-out/lib/ghostty.dll →
+        # ghostty-internal.dll (ghostty commit 4fd16ef9b). GhosttyWin32App
+        # still links against ghostty.dll, so rename on copy.
+        Copy-Item zig-out/lib/ghostty-internal.dll ../ghostty/ghostty.dll
+        Copy-Item include/ghostty.h ../ghostty/
+        # The Zig build writes the small import lib into the cache, not
+        # zig-out. Hunt for the most recently produced one (~60 KB) and
+        # copy it next to the dll.
+        $searchPaths = @(".")
+        if ($env:ZIG_LOCAL_CACHE_DIR) { $searchPaths += $env:ZIG_LOCAL_CACHE_DIR }
+        if (Test-Path "$env:LOCALAPPDATA\zig") { $searchPaths += "$env:LOCALAPPDATA\zig" }
+        $lib = Get-ChildItem -Path $searchPaths -Recurse -Filter "ghostty.lib" -ErrorAction SilentlyContinue |
+               Where-Object { $_.Length -lt 100KB -and $_.Length -gt 10KB } |
+               Sort-Object LastWriteTime -Descending |
+               Select-Object -First 1
+        if ($lib) {
+          Copy-Item $lib.FullName ../ghostty/
+          Write-Host "Found import lib: $($lib.FullName) ($($lib.Length) bytes)"
+        } else {
+          Write-Error "ghostty.lib import library not found"
+          exit 1
+        }
+
+    - name: Setup MSBuild
+      uses: microsoft/setup-msbuild@v2
+
+    - name: Setup NuGet
+      uses: NuGet/setup-nuget@v2
+
+    # The wapproj uses PackageReference (handled by msbuild /t:Restore),
+    # but GhosttyWin32App.vcxproj / GhosttyTests.vcxproj still use the
+    # legacy packages.config format which msbuild's Restore target ignores.
+    # We need both: nuget restore expands ..\packages\ for the vcxprojs,
+    # then msbuild /t:Restore resolves the wapproj's PackageReferences.
+    # NuGet CLI doesn't read .slnx so we point it at each vcxproj.
+    - name: Restore NuGet packages
+      shell: pwsh
+      run: |
+        $ErrorActionPreference = 'Stop'
+        $PSNativeCommandUseErrorActionPreference = $true
+        nuget restore "GhosttyWin32App/GhosttyWin32App.vcxproj" -PackagesDirectory packages -SolutionDirectory .
+        nuget restore "GhosttyTests/GhosttyTests.vcxproj" -PackagesDirectory packages -SolutionDirectory .
+        msbuild GhosttyWin32.slnx /t:Restore /p:Configuration=Release /p:Platform=x64
+
+    - name: Patch manifest version
+      shell: pwsh
+      env:
+        MSIX_VERSION: ${{ inputs.msix-version }}
+      run: |
+        $ErrorActionPreference = 'Stop'
+        $PSNativeCommandUseErrorActionPreference = $true
+        # Read with -Raw so existing line endings are preserved verbatim
+        # (the previous Get-Content + Set-Content -NoNewline approach
+        # joined array elements with no separator, collapsing the XML
+        # declaration into the next line and producing APPX1402).
+        # Use -creplace (case-sensitive) on uppercase Version=, otherwise
+        # -replace also clobbers `version="1.0"` in the <?xml ... ?>
+        # declaration since PowerShell -replace is case-insensitive.
+        $manifestPath = "GhosttyWin32 (Package)/Package.appxmanifest"
+        $content = Get-Content $manifestPath -Raw
+        # (?<=\s) lookbehind requires whitespace before Version=, so
+        # MinVersion= / MaxVersionTested= in <TargetDeviceFamily> aren't
+        # touched — only the Version= attribute on <Identity> matches.
+        $content = $content -creplace '(?<=\s)Version="[\d\.]+"', "Version=`"$env:MSIX_VERSION`""
+        [System.IO.File]::WriteAllText((Resolve-Path $manifestPath), $content)
+        Write-Host "Patched manifest Version to $env:MSIX_VERSION"
+
+    # Sign-only steps. Skipped when `sign` is "false" so PR-time
+    # compile verification doesn't need access to the signing secret.
+    - name: Decode signing certificate
+      id: decode
+      if: ${{ inputs.sign == 'true' }}
+      shell: pwsh
+      env:
+        PFX_BASE64: ${{ inputs.pfx-base64 }}
+        PFX_PASSWORD: ${{ inputs.pfx-password }}
+      run: |
+        $ErrorActionPreference = 'Stop'
+        $PSNativeCommandUseErrorActionPreference = $true
+        if (-not $env:PFX_BASE64) {
+          Write-Error "sign=true but pfx-base64 input is empty. Pass `secrets.SIGNING_PFX_BASE64`."
+          exit 1
+        }
+        $pfxBytes = [System.Convert]::FromBase64String($env:PFX_BASE64)
+        [System.IO.File]::WriteAllBytes("ghostty-signing.pfx", $pfxBytes)
+
+        # Derive the public cer from the PFX so the release artifact and
+        # the signing key are guaranteed to match. We don't commit
+        # Ghostty.cer because the source of truth is the PFX in Secrets —
+        # keeping a second copy in git invites drift.
+        $pfx = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2(
+          (Resolve-Path "ghostty-signing.pfx").Path,
+          $env:PFX_PASSWORD,
+          [System.Security.Cryptography.X509Certificates.X509KeyStorageFlags]::EphemeralKeySet)
+        $cerBytes = $pfx.Export(
+          [System.Security.Cryptography.X509Certificates.X509ContentType]::Cert)
+        $cerPath = (Join-Path (Get-Location) "Ghostty.cer")
+        [System.IO.File]::WriteAllBytes($cerPath, $cerBytes)
+        $pfx.Dispose()
+        "cer_path=$cerPath" >> $env:GITHUB_OUTPUT
+
+    - name: Build MSIX package
+      shell: pwsh
+      env:
+        PFX_PASSWORD: ${{ inputs.pfx-password }}
+      run: |
+        $ErrorActionPreference = 'Stop'
+        $PSNativeCommandUseErrorActionPreference = $true
+        $msbuildArgs = @(
+          "GhosttyWin32 (Package)/GhosttyWin32 (Package).wapproj",
+          "/p:Configuration=Release",
+          "/p:Platform=x64",
+          "/p:PlatformToolset=v143",
+          "/p:GenerateAppxPackageOnBuild=true",
+          "/p:UapAppxPackageBuildMode=SideloadOnly",
+          "/p:AppxBundle=Never"
+        )
+        if ("${{ inputs.sign }}" -eq "true") {
+          $pfxPath = (Resolve-Path "ghostty-signing.pfx").Path
+          $msbuildArgs += @(
+            "/p:AppxPackageSigningEnabled=true",
+            "/p:PackageCertificateKeyFile=$pfxPath",
+            "/p:PackageCertificatePassword=$env:PFX_PASSWORD"
+          )
+        } else {
+          $msbuildArgs += "/p:AppxPackageSigningEnabled=false"
+        }
+        msbuild @msbuildArgs
+
+    # always() so the PFX is wiped even if a prior step failed.
+    # Combined with the sign gate so it doesn't run for unsigned PR builds.
+    - name: Cleanup PFX
+      if: ${{ always() && inputs.sign == 'true' }}
+      shell: pwsh
+      run: |
+        Remove-Item ghostty-signing.pfx -ErrorAction SilentlyContinue
+        # Ghostty.cer (public part) stays for the caller's release upload.
+
+    - name: Locate MSIX
+      id: locate
+      shell: pwsh
+      run: |
+        $ErrorActionPreference = 'Stop'
+        $PSNativeCommandUseErrorActionPreference = $true
+        $msix = Get-ChildItem -Recurse -Filter "*.msix" -Path "GhosttyWin32 (Package)/AppPackages" |
+                Where-Object { $_.Name -notlike "*Microsoft.*" } |
+                Select-Object -First 1
+        if (-not $msix) {
+          Write-Error "Built MSIX not found under GhosttyWin32 (Package)/AppPackages/"
+          exit 1
+        }
+        Write-Host "MSIX: $($msix.FullName)"
+        "msix_path=$($msix.FullName)" >> $env:GITHUB_OUTPUT

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+# Compile-only verification on every PR. Runs the same build pipeline as
+# Dev Build / Release but without signing or publishing — catches build
+# breakages (e.g. /std:c++17 vs c++20 mismatches) before merge.
+on:
+  pull_request: {}
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+# Cancel an older in-flight run on the same ref when a new push arrives.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout GhosttyWin32
+        uses: actions/checkout@v4
+
+      - name: Build MSIX (unsigned)
+        uses: ./.github/actions/build-signed-msix
+        with:
+          # Placeholder version — PR builds don't publish the MSIX, so
+          # the value only matters insofar as the manifest patcher needs
+          # a syntactically valid 4-part number.
+          msix-version: '0.0.0.0'
+          sign: 'false'

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -8,9 +8,9 @@ on:
 permissions:
   contents: write
 
-# Run-coalescing: only one dev-build is meaningful at a time. If a newer push
-# arrives while the previous build is still going, cancel the older one so we
-# don't overwrite a newer artifact with an older one when both finish.
+# Run-coalescing: only one dev-build is meaningful at a time. If a newer
+# push arrives while the previous build is still going, cancel the older
+# one so we don't overwrite a newer artifact with an older one.
 concurrency:
   group: dev-build
   cancel-in-progress: true
@@ -26,13 +26,6 @@ jobs:
     steps:
       - name: Checkout GhosttyWin32
         uses: actions/checkout@v4
-
-      - name: Checkout ghostty fork
-        uses: actions/checkout@v4
-        with:
-          repository: i999rri/ghostty
-          ref: windows-port
-          path: ghostty
 
       - name: Compute dev version
         id: version
@@ -58,143 +51,23 @@ jobs:
           Write-Host "MSIX manifest Version : $msixVersion"
           Write-Host "Display version       : $displayVersion"
 
-      - name: Setup Zig
-        uses: mlugg/setup-zig@v2
+      - name: Build signed MSIX
+        id: build
+        uses: ./.github/actions/build-signed-msix
         with:
-          version: 0.15.2
+          msix-version: ${{ steps.version.outputs.msix_version }}
+          sign: 'true'
+          pfx-base64: ${{ secrets.SIGNING_PFX_BASE64 }}
+          pfx-password: ${{ secrets.SIGNING_PFX_PASSWORD }}
 
-      - name: Build ghostty.dll
+      - name: Rename MSIX for dev release
+        id: artifact
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
           $PSNativeCommandUseErrorActionPreference = $true
-          cd ghostty
-          zig build -Doptimize=ReleaseSafe -Drenderer=directx
-          # upstream renamed the install artifact: zig-out/lib/ghostty.dll →
-          # ghostty-internal.dll (ghostty commit 4fd16ef9b). GhosttyWin32App
-          # still links against ghostty.dll, so rename on copy.
-          Copy-Item zig-out/lib/ghostty-internal.dll ../ghostty/ghostty.dll
-          Copy-Item include/ghostty.h ../ghostty/
-          $searchPaths = @(".")
-          if ($env:ZIG_LOCAL_CACHE_DIR) { $searchPaths += $env:ZIG_LOCAL_CACHE_DIR }
-          if (Test-Path "$env:LOCALAPPDATA\zig") { $searchPaths += "$env:LOCALAPPDATA\zig" }
-          $lib = Get-ChildItem -Path $searchPaths -Recurse -Filter "ghostty.lib" -ErrorAction SilentlyContinue |
-                 Where-Object { $_.Length -lt 100KB -and $_.Length -gt 10KB } |
-                 Sort-Object LastWriteTime -Descending |
-                 Select-Object -First 1
-          if ($lib) {
-            Copy-Item $lib.FullName ../ghostty/
-            Write-Host "Found import lib: $($lib.FullName) ($($lib.Length) bytes)"
-          } else {
-            Write-Error "ghostty.lib import library not found"
-            exit 1
-          }
-
-      - name: Setup MSBuild
-        uses: microsoft/setup-msbuild@v2
-
-      - name: Setup NuGet
-        uses: NuGet/setup-nuget@v2
-
-      # The wapproj uses PackageReference (handled by msbuild /t:Restore),
-      # but GhosttyWin32App.vcxproj / GhosttyTests.vcxproj still use the
-      # legacy packages.config format which msbuild's Restore target ignores.
-      # We need both: nuget restore expands ..\packages\ for the vcxprojs,
-      # then msbuild /t:Restore resolves the wapproj's PackageReferences.
-      # NuGet CLI doesn't read .slnx so we point it at each vcxproj.
-      - name: Restore NuGet packages
-        run: |
-          nuget restore "GhosttyWin32App/GhosttyWin32App.vcxproj" -PackagesDirectory packages -SolutionDirectory .
-          nuget restore "GhosttyTests/GhosttyTests.vcxproj" -PackagesDirectory packages -SolutionDirectory .
-          msbuild GhosttyWin32.slnx /t:Restore /p:Configuration=Release /p:Platform=x64
-
-      - name: Patch manifest version
-        shell: pwsh
-        run: |
-          $ErrorActionPreference = 'Stop'
-          $PSNativeCommandUseErrorActionPreference = $true
-          # Read with -Raw so existing line endings are preserved verbatim
-          # (the previous Get-Content + Set-Content -NoNewline approach
-          # joined array elements with no separator, collapsing the XML
-          # declaration into the next line and producing APPX1402).
-          # Use -creplace (case-sensitive) on uppercase Version=, otherwise
-          # -replace also clobbers `version="1.0"` in the <?xml ... ?>
-          # declaration since PowerShell -replace is case-insensitive.
-          $manifestPath = "GhosttyWin32 (Package)/Package.appxmanifest"
-          $content = Get-Content $manifestPath -Raw
-          # (?<=\s) lookbehind requires whitespace before Version=, so
-          # MinVersion= / MaxVersionTested= in <TargetDeviceFamily> aren't
-          # touched — only the Version= attribute on <Identity> matches.
-          $content = $content -creplace '(?<=\s)Version="[\d\.]+"', "Version=`"${{ steps.version.outputs.msix_version }}`""
-          [System.IO.File]::WriteAllText((Resolve-Path $manifestPath), $content)
-
-      - name: Decode signing certificate
-        shell: pwsh
-        env:
-          PFX_BASE64: ${{ secrets.SIGNING_PFX_BASE64 }}
-          PFX_PASSWORD: ${{ secrets.SIGNING_PFX_PASSWORD }}
-        run: |
-          $ErrorActionPreference = 'Stop'
-          $PSNativeCommandUseErrorActionPreference = $true
-          if (-not $env:PFX_BASE64) {
-            Write-Error "SIGNING_PFX_BASE64 secret is empty. See .github/RELEASING.md."
-            exit 1
-          }
-          $pfxBytes = [System.Convert]::FromBase64String($env:PFX_BASE64)
-          [System.IO.File]::WriteAllBytes("ghostty-signing.pfx", $pfxBytes)
-
-          # Derive the public cer from the PFX so the release artifact and the
-          # signing key are guaranteed to match. See release.yml for rationale.
-          $pfx = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2(
-            (Resolve-Path "ghostty-signing.pfx").Path,
-            $env:PFX_PASSWORD,
-            [System.Security.Cryptography.X509Certificates.X509KeyStorageFlags]::EphemeralKeySet)
-          $cerBytes = $pfx.Export(
-            [System.Security.Cryptography.X509Certificates.X509ContentType]::Cert)
-          [System.IO.File]::WriteAllBytes("Ghostty.cer", $cerBytes)
-          $pfx.Dispose()
-
-      - name: Build MSIX package
-        shell: pwsh
-        env:
-          PFX_PASSWORD: ${{ secrets.SIGNING_PFX_PASSWORD }}
-        run: |
-          $ErrorActionPreference = 'Stop'
-          $PSNativeCommandUseErrorActionPreference = $true
-          $pfxPath = (Resolve-Path "ghostty-signing.pfx").Path
-          msbuild "GhosttyWin32 (Package)/GhosttyWin32 (Package).wapproj" `
-            /p:Configuration=Release `
-            /p:Platform=x64 `
-            /p:PlatformToolset=v143 `
-            /p:GenerateAppxPackageOnBuild=true `
-            /p:AppxPackageSigningEnabled=true `
-            /p:PackageCertificateKeyFile=$pfxPath `
-            /p:PackageCertificatePassword=$env:PFX_PASSWORD `
-            /p:UapAppxPackageBuildMode=SideloadOnly `
-            /p:AppxBundle=Never
-
-      - name: Cleanup PFX
-        if: always()
-        shell: pwsh
-        run: |
-          Remove-Item ghostty-signing.pfx -ErrorAction SilentlyContinue
-          # Ghostty.cer (public part) stays for the release upload step.
-
-      - name: Locate and rename MSIX
-        id: locate
-        shell: pwsh
-        run: |
-          $ErrorActionPreference = 'Stop'
-          $PSNativeCommandUseErrorActionPreference = $true
-          $msix = Get-ChildItem -Recurse -Filter "*.msix" -Path "GhosttyWin32 (Package)/AppPackages" |
-                  Where-Object { $_.Name -notlike "*Microsoft.*" } |
-                  Select-Object -First 1
-          if (-not $msix) {
-            Write-Error "Built MSIX not found under AppPackages/"
-            exit 1
-          }
           $renamed = "Ghostty-dev-x64.msix"
-          Copy-Item $msix.FullName $renamed
+          Copy-Item "${{ steps.build.outputs.msix-path }}" $renamed
           "msix_path=$renamed" >> $env:GITHUB_OUTPUT
 
       # Replace the dev-build release in-place. Deleting the old release first
@@ -272,5 +145,5 @@ jobs:
             --title "Dev build (${{ steps.version.outputs.display_version }})" `
             --notes-file release-notes.md `
             --prerelease `
-            "${{ steps.locate.outputs.msix_path }}" `
-            Ghostty.cer
+            "${{ steps.artifact.outputs.msix_path }}" `
+            "${{ steps.build.outputs.cer-path }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,68 +26,8 @@ jobs:
       - name: Checkout GhosttyWin32
         uses: actions/checkout@v4
 
-      - name: Checkout ghostty fork
-        uses: actions/checkout@v4
-        with:
-          repository: i999rri/ghostty
-          ref: windows-port
-          path: ghostty
-
-      - name: Setup Zig
-        uses: mlugg/setup-zig@v2
-        with:
-          version: 0.15.2
-
-      - name: Build ghostty.dll
-        shell: pwsh
-        run: |
-          $ErrorActionPreference = 'Stop'
-          $PSNativeCommandUseErrorActionPreference = $true
-          cd ghostty
-          zig build -Doptimize=ReleaseSafe -Drenderer=directx
-          # GhosttyWin32App.vcxproj links against ../ghostty/ghostty.{dll,lib,h}
-          # at the workspace root. upstream renamed the install artifact
-          # ghostty.dll → ghostty-internal.dll (ghostty 4fd16ef9b), so rename
-          # on copy to keep the linker target stable.
-          Copy-Item zig-out/lib/ghostty-internal.dll ../ghostty/ghostty.dll
-          Copy-Item include/ghostty.h ../ghostty/
-          # The Zig build writes the small import lib into the cache, not
-          # zig-out. Hunt for the most recently produced one (~60 KB) and
-          # copy it next to the dll.
-          $searchPaths = @(".")
-          if ($env:ZIG_LOCAL_CACHE_DIR) { $searchPaths += $env:ZIG_LOCAL_CACHE_DIR }
-          if (Test-Path "$env:LOCALAPPDATA\zig") { $searchPaths += "$env:LOCALAPPDATA\zig" }
-          $lib = Get-ChildItem -Path $searchPaths -Recurse -Filter "ghostty.lib" -ErrorAction SilentlyContinue |
-                 Where-Object { $_.Length -lt 100KB -and $_.Length -gt 10KB } |
-                 Sort-Object LastWriteTime -Descending |
-                 Select-Object -First 1
-          if ($lib) {
-            Copy-Item $lib.FullName ../ghostty/
-            Write-Host "Found import lib: $($lib.FullName) ($($lib.Length) bytes)"
-          } else {
-            Write-Error "ghostty.lib import library not found"
-            exit 1
-          }
-
-      - name: Setup MSBuild
-        uses: microsoft/setup-msbuild@v2
-
-      - name: Setup NuGet
-        uses: NuGet/setup-nuget@v2
-
-      # The wapproj uses PackageReference (handled by msbuild /t:Restore),
-      # but GhosttyWin32App.vcxproj / GhosttyTests.vcxproj still use the
-      # legacy packages.config format which msbuild's Restore target ignores.
-      # We need both: nuget restore expands ..\packages\ for the vcxprojs,
-      # then msbuild /t:Restore resolves the wapproj's PackageReferences.
-      # NuGet CLI doesn't read .slnx so we point it at each vcxproj.
-      - name: Restore NuGet packages
-        run: |
-          nuget restore "GhosttyWin32App/GhosttyWin32App.vcxproj" -PackagesDirectory packages -SolutionDirectory .
-          nuget restore "GhosttyTests/GhosttyTests.vcxproj" -PackagesDirectory packages -SolutionDirectory .
-          msbuild GhosttyWin32.slnx /t:Restore /p:Configuration=Release /p:Platform=x64
-
       - name: Set MSIX version from tag
+        id: version
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
@@ -105,103 +45,36 @@ jobs:
             exit 1
           }
           $fullVersion = "$version.0"
-          # Read with -Raw so existing line endings are preserved verbatim
-          # (the previous Get-Content + Set-Content -NoNewline approach
-          # joined array elements with no separator, collapsing the XML
-          # declaration into the next line and producing APPX1402).
-          # Use -creplace (case-sensitive) on uppercase Version=, otherwise
-          # -replace also clobbers `version="1.0"` in the <?xml ... ?>
-          # declaration since PowerShell -replace is case-insensitive.
-          $manifestPath = "GhosttyWin32 (Package)/Package.appxmanifest"
-          $content = Get-Content $manifestPath -Raw
-          # (?<=\s) lookbehind requires whitespace before Version=, so
-          # MinVersion= / MaxVersionTested= in <TargetDeviceFamily> aren't
-          # touched — only the Version= attribute on <Identity> matches.
-          $content = $content -creplace '(?<=\s)Version="[\d\.]+"', "Version=`"$fullVersion`""
-          [System.IO.File]::WriteAllText((Resolve-Path $manifestPath), $content)
-          Write-Host "Set MSIX version to $fullVersion"
-          # Echo for downstream steps.
-          "msix_version=$fullVersion" >> $env:GITHUB_ENV
-          "release_version=$version" >> $env:GITHUB_ENV
+          "msix_version=$fullVersion" >> $env:GITHUB_OUTPUT
+          "release_version=$version" >> $env:GITHUB_OUTPUT
+          Write-Host "Tag $tag -> MSIX version $fullVersion (release version $version)"
 
-      - name: Decode signing certificate
-        shell: pwsh
-        env:
-          PFX_BASE64: ${{ secrets.SIGNING_PFX_BASE64 }}
-          PFX_PASSWORD: ${{ secrets.SIGNING_PFX_PASSWORD }}
-        run: |
-          $ErrorActionPreference = 'Stop'
-          $PSNativeCommandUseErrorActionPreference = $true
-          if (-not $env:PFX_BASE64) {
-            Write-Error "SIGNING_PFX_BASE64 secret is empty. See .github/RELEASING.md."
-            exit 1
-          }
-          $pfxBytes = [System.Convert]::FromBase64String($env:PFX_BASE64)
-          [System.IO.File]::WriteAllBytes("ghostty-signing.pfx", $pfxBytes)
+      - name: Build signed MSIX
+        id: build
+        uses: ./.github/actions/build-signed-msix
+        with:
+          msix-version: ${{ steps.version.outputs.msix_version }}
+          sign: 'true'
+          pfx-base64: ${{ secrets.SIGNING_PFX_BASE64 }}
+          pfx-password: ${{ secrets.SIGNING_PFX_PASSWORD }}
 
-          # Derive the public cer from the PFX so the release artifact and the
-          # signing key are guaranteed to match. We don't commit Ghostty.cer
-          # because the source of truth is the PFX in Secrets — keeping a
-          # second copy in git invites drift.
-          $pfx = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2(
-            (Resolve-Path "ghostty-signing.pfx").Path,
-            $env:PFX_PASSWORD,
-            [System.Security.Cryptography.X509Certificates.X509KeyStorageFlags]::EphemeralKeySet)
-          $cerBytes = $pfx.Export(
-            [System.Security.Cryptography.X509Certificates.X509ContentType]::Cert)
-          [System.IO.File]::WriteAllBytes("Ghostty.cer", $cerBytes)
-          $pfx.Dispose()
-
-      - name: Build MSIX package
-        shell: pwsh
-        env:
-          PFX_PASSWORD: ${{ secrets.SIGNING_PFX_PASSWORD }}
-        run: |
-          $ErrorActionPreference = 'Stop'
-          $PSNativeCommandUseErrorActionPreference = $true
-          $pfxPath = (Resolve-Path "ghostty-signing.pfx").Path
-          msbuild "GhosttyWin32 (Package)/GhosttyWin32 (Package).wapproj" `
-            /p:Configuration=Release `
-            /p:Platform=x64 `
-            /p:PlatformToolset=v143 `
-            /p:GenerateAppxPackageOnBuild=true `
-            /p:AppxPackageSigningEnabled=true `
-            /p:PackageCertificateKeyFile=$pfxPath `
-            /p:PackageCertificatePassword=$env:PFX_PASSWORD `
-            /p:UapAppxPackageBuildMode=SideloadOnly `
-            /p:AppxBundle=Never
-
-      - name: Cleanup PFX
-        if: always()
-        shell: pwsh
-        run: |
-          Remove-Item ghostty-signing.pfx -ErrorAction SilentlyContinue
-          # Ghostty.cer (public part) stays for the release upload step.
-
-      - name: Locate and rename MSIX
-        id: locate
+      - name: Rename MSIX for release
+        id: artifact
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
           $PSNativeCommandUseErrorActionPreference = $true
-          $msix = Get-ChildItem -Recurse -Filter "*.msix" -Path "GhosttyWin32 (Package)/AppPackages" |
-                  Where-Object { $_.Name -notlike "*Microsoft.*" } |
-                  Select-Object -First 1
-          if (-not $msix) {
-            Write-Error "Built MSIX not found under AppPackages/"
-            exit 1
-          }
-          $renamed = "Ghostty-$env:release_version-x64.msix"
-          Copy-Item $msix.FullName $renamed
-          Write-Host "Release artifact: $renamed (from $($msix.FullName))"
+          $renamed = "Ghostty-${{ steps.version.outputs.release_version }}-x64.msix"
+          Copy-Item "${{ steps.build.outputs.msix-path }}" $renamed
+          Write-Host "Release artifact: $renamed"
           "msix_path=$renamed" >> $env:GITHUB_OUTPUT
 
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:
           files: |
-            ${{ steps.locate.outputs.msix_path }}
-            Ghostty.cer
+            ${{ steps.artifact.outputs.msix_path }}
+            ${{ steps.build.outputs.cer-path }}
           generate_release_notes: true
           # Tags with a hyphen are pre-releases (rc / beta / alpha).
           prerelease: ${{ contains(github.ref_name, '-') }}
@@ -214,7 +87,7 @@ jobs:
             ```
 
             ### Manual install
-            1. Download `Ghostty.cer` and `Ghostty-${{ env.release_version }}-x64.msix`
+            1. Download `Ghostty.cer` and `Ghostty-${{ steps.version.outputs.release_version }}-x64.msix`
             2. Trust the certificate (Local Machine → Trusted People store)
             3. Double-click the `.msix` to install
 


### PR DESCRIPTION
## Summary

Extract the shared MSIX build pipeline (zig build → ghostty.dll → NuGet restore → manifest patch → optional sign → msbuild) into a composite action at \`.github/actions/build-signed-msix\`. Adds \`ci.yml\` so every pull request runs the same pipeline in compile-only mode.

Replaces #40 — the previous attempt mixed PR verification and dev publishing in the same workflow with conditional gates, which made the YAML hard to follow.

## Why

- \`dev-build.yml\` and \`release.yml\` had ~150 lines of identical build logic. A change to the pipeline meant editing it twice with no enforcement that the two stayed in sync.
- PR breakages like the \`/std:c++17\` vs \`c++20\` mismatch in #38 only surfaced after merging to \`dev\`. Catching them on PR avoids the fix-up round trip we just did with #39.

## Files

| File | What |
|---|---|
| \`.github/actions/build-signed-msix/action.yml\` | New composite action. Owns checkout-of-ghostty / Setup Zig / Build ghostty.dll / Setup MSBuild + NuGet / Restore packages / Patch manifest / Decode signing certificate / Build MSIX / Cleanup PFX / Locate MSIX. |
| \`.github/workflows/ci.yml\` | New. Triggered on \`pull_request\`. Calls the composite with \`sign='false'\` and a placeholder version. Compile-only — no signing, no upload, no PFX secret needed. |
| \`.github/workflows/dev-build.yml\` | Slimmed. Triggered on \`push: branches: [dev]\` (PR trigger removed). Computes the dev version, calls the composite, renames the MSIX, replaces the rolling \`dev-build\` release. |
| \`.github/workflows/release.yml\` | Slimmed. Triggered on tag push. Parses the tag, calls the composite, renames the MSIX, posts to \`softprops/action-gh-release\`. |

Workflow files dropped from 493 lines total to 277 (44% reduction); the build pipeline itself moves to the composite at 222 lines.

## Composite contract

\`\`\`yaml
inputs:
  msix-version:    # 4-part numeric version (e.g. "0.3.0.42")
  sign:            # 'true' | 'false'
  pfx-base64:      # required when sign='true'
  pfx-password:    # required when sign='true'
  ghostty-repo:    # default 'i999rri/ghostty'
  ghostty-ref:     # default 'windows-port'
  zig-version:     # default '0.15.2'
outputs:
  msix-path:       # absolute path to the produced MSIX
  cer-path:        # absolute path to Ghostty.cer (empty when sign='false')
\`\`\`

\`Decode signing certificate\` and \`Cleanup PFX\` inside the composite are gated on \`inputs.sign == 'true'\`. \`Cleanup PFX\` keeps \`always()\` (combined with the sign gate) so the PFX still gets wiped if a step before it fails on a signed build.

## Test plan

- [ ] CI run on this PR completes successfully (verifies the composite + the unsigned compile-only path)
- [ ] After merge, push to \`dev\` triggers Dev Build and produces a publishable signed MSIX as before
- [ ] When ready, an RC tag (e.g. \`v0.3.0-rc1\`) end-to-end-tests \`release.yml\` against the composite

🤖 Generated with [Claude Code](https://claude.com/claude-code)