### PR TITLE
Distinguish RC from production in MSIX artifact name

### DIFF
--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -269,6 +269,15 @@ git push origin v0.3.0-rc1
 挙動: Production と同じビルドパスだが、自動承認 + GitHub Releases で **Pre-release マーク** 付き。
 タグ名 / バージョン番号は同じ仕組み (`v0.3.0-rc1` → MSIX manifest は `0.3.0.0`、リリース名は `v0.3.0-rc1`)。
 
+**MSIX 成果物のファイル名は production と RC で異なる** (assets 一覧で見分けられるように):
+
+| タグ | 成果物ファイル名 |
+|---|---|
+| `v0.3.0` (production) | `Ghostty-0.3.0-x64.msix` |
+| `v0.3.0-rc1` (RC) | `Ghostty-v0.3.0-rc1-x64.msix` |
+
+scoop manifest 側はこの違いを autoupdate URL pattern で吸収する (RC channel の manifest では `$matchHead` か full ref を使う)。
+
 RC2 以降が必要になった場合は、dev に修正コミットを積んでから新タグ:
 
 ```powershell

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,13 +58,33 @@ jobs:
           pfx-base64: ${{ secrets.SIGNING_PFX_BASE64 }}
           pfx-password: ${{ secrets.SIGNING_PFX_PASSWORD }}
 
+      # MSIX file naming differs by channel so the two are visually
+      # distinguishable in the GitHub Releases asset list and in the
+      # scoop bucket:
+      #
+      #   Production tag v0.3.0          →  Ghostty-0.3.0-x64.msix
+      #   Pre-release tag v0.3.0-rc1     →  Ghostty-v0.3.0-rc1-x64.msix
+      #
+      # Stable keeps the short version (no "v" prefix) for backward
+      # compatibility with the existing scoop manifest URL pattern; RC
+      # uses the full ref_name so users grabbing the artifact can tell
+      # at a glance "this is RC1, not the final v0.3.0".
       - name: Rename MSIX for release
         id: artifact
         shell: pwsh
+        env:
+          REF_NAME: ${{ github.ref_name }}
+          RELEASE_VERSION: ${{ steps.version.outputs.release_version }}
         run: |
           $ErrorActionPreference = 'Stop'
           $PSNativeCommandUseErrorActionPreference = $true
-          $renamed = "Ghostty-${{ steps.version.outputs.release_version }}-x64.msix"
+          if ($env:REF_NAME -match '-') {
+            # Pre-release: full tag including 'v' prefix and -rcN/-beta suffix
+            $renamed = "Ghostty-$env:REF_NAME-x64.msix"
+          } else {
+            # Production: short version, no 'v' prefix
+            $renamed = "Ghostty-$env:RELEASE_VERSION-x64.msix"
+          }
           Copy-Item "${{ steps.build.outputs.msix-path }}" $renamed
           Write-Host "Release artifact: $renamed"
           "msix_path=$renamed" >> $env:GITHUB_OUTPUT
@@ -87,7 +107,7 @@ jobs:
             ```
 
             ### Manual install
-            1. Download `Ghostty.cer` and `Ghostty-${{ steps.version.outputs.release_version }}-x64.msix`
+            1. Download `Ghostty.cer` and the `.msix` from the assets above
             2. Trust the certificate (Local Machine → Trusted People store)
             3. Double-click the `.msix` to install
 


### PR DESCRIPTION
## Summary

When the same version goes through RC and then final, both releases currently produce \`Ghostty-0.3.0-x64.msix\` — impossible to distinguish in the GitHub Releases asset list or once downloaded. Rename the RC artifact to include the full ref name (\`v\` prefix + suffix) so assets are visually distinct.

| Tag | Artifact filename |
|---|---|
| \`v0.3.0\` (production) | \`Ghostty-0.3.0-x64.msix\` (unchanged) |
| \`v0.3.0-rc1\` (RC) | \`Ghostty-v0.3.0-rc1-x64.msix\` (new) |

Needed for the upcoming RC scoop channel (separate \`ghosttywin32-rc\` manifest pointing to RC artifacts) — without distinct filenames the autoupdate URL pattern can't tell the two apart.

## Changes

- \`.github/workflows/release.yml\` — \`Rename MSIX for release\` step branches on whether \`github.ref_name\` contains \`-\`. Body of the release note also drops the inline version reference in favour of "the \`.msix\` from the assets above" so it stays correct for both channels.
- \`.github/RELEASING.md\` — new table in the Pre-release section documenting the naming difference, with a forward-reference to the scoop side that needs to handle it.

Stable side stays at the short-version name to avoid churning the existing \`ghosttywin32\` scoop manifest URL pattern.

## Test plan

- [ ] Next RC tag (\`v0.3.0-rc2\`+) produces \`Ghostty-v0.3.0-rcN-x64.msix\` in Releases
- [ ] Production tag still produces \`Ghostty-0.3.0-x64.msix\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)