### PR TITLE
README: scope MSIX/elevation note to v0.3.0+

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,14 +103,24 @@ scoop bucket add ghostty https://github.com/i999rri/scoop-bucket
 scoop install ghosttywin32
 ```
 
-The bucket ships a signed MSIX. Installation imports the signing certificate
-into `LocalMachine\TrustedPeople` and registers the MSIX via
-`Add-AppxPackage`, so the command currently has to run from an elevated
-PowerShell. See [issue #46](https://github.com/i999rri/GhosttyWin32/issues/46)
-for the in-flight migration to SignPath Foundation, which will remove the
+**v0.2.x (current latest release):** the bucket ships a portable ZIP. No
+elevation required.
+
+**v0.3.0 and later (in development):** the bucket will ship a signed MSIX.
+Installation imports the signing certificate into
+`LocalMachine\TrustedPeople` and registers the MSIX via `Add-AppxPackage`,
+so `scoop install` has to run from an elevated PowerShell. See
+[issue #46](https://github.com/i999rri/GhosttyWin32/issues/46) for the
+in-flight migration to SignPath Foundation, which will remove the
 elevation requirement.
 
-### Manual (MSIX)
+### Manual install
+
+**v0.2.x:** download `GhosttyWin32-v<version>-x64.zip` from
+[Releases](https://github.com/i999rri/GhosttyWin32/releases) and unzip
+anywhere.
+
+**v0.3.0 and later:**
 
 1. Download `Ghostty-<version>-x64.msix` and `Ghostty.cer` from
    [Releases](https://github.com/i999rri/GhosttyWin32/releases).


### PR DESCRIPTION
## Summary / 概要

The Install section warning that `scoop install` "currently has to run from an elevated PowerShell" landed in #48 without a version qualifier. That caveat only applies starting v0.3.0, when the scoop bucket switches from the v0.2.x portable ZIP to a signed MSIX. The current latest release (v0.2.2) installs without elevation, so people pinned to v0.2.x would have mistaken the warning as in effect today.

<details><summary>日本語</summary>

#48 でマージされた Install セクションには「`scoop install` は elevated PowerShell が必要」という注意書きが入っているが、これは scoop bucket が v0.2.x の portable ZIP から署名済 MSIX に切り替わる **v0.3.0 以降のみ** に該当する。現在の最新リリース (v0.2.2) は elevation なしで install できるので、v0.2.x を使っているユーザーが「今この警告が効いている」と誤解しないよう、バージョン境界を明示する。

</details>

## Changes / 変更

### Modified Files / 変更ファイル

| File | Change |
|------|--------|
| `README.md` | Split Scoop and Manual install instructions by version: v0.2.x (ZIP, no elevation) vs v0.3.0+ (MSIX, elevation until #46 lands) |

<details><summary>日本語</summary>

| ファイル | 変更内容 |
|------|--------|
| `README.md` | Scoop と Manual install の手順をバージョンで分割: v0.2.x (ZIP、elevation 不要) と v0.3.0+ (MSIX、#46 解消まで elevation 必要) |

</details>

## Related / 関連

- #48 — README refresh that introduced the unscoped warning.
- #46 — SignPath migration that will drop the elevation requirement for v0.3.x.