### PR TITLE
ci: anchor auto-generated release notes against an explicit baseline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,16 +89,94 @@ jobs:
           Write-Host "Release artifact: $renamed"
           "msix_path=$renamed" >> $env:GITHUB_OUTPUT
 
+      # Pick the previous tag to anchor the auto-generated changelog
+      # against. GitHub's default is "most recent semver tag", which
+      # bundles RC iteration noise into the production release notes
+      # and ignores production lineage when the next release skips a
+      # version. Make the choice explicit instead:
+      #
+      #   vX.Y.Z-rc1     -> latest production tag (e.g. v0.2.2)
+      #   vX.Y.Z-rcN>1   -> previous RC of the same base (vX.Y.Z-rc(N-1))
+      #   vX.Y.Z         -> latest production tag (excluding self)
+      #
+      # If no suitable baseline exists, leave it empty and let GitHub
+      # decide (first-release bootstrap case).
+      - name: Determine previous tag for changelog
+        id: prev
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          prev=""
+          if [[ "$REF_NAME" =~ ^v([0-9]+\.[0-9]+\.[0-9]+)-rc([0-9]+)$ ]]; then
+            base="${BASH_REMATCH[1]}"
+            rc_num="${BASH_REMATCH[2]}"
+            if [[ "$rc_num" -gt 1 ]]; then
+              # Find the highest RC of the same base less than current.
+              # sort -V handles rc1..rc10 numerically (lexical would mis-sort).
+              prev=$(gh release list --limit 100 --json tagName \
+                --jq ".[] | .tagName | select(startswith(\"v${base}-rc\"))" \
+                | grep -vx "$REF_NAME" | sort -V | tail -1 || true)
+            fi
+            if [[ -z "$prev" ]]; then
+              prev=$(gh release list --limit 100 --json tagName,isPrerelease \
+                --jq '[.[] | select(.isPrerelease == false) | .tagName] | first // ""')
+            fi
+          elif [[ "$REF_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            prev=$(gh release list --limit 100 --json tagName,isPrerelease \
+              --jq "[.[] | select(.isPrerelease == false and .tagName != \"$REF_NAME\") | .tagName] | first // \"\"")
+          fi
+          echo "tag=$prev" >> "$GITHUB_OUTPUT"
+          echo "Previous tag selected: ${prev:-<none>}"
+
+      # Generate the changelog body manually so we can pass
+      # previous_tag_name explicitly. softprops/action-gh-release's
+      # generate_release_notes: true would call the same API but with
+      # GitHub's default baseline.
+      - name: Generate release notes body
+        id: notes
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REF_NAME: ${{ github.ref_name }}
+          PREV_TAG: ${{ steps.prev.outputs.tag }}
+        run: |
+          set -euo pipefail
+          if [[ -n "$PREV_TAG" ]]; then
+            body=$(gh api "repos/${GITHUB_REPOSITORY}/releases/generate-notes" \
+              --method POST \
+              -f tag_name="$REF_NAME" \
+              -f previous_tag_name="$PREV_TAG" \
+              --jq '.body')
+          else
+            body=$(gh api "repos/${GITHUB_REPOSITORY}/releases/generate-notes" \
+              --method POST \
+              -f tag_name="$REF_NAME" \
+              --jq '.body')
+          fi
+          {
+            echo "body<<RELEASE_NOTES_EOF"
+            echo "$body"
+            echo "RELEASE_NOTES_EOF"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:
           files: |
             ${{ steps.artifact.outputs.msix_path }}
             ${{ steps.build.outputs.cer-path }}
-          generate_release_notes: true
           # Tags with a hyphen are pre-releases (rc / beta / alpha).
           prerelease: ${{ contains(github.ref_name, '-') }}
+          # Auto-generated changelog (anchored at the tag chosen above)
+          # followed by the install instructions. generate_release_notes
+          # is deliberately not used so previous_tag_name above takes
+          # effect.
           body: |
+            ${{ steps.notes.outputs.body }}
+
             ## Installation
 
             ### Scoop (recommended)


### PR DESCRIPTION
## Summary / 概要

Anchor `release.yml`'s auto-generated release notes against an explicit `previous_tag_name` so RC iteration and stable lineage each get a sensible "Full Changelog" baseline, even when intermediate versions are skipped.

<details><summary>日本語</summary>

`release.yml` の自動生成リリースノートで使う `previous_tag_name` を、タグの種別に応じて明示的に決定するように変更する。これによって RC 連番中も、production 連番中も、また中間バージョンを飛ばしたケースでも、「Full Changelog」が意味のある差分を指すようになる。

</details>

## Background / 背景

GitHub's default `generate_release_notes: true` picks "the most recent semver tag" as the comparison baseline. That produces two awkward outcomes for this project:

- **RC iteration noise** lands in the production body. Going `v0.3.0-rc2 -> v0.3.0` would otherwise show only the few fixes between rc1 and rc2, not the full delta since the previous stable.
- **Skipped versions** anchor incorrectly. If `v0.3.0` never ships as a production release (e.g. blocked on signing) and the next release is `v0.4.0-rc1`, the "Full Changelog" still anchors against `v0.3.0-rc1`, hiding everything that changed since `v0.2.2` — which is the version actually installed by current users.

<details><summary>日本語</summary>

GitHub の `generate_release_notes: true` はデフォルトで「最新の semver タグ」を baseline に選ぶ。このリポでは以下の問題が出る:

- **RC 連番ノイズが production に混入**: 例えば `v0.3.0-rc2 -> v0.3.0` のリリースノートが「rc2 からの差分」しか出さず、stable から見た累積差分が見えなくなる
- **バージョン飛ばしで baseline がズレる**: `v0.3.0` を production として出さずに `v0.4.0-rc1` に進んだ場合、Full Changelog が `v0.3.0-rc1` を baseline にしてしまい、実際にユーザーが使っている `v0.2.2` からの累積差分が分からない

</details>

## Logic / ロジック

| Current tag | Baseline used |
|---|---|
| `vX.Y.Z-rc1` (first RC of the base) | Latest production tag (e.g. `v0.2.2`) |
| `vX.Y.Z-rcN` for N > 1 | Previous RC of the same base (`vX.Y.Z-rc(N-1)`) |
| `vX.Y.Z` (production) | Latest production tag excluding self |

If no suitable baseline exists (bootstrap case), `previous_tag_name` is left empty and GitHub's default applies.

<details><summary>日本語</summary>

| 現タグ | 取る baseline |
|---|---|
| `vX.Y.Z-rc1` (初回 RC) | 直近の production タグ (例: `v0.2.2`) |
| `vX.Y.Z-rcN` (N > 1) | 同じ base の前の RC (`vX.Y.Z-rc(N-1)`) |
| `vX.Y.Z` (production) | 直近の production タグ (自分を除く) |

該当 baseline が無い (最初のリリース等) 場合は空のまま、GitHub のデフォルトに委ねる。

</details>

## Changes / 変更

### Modified Files / 変更ファイル

| File | Change |
|------|--------|
| `.github/workflows/release.yml` | Add `Determine previous tag for changelog` and `Generate release notes body` steps; drop `generate_release_notes: true` from `softprops/action-gh-release` and prepend the manually generated body to the install instructions instead |

<details><summary>日本語</summary>

| ファイル | 変更内容 |
|------|--------|
| `.github/workflows/release.yml` | `Determine previous tag for changelog` と `Generate release notes body` の 2 ステップを追加。`softprops/action-gh-release` から `generate_release_notes: true` を削除し、手動生成した body を install 手順の前に連結する形に変更 |

</details>

## Technical Decisions / 技術的決定

- **Use `sort -V` for RC ordering.** Lexical sort would put `rc10` before `rc2`. `sort -V` handles RC numbers numerically.
- **`generate_release_notes: true` is removed**, not used alongside the manual body. softprops/action-gh-release applies the manual body and then appends the auto-generated notes, but it uses GitHub's default baseline for that — defeating the point of the explicit `previous_tag_name`. Generating notes ourselves and passing the full body wins back the control.
- **Fallback when no baseline is found**: omit `previous_tag_name` entirely and let GitHub decide. Covers the very-first-release bootstrap case.

<details><summary>日本語</summary>

- **RC 順序の決定に `sort -V` を使用**: 辞書順だと `rc10` が `rc2` より前に来てしまう。`sort -V` は数値順で正しく扱う
- **`generate_release_notes: true` は削除**: 手動 body と併用しない。併用すると softprops/action-gh-release は手動 body の後にデフォルト baseline で自動生成したノートを追記するため、明示した `previous_tag_name` が効かなくなる。自分でノートを生成して body 全体を渡す方式に変える
- **baseline が無い場合のフォールバック**: `previous_tag_name` を渡さず GitHub のデフォルトに任せる。最初のリリース用の bootstrap ケースに対応

</details>

## Verification / 検証

Manually exercised the API with the same logic, dry-run for likely upcoming tags:

```
v0.3.1-rc1     -> baseline v0.2.2  (no prior rc for this base, fall back to production)
v0.3.0-rc2     -> baseline v0.3.0-rc1  (same-base RC iteration)
v0.4.0-rc1     -> baseline v0.2.2  (skips v0.3.0 production)
v0.4.0         -> baseline v0.2.2  (or v0.3.0 if it ships)
```

The actual workflow run will be exercised the next time a tag is pushed.

<details><summary>日本語</summary>

同じロジックを API 単体で手動実行し、近い将来のタグ候補で dry-run 確認:

```
v0.3.1-rc1     -> baseline v0.2.2  (このベースの前 RC なし、production にフォールバック)
v0.3.0-rc2     -> baseline v0.3.0-rc1  (同 base の RC 連番)
v0.4.0-rc1     -> baseline v0.2.2  (v0.3.0 production を飛ばすパターン)
v0.4.0         -> baseline v0.2.2  (v0.3.0 が出ていればそちら)
```

実際の workflow 実行は次の tag push 時に確認する。

</details>

## Related / 関連

- Discovered while planning the v0.3.x release flow under #46 (SignPath migration). The existing `open-release-pr.yml` already uses an explicit `previous_tag_name`; this PR brings `release.yml` in line.
