### PR TITLE
Handle GHOSTTY_ACTION_OPEN_URL via ShellExecuteW

### DIFF
--- a/GhosttyWin32App/MainWindow.xaml.cpp
+++ b/GhosttyWin32App/MainWindow.xaml.cpp
@@ -9,9 +9,11 @@
 #endif
 #include <microsoft.ui.xaml.window.h>
 #include <dwmapi.h>
+#include <shellapi.h>
 #include <filesystem>
 #include <fstream>
 #pragma comment(lib, "dwmapi.lib")
+#pragma comment(lib, "shell32.lib")
 
 namespace {
     // Flag file used to detect that the previous process didn't exit cleanly.
@@ -491,6 +493,25 @@ namespace winrt::GhosttyWin32::implementation
                             winrt::Windows::UI::Color{ 255, r, g, b });
                         mw->Content().as<winrt::Microsoft::UI::Xaml::Controls::Panel>().Background(brush);
                     });
+                }
+                return true;
+            }
+
+            // Ctrl+click on a URL in the terminal. Hand off to the shell
+            // verb opener so the user's default browser / mail client /
+            // etc. handles it. Without this, libghostty falls back to
+            // spawning `rundll32 url.dll,FileProtocolHandler` via
+            // std.process.Child, which works but is slower and leaves a
+            // brief child-process flash visible in tools like Process
+            // Hacker.
+            if (action.tag == GHOSTTY_ACTION_OPEN_URL) {
+                auto& ou = action.action.open_url;
+                if (ou.url && ou.len > 0) {
+                    std::wstring wurl = Encoding::toUtf16(ou.url, static_cast<int>(ou.len));
+                    if (!wurl.empty()) {
+                        HWND hwnd = g_mainWindow ? g_mainWindow->m_hwnd : nullptr;
+                        ShellExecuteW(hwnd, L"open", wurl.c_str(), nullptr, nullptr, SW_SHOWNORMAL);
+                    }
                 }
                 return true;
             }


### PR DESCRIPTION
## Summary

Wire `GHOSTTY_ACTION_OPEN_URL` into `ShellExecuteW`. Before this, Ctrl+click on a URL in the terminal crashed the host with exit code 3 inside `ghostty.dll`. Root cause is in libghostty's `resolvePathForOpening` on Windows — fix in i999rri/ghostty#39 (windows-port). With both fixes:

- Ctrl+click `https://example.com` → opens the user's default browser via `ShellExecuteW`.
- Ctrl+click `src/foo.zig:42:10` → no panic; the action is delivered with the raw URL, which Windows decides how to handle.

Routing through our own handler instead of letting libghostty fall back to `rundll32 url.dll,FileProtocolHandler` matches the behaviour the README already advertised and avoids a brief `rundll32` child-process flash in task managers.

## Dependencies

- Requires i999rri/ghostty#39 in `ghostty.dll` to actually clear the panic. Without that, this PR alone gets you "GHOSTTY_ACTION_OPEN_URL is now wired up" but the panic still fires earlier in libghostty before the action is dispatched.

## Test plan

- [x] Manual: Ctrl+click a URL in a tab → default browser opens at that URL.
- [x] Manual: Multiple tabs, URL clicked in tab 2 → opens; other tabs unaffected.
- [x] Manual: URL containing IDN / non-ASCII path → opens (UTF-8 → UTF-16 round-trips via `Encoding::toUtf16`).

Closes #12.
