### PR TITLE
Wire MOUSE_SHAPE into TerminalControl.ProtectedCursor

### DIFF
--- a/GhosttyWin32App/MainWindow.xaml.cpp
+++ b/GhosttyWin32App/MainWindow.xaml.cpp
@@ -497,6 +497,27 @@ namespace winrt::GhosttyWin32::implementation
                 return true;
             }
 
+            // Pointer cursor shape requests — IBeam over cells, Hand
+            // when Ctrl-hovering a link, resize arrows on split borders
+            // (not yet exposed), etc. Per-surface so multi-tab windows
+            // can have different cursors per tab.
+            if (action.tag == GHOSTTY_ACTION_MOUSE_SHAPE
+                && target.tag == GHOSTTY_TARGET_SURFACE) {
+                auto surface = target.target.surface;
+                auto shape = action.action.mouse_shape;
+                if (g_mainWindow && surface) {
+                    auto mw = g_mainWindow;
+                    mw->DispatcherQueue().TryEnqueue([mw, surface, shape]() {
+                        if (auto* t = mw->m_tabs.FindBySurface(surface)) {
+                            if (auto* tc = t->ActiveControl()) {
+                                tc->SetCursorShape(shape);
+                            }
+                        }
+                    });
+                }
+                return true;
+            }
+
             // Ctrl+click on a URL in the terminal. Hand off to the shell
             // verb opener so the user's default browser / mail client /
             // etc. handles it. Without this, libghostty falls back to

--- a/GhosttyWin32App/TerminalControl.xaml.cpp
+++ b/GhosttyWin32App/TerminalControl.xaml.cpp
@@ -267,6 +267,46 @@ namespace winrt::GhosttyWin32::implementation
             keyEvent.mods = currentMods();
             ghostty_surface_key(self->m_surface, keyEvent);
         });
+
+        // Terminals default to a text-input cursor; ghostty issues a
+        // MOUSE_SHAPE = TEXT request once the surface is wired up, but
+        // setting it here too avoids a flash of arrow cursor between
+        // window show and the first ghostty tick.
+        SetCursorShape(GHOSTTY_MOUSE_SHAPE_TEXT);
+    }
+
+    void TerminalControl::SetCursorShape(ghostty_action_mouse_shape_e shape)
+    {
+        using muxi = winrt::Microsoft::UI::Input::InputSystemCursorShape;
+        muxi mapped;
+        switch (shape) {
+            case GHOSTTY_MOUSE_SHAPE_TEXT:
+            case GHOSTTY_MOUSE_SHAPE_VERTICAL_TEXT:    mapped = muxi::IBeam; break;
+            case GHOSTTY_MOUSE_SHAPE_POINTER:          mapped = muxi::Hand; break;
+            case GHOSTTY_MOUSE_SHAPE_HELP:             mapped = muxi::Help; break;
+            case GHOSTTY_MOUSE_SHAPE_WAIT:             mapped = muxi::Wait; break;
+            case GHOSTTY_MOUSE_SHAPE_PROGRESS:         mapped = muxi::AppStarting; break;
+            case GHOSTTY_MOUSE_SHAPE_CROSSHAIR:        mapped = muxi::Cross; break;
+            case GHOSTTY_MOUSE_SHAPE_NOT_ALLOWED:
+            case GHOSTTY_MOUSE_SHAPE_NO_DROP:          mapped = muxi::UniversalNo; break;
+            case GHOSTTY_MOUSE_SHAPE_ALL_SCROLL:       mapped = muxi::SizeAll; break;
+            case GHOSTTY_MOUSE_SHAPE_N_RESIZE:
+            case GHOSTTY_MOUSE_SHAPE_S_RESIZE:
+            case GHOSTTY_MOUSE_SHAPE_NS_RESIZE:
+            case GHOSTTY_MOUSE_SHAPE_ROW_RESIZE:       mapped = muxi::SizeNorthSouth; break;
+            case GHOSTTY_MOUSE_SHAPE_E_RESIZE:
+            case GHOSTTY_MOUSE_SHAPE_W_RESIZE:
+            case GHOSTTY_MOUSE_SHAPE_EW_RESIZE:
+            case GHOSTTY_MOUSE_SHAPE_COL_RESIZE:       mapped = muxi::SizeWestEast; break;
+            case GHOSTTY_MOUSE_SHAPE_NE_RESIZE:
+            case GHOSTTY_MOUSE_SHAPE_SW_RESIZE:
+            case GHOSTTY_MOUSE_SHAPE_NESW_RESIZE:      mapped = muxi::SizeNortheastSouthwest; break;
+            case GHOSTTY_MOUSE_SHAPE_NW_RESIZE:
+            case GHOSTTY_MOUSE_SHAPE_SE_RESIZE:
+            case GHOSTTY_MOUSE_SHAPE_NWSE_RESIZE:      mapped = muxi::SizeNorthwestSoutheast; break;
+            default:                                   mapped = muxi::Arrow; break;
+        }
+        ProtectedCursor(winrt::Microsoft::UI::Input::InputSystemCursor::Create(mapped));
     }
 
     TerminalControl::~TerminalControl()

--- a/GhosttyWin32App/TerminalControl.xaml.h
+++ b/GhosttyWin32App/TerminalControl.xaml.h
@@ -100,6 +100,14 @@ namespace winrt::GhosttyWin32::implementation
         ghostty_surface_t Surface() const noexcept { return m_surface; }
         HANDLE CompositionHandle() const noexcept { return m_compositionHandle; }
 
+        // Apply a ghostty-requested mouse cursor shape. Must be called on
+        // the UI thread (the caller in MainWindow::action_cb dispatches
+        // via DispatcherQueue). Unrecognised shapes fall back to Arrow.
+        // Used both for the initial IBeam set in the ctor and for live
+        // updates as the pointer moves over/off cells, links, resize
+        // borders, etc.
+        void SetCursorShape(ghostty_action_mouse_shape_e shape);
+
     private:
         // Builds the per-control CoreTextEditContext and wires its
         // seven event handlers (TextRequested / SelectionRequested /


### PR DESCRIPTION
## Summary

Apply ghostty's requested cursor shape to the active TerminalControl so the cursor actually responds to terminal state:

- IBeam over normal cells (drag-to-select feels right).
- Hand when Ctrl-hovering a URL (visual cue that the click is going somewhere).
- Resize cursors prewired for future split-pane work (col/row/8-directional).

The previous behaviour was a single static arrow cursor regardless of what ghostty asked for, which made link Ctrl-hover ambiguous and selection drags feel un-native.

## How it's wired

- `TerminalControl::SetCursorShape(ghostty_action_mouse_shape_e)` maps the ghostty enum to `Microsoft::UI::Input::InputSystemCursorShape` and sets it via `UIElement::ProtectedCursor`. Unknown shapes fall back to `Arrow`.
- `MainWindow::action_cb` catches `GHOSTTY_ACTION_MOUSE_SHAPE` and dispatches to the matching surface's `TerminalControl` via `DispatcherQueue` (action_cb is called from the renderer thread; `ProtectedCursor` must be set from the UI thread).
- Constructor seeds `IBeam` directly to avoid a flash of arrow cursor between window show and the first ghostty tick.

## Test plan

- [x] Manual: hover over cells → IBeam.
- [x] Manual: Ctrl+hover a URL → Hand. (Pairs with #52.)
- [x] Manual: release Ctrl → IBeam comes back.
- [x] Manual: switch tabs → each tab tracks its own cursor (different selection states don't bleed).
