### PR TITLE
Automate dev → main release PR + auto-tag on merge

### DIFF
--- a/.github/workflows/auto-tag-release-pr.yml
+++ b/.github/workflows/auto-tag-release-pr.yml
@@ -1,0 +1,70 @@
+name: Auto-tag release PR
+
+# When a `release/vX.Y.Z` PR is merged into main, tag main HEAD with
+# vX.Y.Z and push. The tag push is what release.yml watches for, so
+# this is the bridge between "release PR merged" and "GitHub Release
+# published".
+#
+# Branch name (release/vX.Y.Z) is the source of truth for the version
+# rather than PR title — branch refs are immutable once created, while
+# titles can be edited after the fact and would silently break the
+# auto-tag path.
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    if: |
+      github.event.pull_request.merged == true &&
+      startsWith(github.event.pull_request.head.ref, 'release/v')
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Extract and validate version
+        id: ver
+        env:
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          set -euo pipefail
+          # release/v0.3.0 → v0.3.0
+          version="${HEAD_REF#release/}"
+
+          # Production-only auto-tag: vX.Y.Z, no hyphen suffix. RC tags
+          # are intentionally a manual `git tag` flow per RELEASING.md
+          # so we don't accidentally publish an auto-approved RC build.
+          if [[ ! "$version" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Branch '$HEAD_REF' doesn't match release/vX.Y.Z (no hyphen suffix allowed)."
+            exit 1
+          fi
+
+          # Refuse silent retag of an existing release. If a previous
+          # attempt already pushed the tag, the operator should clean
+          # up explicitly.
+          if git rev-parse "$version" >/dev/null 2>&1; then
+            echo "::error::Tag $version already exists. Delete it before re-running."
+            exit 1
+          fi
+
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Tag main HEAD and push
+        env:
+          VERSION: ${{ steps.ver.outputs.version }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "$VERSION" -m "Release $VERSION"
+          git push origin "$VERSION"
+          echo "Pushed tag $VERSION → release.yml will fire."

--- a/.github/workflows/open-release-pr.yml
+++ b/.github/workflows/open-release-pr.yml
@@ -1,0 +1,138 @@
+name: Open release PR
+
+# Cuts a "release/vX.Y.Z" branch from `dev` HEAD and opens a PR against
+# `main`. Triggered manually from the Actions tab when ready to ship a
+# production release.
+#
+# RC tags (vX.Y.Z-rcN) are intentionally NOT supported here — they're
+# created with `git tag` directly on `dev` per the model in
+# .github/RELEASING.md. This workflow only handles the dev → main
+# promotion that yields a production semver tag.
+#
+# After merge, .github/workflows/auto-tag-release-pr.yml picks up the
+# release/v* head ref and tags `main` HEAD, which fires release.yml.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version (例: 0.3.0、production のみ。"v" は付けない、ハイフン suffix も不可)'
+        required: true
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  open-pr:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: dev
+          fetch-depth: 0
+
+      - name: Validate version
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Version '$VERSION' must be plain semver (X.Y.Z, no 'v' prefix, no hyphen suffix)."
+            echo "::error::RC tags are made manually on dev — see .github/RELEASING.md."
+            exit 1
+          fi
+
+      - name: Create release branch
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          BRANCH="release/v$VERSION"
+
+          # Refuse if any release/* PR is already open against main —
+          # we only run one release at a time so the auto-tag workflow
+          # has an unambiguous target.
+          existing=$(gh pr list --base main --search "head:release/" --state open --json number --jq 'length')
+          if [[ "$existing" -gt 0 ]]; then
+            echo "::error::An open release/* PR already exists. Close or merge it first."
+            exit 1
+          fi
+
+          # Refuse if the branch is already on the remote (could be from
+          # a previous abandoned attempt — let the operator clean up
+          # explicitly rather than silently overwriting).
+          if git ls-remote --exit-code origin "refs/heads/$BRANCH" >/dev/null 2>&1; then
+            echo "::error::Branch $BRANCH already exists on origin. Delete it (gh api -X DELETE) before retrying."
+            exit 1
+          fi
+
+          # Push current dev HEAD as the release branch. From this point
+          # the branch is a frozen snapshot — dev can keep moving.
+          git push origin "HEAD:refs/heads/$BRANCH"
+          echo "Pushed branch $BRANCH at $(git rev-parse --short HEAD)"
+
+      - name: Generate change list
+        id: changes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+
+          # Pick the most recent production release as the "previous"
+          # baseline. Filtering on isPrerelease=false excludes both RC
+          # tags (vX.Y.Z-rcN) and the rolling `dev-build` release.
+          prev_tag=$(gh release list --json tagName,isPrerelease \
+            --jq '[.[] | select(.isPrerelease == false) | .tagName] | first // ""')
+
+          if [[ -n "$prev_tag" ]]; then
+            echo "Generating notes vs previous tag: $prev_tag"
+            notes=$(gh api "repos/${GITHUB_REPOSITORY}/releases/generate-notes" \
+              --method POST \
+              -f tag_name="v$VERSION" \
+              -f target_commitish="release/v$VERSION" \
+              -f previous_tag_name="$prev_tag" \
+              --jq '.body')
+          else
+            echo "No previous production release found — bootstrap mode."
+            notes="(No previous production release found. This is the first one.)"
+          fi
+
+          # multi-line outputs need a heredoc-style delimiter.
+          {
+            echo "notes<<RELEASE_NOTES_EOF"
+            echo "$notes"
+            echo "RELEASE_NOTES_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Open release PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ inputs.version }}
+          NOTES: ${{ steps.changes.outputs.notes }}
+        run: |
+          set -euo pipefail
+          BRANCH="release/v$VERSION"
+
+          body=$(cat <<EOM
+          ## What's in this release
+
+          $NOTES
+
+          ---
+
+          このブランチは \`dev\` の HEAD をスナップショットしたもの。マージで自動的に
+          \`v$VERSION\` タグが \`main\` に打たれて \`release.yml\` が走る。
+
+          See [.github/RELEASING.md](.github/RELEASING.md) for the full release procedure.
+          EOM
+          )
+
+          gh pr create \
+            --base main \
+            --head "$BRANCH" \
+            --title "Release v$VERSION" \
+            --body "$body"


### PR DESCRIPTION
## Summary

Mechanise the production-release flow documented in #42 / \`.github/RELEASING.md\`. Two new workflows reduce the dev → main → tag → GitHub Release chain to three clicks (Run / Merge / Approve deployment).

## Files

| File | Trigger | Job |
|---|---|---|
| \`.github/workflows/open-release-pr.yml\` | \`workflow_dispatch\` (Run with version input) | Snapshot dev → \`release/vX.Y.Z\` branch, open PR with auto-generated change list |
| \`.github/workflows/auto-tag-release-pr.yml\` | \`pull_request: closed\` on main (filtered to release/v\*) | Tag main HEAD with vX.Y.Z, push, fires release.yml |

## Design choices

**Branch name as source of truth.** The version comes from the head ref (\`release/v0.3.0\` → \`v0.3.0\`), not the PR title. Branch refs are immutable once created; titles aren't. So accidentally renaming the PR doesn't silently break the auto-tag path.

**Snapshot branch instead of head=dev.** The release branch freezes content at creation time, so dev can keep moving (next patch fix, parallel \`vX.Y.Z+1-rc1\`) without affecting the in-flight release PR.

**Production-only auto-flow.** \`open-release-pr.yml\` rejects RC versions (anything with a hyphen). RC tags stay a manual \`git tag\` flow on dev per RELEASING.md, so we don't accidentally promote an auto-approved RC build through the dev-release Environment.

**Change list via \`releases/generate-notes\` API.** Same source GitHub uses when you click "Generate release notes" on a Release. Filters for previous *production* tag (skipping -rcN / dev-build), so the PR body and the eventual Release notes stay in sync.

**Refuse-to-clobber checks.** Both workflows fail loud if state already exists (open release/\* PR, existing branch, existing tag) instead of silently overwriting.

## Bootstrap caveat

The auto-tag workflow only takes effect once it's on \`main\`, which happens with the first release after this lands on dev. So:

1. Merge this PR to dev (\`ci.yml\` verifies it compiles)
2. Eventually merge dev → main as a release (the very first one might still need a manual \`git tag\` if needed)
3. From the second release onward, the dispatch → merge → tag chain is fully automatic

## Test plan

- [ ] \`ci.yml\` passes on this PR
- [ ] After merge to dev, the \`Open release PR\` workflow appears in the Actions tab
- [ ] First end-to-end exercise: when ready to release, run the workflow with a version, verify the PR opens with the expected branch + body, merge it, confirm the tag is pushed and release.yml fires

## Related

- #42 documents the strategy this implements

🤖 Generated with [Claude Code](https://claude.com/claude-code)