### PR TITLE
README: refresh to match the WinUI 3 architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,106 +1,123 @@
 # GhosttyWin32
 
-Windows host application for [Ghostty](https://github.com/ghostty-org/ghostty) terminal emulator.
+Windows host application for the [Ghostty](https://github.com/ghostty-org/ghostty) terminal emulator.
 
-Uses the libghostty C API (DLL) with a Win32 window. Supports **DirectX 11** (default) and **OpenGL** (via [Mesa Zink](https://docs.mesa3d.org/drivers/zink.html)) rendering backends.
+A WinUI 3 + C++/WinRT shell that hosts the libghostty C API. Each tab owns its own ghostty Surface and DirectX 11 device, rendered into a `SwapChainPanel`.
 
 ## Features
 
 ### Terminal
-- Full terminal emulation via libghostty (VT parser, ConPTY)
-- PowerShell / cmd.exe / custom shell (`command` config)
-- Japanese/CJK font rendering with system font fallback
-- IME input (Japanese, Chinese, Korean)
-- UTF-16 surrogate pair support (emoji)
+
+- Full terminal emulation via libghostty (VT parser, ConPTY backend)
+- PowerShell / cmd.exe / arbitrary shell (`command` config option)
+- Japanese / CJK glyph rendering with system font fallback
+- IME input (Japanese, Chinese, Korean) with composition preview
+- UTF-16 surrogate pair support (emoji, supplementary planes)
+- Auto-close tab when the shell process exits
+
+### Tabs
+
+- Multi-tab UI via WinUI 3 `TabView`
+- Per-tab isolation: each tab owns its own ghostty Surface + D3D11 device
+- Per-tab SEH guard: a hardware exception in one tab does not take down siblings (fatal cases still trigger a clean process exit)
+- New tab / close tab / reorder via standard `TabView` gestures
+- Custom XAML caption buttons (minimize / maximize / close) that route through `WM_SYSCOMMAND` to avoid driver-side state-change crashes
 
 ### Input
-- Keyboard: WM_CHAR text input + WM_KEYDOWN special keys
-- Modifier keys: Ctrl, Shift, Alt (sent to ghostty for keybindings)
-- Mouse: left/middle/right click, drag, scroll wheel
-- Text selection: left-click drag, Ctrl+C copy, Ctrl+V paste, right-click copy
-- Selection auto-clear after copy
-- Ctrl+click: URL highlight detection
 
-### Window Management
-- Fullscreen toggle (Ctrl+Enter)
-- Maximize/restore
-- Window decorations toggle (title bar show/hide)
-- Borderless mode with drag (top 30px) and edge resize (WM_NCHITTEST)
-- Minimum/maximum window size limits (SIZE_LIMIT)
+- Keyboard: `WM_CHAR` text input plus key-level events for shortcuts
+- Modifier-aware keybindings (Ctrl / Shift / Alt) forwarded to libghostty
+- Mouse: left / middle / right click, drag, scroll wheel
+- Selection: drag-to-select, Ctrl+C copy, Ctrl+V paste, right-click copy
+- Selection auto-clear after copy
+- Ctrl+click: URL highlight detection (see Known Issues)
+
+### Window
+
+- Custom title bar with `ExtendsContentIntoTitleBar`
+- Drag region sized to survive many open tabs
+- Fullscreen toggle, maximize / restore
 - DPI scaling (Per-Monitor DPI Aware V2)
+- Mica / Acrylic backdrop (when running as an MSIX package)
 
 ### Visual
+
 - Theme support (config file or `%LOCALAPPDATA%\ghostty\themes\`)
 - Background image (`background-image` config)
 - Background opacity (`background-opacity` config)
-- Title bar color synced with terminal background (DwmSetWindowAttribute, Windows 11)
-- Custom color palette (ANSI 16 colors)
+- Title bar tint synced with terminal background (`DwmSetWindowAttribute`, Windows 11)
+- Custom ANSI 16-color palette
 - Cursor color customization
 
 ### Rendering
-- **DirectX 11** (default) — native D3D11, no external dependencies, FLIP_DISCARD swap chain
-- **OpenGL 4.3+** (fallback) — via Mesa Zink (GL-to-Vulkan translation)
-- High-resolution waitable timer for frame pacing (Windows 10 1803+)
-- V-Sync OFF for low input latency
 
-### Callbacks
-- `SET_TITLE`: window title from terminal
+- DirectX 11 via the libghostty native renderer (no external dependencies)
+- FLIP_DISCARD swap chain hosted in a `SwapChainPanel`
+- High-resolution waitable timer for frame pacing (Windows 10 1803+)
+
+### libghostty Callbacks
+
+- `SET_TITLE`: tab title from terminal escape sequences
 - `MOUSE_SHAPE`: cursor changes (text, pointer, hand, resize, etc.)
-- `MOUSE_VISIBILITY`: hide/show cursor
-- `OPEN_URL`: open URLs in default browser (ShellExecuteW)
+- `MOUSE_VISIBILITY`: hide / show cursor
+- `OPEN_URL`: open URLs in the default browser (`ShellExecuteW`)
 - `RING_BELL`: flash window + system beep
-- `COLOR_CHANGE`: sync title bar color with background
-- `TOGGLE_FULLSCREEN` / `TOGGLE_MAXIMIZE` / `TOGGLE_WINDOW_DECORATIONS`
+- `COLOR_CHANGE`: sync title bar tint with terminal background
+- `TOGGLE_FULLSCREEN` / `TOGGLE_MAXIMIZE`
 - `SIZE_LIMIT` / `INITIAL_SIZE` / `RESET_WINDOW_SIZE`
+- `NEW_TAB` / `CLOSE_TAB` / `GOTO_TAB`
 - `QUIT`: clean shutdown
-- Clipboard read/write (onReadClipboard, onWriteClipboard)
-- Wakeup: thread-safe PostMessage to main thread
+- Clipboard read / write
+- Wakeup: thread-safe `PostMessage` to the UI thread
 
 ## Architecture
 
 ```
-GhosttyWin32.exe (C++/Win32)
-  └── GhosttyBridge (singleton)
-      ├── Win32 window (WS_POPUP or WS_OVERLAPPEDWINDOW)
-      ├── Input handling (keyboard, mouse, IME)
-      ├── Clipboard (Win32 API)
-      ├── Config reading (ghostty_config_get API)
-      ├── Action dispatch (onAction callback)
-      └── 4MB stack threads (ghostty_init, config, surface)
+GhosttyWin32App.exe (WinUI 3 / C++/WinRT)
+  ├── App.xaml — application entry, XAML Controls Resources
+  ├── MainWindow
+  │   ├── Custom title bar + caption buttons
+  │   ├── TabView
+  │   │   └── TerminalControl (per tab)
+  │   │       ├── SwapChainPanel → ghostty Surface
+  │   │       ├── Input forwarding (key / pointer / IME)
+  │   │       └── Per-tab D3D11 device + SEH guard
+  │   └── SetUnhandledExceptionFilter — best-effort cleanup
+  ├── GhosttyApp — ghostty_app_t lifetime wrapper (config, callbacks)
+  └── Tabs / TabFactory / TabIdAllocator — tab bookkeeping
 
 ghostty.dll (Zig, from i999rri/ghostty windows-port branch)
   ├── Terminal emulator core (VT parser, Screen)
-  ├── DirectX 11 renderer (HLSL SM5.0 shaders, d3d11_impl.c COM wrapper)
-  ├── OpenGL 4.3 renderer (GLSL 430 shaders, Mesa Zink fallback)
+  ├── DirectX 11 renderer (HLSL SM5.0, d3d11_impl.c COM wrapper)
   ├── Font rendering (Freetype + Harfbuzz)
   ├── ConPTY subprocess management
   └── Windows font discovery (registry lookup, %WINDIR%\Fonts)
-
-[Optional] Mesa Zink (opengl32.dll + libgallium_wgl.dll)
-  └── Translates OpenGL 4.6 → Vulkan (only needed for OpenGL fallback)
 ```
 
 ## Install
 
-### Scoop (Recommended)
+### Scoop (recommended)
 
 ```powershell
 scoop bucket add ghostty https://github.com/i999rri/scoop-bucket
 scoop install ghosttywin32
 ```
 
-Then run from terminal or start menu:
-```powershell
-GhosttyWin32
-```
+The bucket ships a signed MSIX. Installation imports the signing certificate
+into `LocalMachine\TrustedPeople` and registers the MSIX via
+`Add-AppxPackage`, so the command currently has to run from an elevated
+PowerShell. See [issue #46](https://github.com/i999rri/GhosttyWin32/issues/46)
+for the in-flight migration to SignPath Foundation, which will remove the
+elevation requirement.
 
 ### Manual (MSIX)
 
-1. Download `Ghostty-X.Y.Z-x64.msix` and `Ghostty.cer` from
+1. Download `Ghostty-<version>-x64.msix` and `Ghostty.cer` from
    [Releases](https://github.com/i999rri/GhosttyWin32/releases).
 2. Trust the certificate (one-time per machine; **Local Machine → Trusted
-   People** store — see [docs/INSTALL.md](docs/INSTALL.md) for the exact wizard
-   choices, since the wrong store choice silently fails with `0x800B0109`).
+   People** store — see [docs/INSTALL.md](docs/INSTALL.md) for the exact
+   wizard choices, since the wrong store choice silently fails with
+   `0x800B0109`).
 3. Double-click the `.msix` to install.
 
 Subsequent updates only require step 3. Detailed walkthrough and
@@ -110,13 +127,15 @@ troubleshooting: [docs/INSTALL.md](docs/INSTALL.md).
 
 ### Prerequisites
 
-- Visual Studio 2022+ with C++ desktop development workload
+- Visual Studio 2022 (17.10+) with the "Desktop development with C++" and
+  "Universal Windows Platform development" workloads
+- Windows App SDK 1.6+ (installed via the project's NuGet packages)
 - Zig 0.15.2+
-- Windows SDK
+- Windows SDK 10.0.22621.0+
 
 ### Build ghostty.dll
 
-This requires a forked version of Ghostty with Windows support patches:
+This requires the forked Ghostty with Windows support patches:
 
 ```bash
 git clone https://github.com/i999rri/ghostty.git
@@ -125,43 +144,18 @@ git switch windows-port
 zig build -Doptimize=ReleaseSafe -Drenderer=directx
 ```
 
-Copy the following files to `GhosttyWin32/ghostty/`:
+Copy the following into `GhosttyWin32App/`:
+
 - `zig-out/lib/ghostty.dll`
-- `.zig-cache/o/<hash>/ghostty.lib` (small import library ~60KB)
-- `include/ghostty.h` (already included in this repo)
+- `zig-out/lib/ghostty.lib`
+- (`ghostty.h` is already vendored in the repo)
 
 ### Build GhosttyWin32
 
-Open `GhosttyWin32.slnx` in Visual Studio, set to **Release | x64**, and build.
-
-### Mesa Zink Setup (Optional, for OpenGL fallback)
-
-Only needed if using the OpenGL renderer instead of DirectX.
-
-Download [mesa-dist-win](https://github.com/pal1000/mesa-dist-win/releases) (MSVC release) and copy to the exe directory:
-- `x64/opengl32.dll`
-- `x64/libgallium_wgl.dll`
-
-### Run
-
-```bash
-GhosttyWin32.exe
-```
-
-## Renderer Selection
-
-DirectX 11 is the default renderer. To use OpenGL instead:
-
-```powershell
-$env:GHOSTTY_RENDERER = "opengl"
-$env:GALLIUM_DRIVER = "zink"
-GhosttyWin32.exe
-```
-
-| Environment Variable | Default | Description |
-|---------------------|---------|-------------|
-| `GHOSTTY_RENDERER` | (DirectX) | Set to `opengl` for OpenGL/Zink fallback |
-| `GALLIUM_DRIVER` | — | Set to `zink` when using OpenGL renderer |
+Open `GhosttyWin32.slnx` in Visual Studio, select **Release | x64**, and
+build the `GhosttyWin32App` project. F5 deploys as a packaged MSIX into
+the local appx registry; `Release | x64` build artifacts land under
+`x64/Release/GhosttyWin32App/`.
 
 ## Configuration
 
@@ -179,18 +173,30 @@ background-image-opacity=0.3
 background-image-fit=cover
 ```
 
-Theme files go in `%LOCALAPPDATA%\ghostty\themes\`. See [Ghostty documentation](https://ghostty.org/docs/config) for all options.
+Theme files go in `%LOCALAPPDATA%\ghostty\themes\`. See the upstream
+[Ghostty documentation](https://ghostty.org/docs/config) for the full
+option list.
 
 ## Known Issues
 
-- `exit` does not close window ([#8](https://github.com/i999rri/GhosttyWin32/issues/8))
-- Ctrl+click URL causes process exit ([#12](https://github.com/i999rri/GhosttyWin32/issues/12)) — ghostty-side issue
-- Mesa Zink DLLs trigger Windows Defender false positive ([#11](https://github.com/i999rri/GhosttyWin32/issues/11))
-- OpenGL renderer: native WGL (without Mesa Zink) has flickering due to WGL+DWM issue
+- Ctrl+click on a URL exits the process with code 3
+  ([#12](https://github.com/i999rri/GhosttyWin32/issues/12)) — ghostty-side issue
+- Split panes are not yet implemented; only tabs
+  ([#13](https://github.com/i999rri/GhosttyWin32/issues/13))
+- Windows-specific config options (`windows-tab-bar`, `windows-drag-region`)
+  are not exposed yet ([#17](https://github.com/i999rri/GhosttyWin32/issues/17))
 
 ## Status
 
-This is an experimental Windows port. See the [windows-port branch](https://github.com/i999rri/ghostty/tree/windows-port) for Ghostty-side changes and [Discussion #2563](https://github.com/ghostty-org/ghostty/discussions/2563) for context.
+This is an experimental Windows port. See the
+[windows-port branch](https://github.com/i999rri/ghostty/tree/windows-port) for
+Ghostty-side changes and
+[Discussion #2563](https://github.com/ghostty-org/ghostty/discussions/2563) for
+context.
+
+## License
+
+[MIT](LICENSE). The libghostty library it embeds is also MIT-licensed.
 
 ## AI Disclosure
 


### PR DESCRIPTION
## Summary / 概要

The README still described the pre-WinUI 3 Win32 + GhosttyBridge singleton with an OpenGL / Mesa Zink fallback. That stack was replaced by the WinUI 3 + TabView shell, so the "Architecture" section and most of the rendering / build instructions were stale.

<details><summary>日本語</summary>

README が WinUI 3 移行前 (Win32 + GhosttyBridge シングルトン + OpenGL/Mesa Zink フォールバック) の構成のままになっていた。実装はすでに WinUI 3 + TabView シェルに置き換わっており、「Architecture」セクションとレンダリング・ビルド手順の大部分が現状と合っていなかったので更新する。

</details>

## Changes / 変更

### Modified Files / 変更ファイル

| File | Change |
|------|--------|
| `README.md` | Rewrite to match the current WinUI 3 architecture; drop OpenGL / Mesa Zink content; refresh Known Issues; add License section |

<details><summary>日本語</summary>

| ファイル | 変更内容 |
|------|--------|
| `README.md` | 現行の WinUI 3 アーキテクチャに合わせて全面改稿。OpenGL / Mesa Zink 関連を削除、Known Issues を更新、License セクション追加 |

</details>

## Highlights / 主な変更点

- **Architecture diagram** rewritten: `GhosttyWin32App.exe` → `MainWindow` → `TabView` → `TerminalControl` per tab; `GhosttyApp` wraps `ghostty_app_t`; per-tab D3D11 device + SEH guard.
- **New "Tabs" feature section** covering multi-tab UI, per-tab isolation, custom XAML caption buttons.
- **OpenGL / Mesa Zink** sections removed — `GhosttyWin32App` only links against the libghostty DirectX renderer; the `GHOSTTY_RENDERER` / `GALLIUM_DRIVER` knobs no longer apply.
- **Known Issues** pruned: #8 (exit doesn't close) and #11 (Mesa Defender) closed and removed. Added #13 (split panes) and #17 (Windows-specific config options).
- **Install** section now references #46 for the in-flight SignPath migration, which will drop the elevation requirement for `scoop install`.
- **Building from Source** simplified: WinUI 3 / Windows App SDK workload is required; Mesa Zink step removed.
- **License** section added pointing at the `LICENSE` file (#PR for LICENSE already merged).

<details><summary>日本語</summary>

- **アーキテクチャ図** を刷新: `GhosttyWin32App.exe` → `MainWindow` → `TabView` → タブごとの `TerminalControl`、`GhosttyApp` が `ghostty_app_t` をラップ、タブごとに独立した D3D11 デバイス + SEH ガード
- **Tabs フィーチャーセクションを新設**: マルチタブ UI、タブ単位の隔離、カスタム XAML キャプションボタン
- **OpenGL / Mesa Zink** 関連を削除 — `GhosttyWin32App` は libghostty の DirectX レンダラーにのみリンクしており、`GHOSTTY_RENDERER` / `GALLIUM_DRIVER` 切替は機能しなくなっている
- **Known Issues** を整理: クローズ済の #8 (exit が window を閉じない) と #11 (Mesa Defender) を削除、#13 (split pane) と #17 (Windows 固有 config) を追加
- **Install** セクションから #46 (SignPath 移行) を参照、`scoop install` の elevation 要件解消の見通しを併記
- **Building from Source** を簡略化: WinUI 3 / Windows App SDK ワークロードを必須に、Mesa Zink セクションを削除
- **License** セクションを追加、`LICENSE` ファイル (既マージ) を参照

</details>

## Technical Decisions / 技術的決定

- **README stays English-only.** The writing-guide bilingual format is applied to issues and PRs (and this PR follows it), but the project README is the external face of the repo and matches the existing English-only convention. If a bilingual README is preferred, that can be a follow-up PR.
- **`GhosttyBridge.cpp` / `GhosttyBridge.h` at the repo root are not removed in this PR.** They are no longer referenced from `GhosttyWin32App` and are effectively dead code, but cleanup belongs in a separate refactor PR rather than mixed into a docs change.

<details><summary>日本語</summary>

- **README は英語のみとする。** writing-guide のバイリンガル形式は Issue / PR (この PR 自身も含む) に適用するが、プロジェクト README はリポジトリの対外的な顔であり、既存の英語のみの慣例を維持する。バイリンガル README が望ましいなら後続 PR で対応する
- **ルートの `GhosttyBridge.cpp` / `GhosttyBridge.h` は本 PR では削除しない。** `GhosttyWin32App` から参照されておらず実質デッドコードだが、ドキュメント変更に紛れ込ませず別の整理 PR で行う

</details>

## Related / 関連

- #46 — SignPath Foundation migration (referenced from the install section).
- #13 — Split panes (listed in Known Issues).
- #17 — Windows-specific config options (listed in Known Issues).