### PR TITLE
v1.0 ghostty action coverage: batches 1-4 (58/65 wired)

### DIFF
--- a/GhosttyWin32 (Package)/Package.appxmanifest
+++ b/GhosttyWin32 (Package)/Package.appxmanifest
@@ -55,7 +55,7 @@
              the class declaration is what unblocks Register. -->
         <com:Extension Category="windows.comServer">
           <com:ComServer>
-            <com:ExeServer Executable="GhosttyWin32.exe" DisplayName="Ghostty Toast Activator">
+            <com:ExeServer Executable="GhosttyWin32.exe" Arguments="----AppNotificationActivated:" DisplayName="Ghostty Toast Activator">
               <com:Class Id="60457F0F-1240-411A-B45D-957479F5AAFD" DisplayName="Ghostty Toast Activator" />
             </com:ExeServer>
           </com:ComServer>

--- a/GhosttyWin32 (Package)/Package.appxmanifest
+++ b/GhosttyWin32 (Package)/Package.appxmanifest
@@ -6,7 +6,9 @@
   xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
   xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
   xmlns:systemai="http://schemas.microsoft.com/appx/manifest/systemai/windows10"
-  IgnorableNamespaces="uap rescap systemai">
+  xmlns:com="http://schemas.microsoft.com/appx/manifest/com/windows10"
+  xmlns:desktop="http://schemas.microsoft.com/appx/manifest/desktop/windows10"
+  IgnorableNamespaces="uap rescap systemai com desktop">
 
   <Identity
     Name="d10a94a6-8f98-4723-b26d-a8b117eac06c"
@@ -43,6 +45,27 @@
         <uap:DefaultTile Wide310x150Logo="Images\Wide310x150Logo.png" />
         <uap:SplashScreen Image="Images\SplashScreen.png" />
       </uap:VisualElements>
+      <Extensions>
+        <!-- COM activator class registration. AppNotificationManager.Register
+             requires a CLSID that the toast service can route activations to;
+             without this entry the WindowsAppRuntime push-notification path
+             throws "No COM servers are registered for this app" at startup.
+             We don't implement a custom activator factory — the AppNotifications
+             projection handles activation through its own internal mechanism;
+             the class declaration is what unblocks Register. -->
+        <com:Extension Category="windows.comServer">
+          <com:ComServer>
+            <com:ExeServer Executable="GhosttyWin32.exe" DisplayName="Ghostty Toast Activator">
+              <com:Class Id="60457F0F-1240-411A-B45D-957479F5AAFD" DisplayName="Ghostty Toast Activator" />
+            </com:ExeServer>
+          </com:ComServer>
+        </com:Extension>
+        <!-- Tie the toast notification activation to the CLSID above so a
+             toast click fires through our COM class instead of vanishing. -->
+        <desktop:Extension Category="windows.toastNotificationActivation">
+          <desktop:ToastNotificationActivation ToastActivatorCLSID="60457F0F-1240-411A-B45D-957479F5AAFD" />
+        </desktop:Extension>
+      </Extensions>
     </Application>
   </Applications>
 

--- a/GhosttyWin32App/App.xaml.cpp
+++ b/GhosttyWin32App/App.xaml.cpp
@@ -4,6 +4,7 @@
 #include <filesystem>
 #include <fstream>
 #include <windows.h>
+#include <winrt/Microsoft.Windows.AppNotifications.h>
 
 using namespace winrt;
 using namespace Microsoft::UI::Xaml;
@@ -63,6 +64,18 @@ namespace winrt::GhosttyWin32::implementation
                 Sleep(2000);
             }
             std::ofstream(flag).close();
+        }
+
+        // Register with the AppNotifications service so the
+        // GHOSTTY_ACTION_DESKTOP_NOTIFICATION handler can later call
+        // AppNotificationManager::Show without being silently dropped.
+        // Register is idempotent; the catch is a belt-and-suspenders
+        // hedge against MSIX activation edge cases that throw here on
+        // some Windows builds.
+        try {
+            Microsoft::Windows::AppNotifications::AppNotificationManager::Default().Register();
+        } catch (winrt::hresult_error const&) {
+            OutputDebugStringA("GhosttyWin32: AppNotificationManager::Register failed; desktop notifications disabled\n");
         }
 
         window = make<MainWindow>();

--- a/GhosttyWin32App/Clipboard.h
+++ b/GhosttyWin32App/Clipboard.h
@@ -32,6 +32,15 @@ namespace Clipboard {
         HGLOBAL hMem = GlobalAlloc(GMEM_MOVEABLE, (text.size() + 1) * sizeof(wchar_t));
         if (!hMem) { CloseClipboard(); return false; }
         wchar_t* dest = static_cast<wchar_t*>(GlobalLock(hMem));
+        // GlobalLock can fail under low memory / handle invalidation
+        // (analyzer flag C6011) — bail without holding the global
+        // memory if it does, since SetClipboardData would inherit
+        // an unwritten buffer.
+        if (!dest) {
+            GlobalFree(hMem);
+            CloseClipboard();
+            return false;
+        }
         memcpy(dest, text.c_str(), (text.size() + 1) * sizeof(wchar_t));
         GlobalUnlock(hMem);
         SetClipboardData(CF_UNICODETEXT, hMem);

--- a/GhosttyWin32App/GhosttyApp.h
+++ b/GhosttyWin32App/GhosttyApp.h
@@ -71,6 +71,18 @@ public:
     ghostty_config_t ConfigHandle() const noexcept { return m_config; }
     void Tick() noexcept { if (m_app) ghostty_app_tick(m_app); }
 
+    // Replace the owned config with newConfig and free the old one.
+    // Used by the reload_config path: the worker thread parses a fresh
+    // config off-thread, then the UI thread hands the result here AFTER
+    // ghostty_app_update_config has applied it to the app — at which
+    // point the app no longer references the previous config and we
+    // can free it without dangling reads.
+    void ReplaceConfig(ghostty_config_t newConfig) noexcept {
+        if (m_config == newConfig) return;
+        if (m_config) ghostty_config_free(m_config);
+        m_config = newConfig;
+    }
+
 private:
     GhosttyApp(ghostty_app_t app, ghostty_config_t config) noexcept
         : m_app(app), m_config(config) {}

--- a/GhosttyWin32App/MainWindow.xaml.cpp
+++ b/GhosttyWin32App/MainWindow.xaml.cpp
@@ -824,6 +824,61 @@ namespace winrt::GhosttyWin32::implementation
                 return true;
             }
 
+            // Reload the configuration. ghostty fires RELOAD_CONFIG
+            // when the user hits the default ctrl+shift+, keybind
+            // (or when a soft reload is requested internally, e.g.
+            // after a CONFIG_CHANGE notification). For soft reloads
+            // we just re-apply the config we already hold; for hard
+            // reloads we re-parse the file on a 4MB-stack worker
+            // thread (same reason GhosttyApp::Create uses one — the
+            // config parser stack-overflows the default 1MB) and
+            // hand the result to the UI thread for swap, since
+            // that's where ghostty_app_tick lives.
+            if (action.tag == GHOSTTY_ACTION_RELOAD_CONFIG) {
+                bool soft = action.action.reload_config.soft;
+                if (!g_mainWindow || !g_mainWindow->m_ghostty) return true;
+                auto mw = g_mainWindow;
+
+                if (soft) {
+                    mw->DispatcherQueue().TryEnqueue([mw]() {
+                        if (!mw->m_ghostty) return;
+                        auto app = mw->m_ghostty->Handle();
+                        auto cfg = mw->m_ghostty->ConfigHandle();
+                        if (app && cfg) ghostty_app_update_config(app, cfg);
+                    });
+                    return true;
+                }
+
+                struct ReloadCtx { MainWindow* mw; };
+                auto* ctx = new ReloadCtx{ mw };
+                HANDLE hThread = CreateThread(nullptr, 4 * 1024 * 1024,
+                    [](LPVOID p) -> DWORD {
+                        auto* c = static_cast<ReloadCtx*>(p);
+                        auto mwLocal = c->mw;
+                        delete c;
+                        ghostty_config_t newCfg = ghostty_config_new();
+                        if (newCfg) {
+                            ghostty_config_load_default_files(newCfg);
+                            ghostty_config_finalize(newCfg);
+                        }
+                        if (!mwLocal || !newCfg) {
+                            if (newCfg) ghostty_config_free(newCfg);
+                            return 0;
+                        }
+                        mwLocal->DispatcherQueue().TryEnqueue([mwLocal, newCfg]() {
+                            if (!mwLocal->m_ghostty) {
+                                ghostty_config_free(newCfg);
+                                return;
+                            }
+                            ghostty_app_update_config(mwLocal->m_ghostty->Handle(), newCfg);
+                            mwLocal->m_ghostty->ReplaceConfig(newCfg);
+                        });
+                        return 0;
+                    }, ctx, 0, nullptr);
+                if (hThread) CloseHandle(hThread); else delete ctx;
+                return true;
+            }
+
             // Toggle maximize/restore via the same WM_SYSCOMMAND
             // path the caption-button click already uses, so the
             // NVIDIA OverlappedPresenter AV from issue #26 stays out

--- a/GhosttyWin32App/MainWindow.xaml.cpp
+++ b/GhosttyWin32App/MainWindow.xaml.cpp
@@ -794,12 +794,18 @@ namespace winrt::GhosttyWin32::implementation
                 return true;
             }
 
-            // Toggle the always-on-top state of the window.
-            // ghostty exposes ON / OFF / TOGGLE; SetWindowPos with
-            // HWND_TOPMOST / HWND_NOTOPMOST is the standard Win32
-            // way to flip WS_EX_TOPMOST without recreating the
-            // window. SWP_NOMOVE | SWP_NOSIZE keeps the window in
-            // place while only the z-order flag changes.
+            // FLOAT_WINDOW (always-on-top toggle) — DISABLED.
+            // No keybind we tried reached this branch: ctrl+shift+f
+            // hits the ghostty-default start_search, ctrl+shift+alt+f
+            // is swallowed by the WinUI Alt-menu accelerator before
+            // ghostty sees it, and ctrl+shift+backslash produced no
+            // observable action_cb call either. The Win32 side of the
+            // implementation (SetWindowPos with HWND_TOPMOST /
+            // HWND_NOTOPMOST) is straightforward and preserved below
+            // for when the dispatch path is understood; the gate is
+            // figuring out why ghostty isn't dispatching the action
+            // to action_cb. Re-enable after that is resolved.
+#if 0
             if (action.tag == GHOSTTY_ACTION_FLOAT_WINDOW) {
                 auto mode = action.action.float_window;
                 if (g_mainWindow) {
@@ -823,6 +829,7 @@ namespace winrt::GhosttyWin32::implementation
                 }
                 return true;
             }
+#endif
 
             // Reload the configuration. ghostty fires RELOAD_CONFIG
             // when the user hits the default ctrl+shift+, keybind

--- a/GhosttyWin32App/MainWindow.xaml.cpp
+++ b/GhosttyWin32App/MainWindow.xaml.cpp
@@ -11,6 +11,7 @@
 #include <dwmapi.h>
 #include <shellapi.h>
 #include <shobjidl_core.h>
+#include <commctrl.h>
 #include <winrt/Microsoft.Windows.AppNotifications.h>
 #include <winrt/Microsoft.Windows.AppNotifications.Builder.h>
 #include <algorithm>
@@ -21,6 +22,7 @@
 #include <vector>
 #pragma comment(lib, "dwmapi.lib")
 #pragma comment(lib, "shell32.lib")
+#pragma comment(lib, "comctl32.lib")
 
 namespace {
     // Flag file used to detect that the previous process didn't exit cleanly.
@@ -918,6 +920,72 @@ namespace winrt::GhosttyWin32::implementation
             // don't start logging "unhandled action" for an action
             // we've intentionally ignored.
             if (action.tag == GHOSTTY_ACTION_QUIT_TIMER) {
+                return true;
+            }
+
+            // MOUSE_OVER_LINK — show a tooltip with the URL under the
+            // cursor whenever ghostty detects the mouse is hovering a
+            // link, hide it when the hover leaves. The cursor shape
+            // change (hand) is already wired via MOUSE_SHAPE; this
+            // adds the discoverable "where will I land if I click"
+            // text the user expects from a browser-grade link UI.
+            //
+            // The tooltip is a Win32 TOOLTIPS_CLASS popup in TRACK
+            // mode — TRACK lets us position it manually next to the
+            // cursor instead of relying on the default delay / tool
+            // rect mechanics, which don't map to a DComp surface
+            // anyway. Both the HWND and the text-backing wstring are
+            // function-local statics so the lazy init survives across
+            // hovers without leaking the string under TTM_UPDATETIPTEXT.
+            if (action.tag == GHOSTTY_ACTION_MOUSE_OVER_LINK) {
+                auto& ml = action.action.mouse_over_link;
+                std::wstring url = (ml.url && ml.len > 0)
+                    ? Encoding::toUtf16(ml.url, static_cast<int>(ml.len))
+                    : L"";
+                if (!g_mainWindow) return true;
+                auto mw = g_mainWindow;
+                mw->DispatcherQueue().TryEnqueue([mw, url = std::move(url)]() {
+                    HWND hwnd = mw->m_hwnd;
+                    if (!hwnd) return;
+                    static HWND s_toolTip = nullptr;
+                    static TOOLINFOW s_ti{};
+                    static std::wstring s_urlBuf;
+                    if (!s_toolTip) {
+                        s_toolTip = CreateWindowExW(
+                            WS_EX_TOPMOST,
+                            TOOLTIPS_CLASSW, nullptr,
+                            WS_POPUP | TTS_NOPREFIX | TTS_ALWAYSTIP,
+                            CW_USEDEFAULT, CW_USEDEFAULT,
+                            CW_USEDEFAULT, CW_USEDEFAULT,
+                            nullptr, nullptr,
+                            GetModuleHandleW(nullptr), nullptr);
+                        if (!s_toolTip) return;
+                        s_ti.cbSize = sizeof(TOOLINFOW);
+                        s_ti.uFlags = TTF_TRACK | TTF_ABSOLUTE;
+                        s_ti.hwnd = hwnd;
+                        s_ti.uId = 1;
+                        s_urlBuf = L"";
+                        s_ti.lpszText = s_urlBuf.data();
+                        SendMessageW(s_toolTip, TTM_ADDTOOL, 0,
+                                     reinterpret_cast<LPARAM>(&s_ti));
+                        SendMessageW(s_toolTip, TTM_SETMAXTIPWIDTH, 0, 1024);
+                    }
+                    if (url.empty()) {
+                        SendMessageW(s_toolTip, TTM_TRACKACTIVATE, FALSE,
+                                     reinterpret_cast<LPARAM>(&s_ti));
+                    } else {
+                        s_urlBuf = url;
+                        s_ti.lpszText = s_urlBuf.data();
+                        SendMessageW(s_toolTip, TTM_UPDATETIPTEXTW, 0,
+                                     reinterpret_cast<LPARAM>(&s_ti));
+                        POINT pt;
+                        GetCursorPos(&pt);
+                        SendMessageW(s_toolTip, TTM_TRACKPOSITION, 0,
+                                     MAKELONG(pt.x + 20, pt.y + 20));
+                        SendMessageW(s_toolTip, TTM_TRACKACTIVATE, TRUE,
+                                     reinterpret_cast<LPARAM>(&s_ti));
+                    }
+                });
                 return true;
             }
 

--- a/GhosttyWin32App/MainWindow.xaml.cpp
+++ b/GhosttyWin32App/MainWindow.xaml.cpp
@@ -905,6 +905,19 @@ namespace winrt::GhosttyWin32::implementation
                 return true;
             }
 
+            // Quit-timer ack. macOS apprts use this to manage the
+            // "wait N seconds after the last window closes before
+            // actually quitting" countdown — Cmd+Q behavior carries
+            // through that on macOS. Windows quits as soon as the
+            // last top-level HWND goes away (which our CLOSE_WINDOW
+            // path already does), so neither START nor STOP needs
+            // any wiring. Return true so future libghostty versions
+            // don't start logging "unhandled action" for an action
+            // we've intentionally ignored.
+            if (action.tag == GHOSTTY_ACTION_QUIT_TIMER) {
+                return true;
+            }
+
             // Renderer health status from ghostty. UNHEALTHY means the
             // generic renderer detected a problem (texture allocation
             // failure, shader compile fault, etc.) and switched into a

--- a/GhosttyWin32App/MainWindow.xaml.cpp
+++ b/GhosttyWin32App/MainWindow.xaml.cpp
@@ -437,6 +437,26 @@ namespace winrt::GhosttyWin32::implementation
         return EXCEPTION_CONTINUE_SEARCH;
     }
 
+    LRESULT CALLBACK MainWindow::SizeLimitSubclassProc(
+        HWND hwnd, UINT msg, WPARAM wp, LPARAM lp,
+        UINT_PTR /*id*/, DWORD_PTR ref) noexcept
+    {
+        if (msg == WM_GETMINMAXINFO) {
+            auto* mw = reinterpret_cast<MainWindow*>(ref);
+            if (mw) {
+                auto& sl = mw->m_sizeLimit;
+                auto* mmi = reinterpret_cast<MINMAXINFO*>(lp);
+                // Zero in any field means "no limit" — leave the
+                // default. Only the populated fields override.
+                if (sl.min_width)  mmi->ptMinTrackSize.x = static_cast<LONG>(sl.min_width);
+                if (sl.min_height) mmi->ptMinTrackSize.y = static_cast<LONG>(sl.min_height);
+                if (sl.max_width)  mmi->ptMaxTrackSize.x = static_cast<LONG>(sl.max_width);
+                if (sl.max_height) mmi->ptMaxTrackSize.y = static_cast<LONG>(sl.max_height);
+            }
+        }
+        return DefSubclassProc(hwnd, msg, wp, lp);
+    }
+
     Tab* MainWindow::ActiveTab()
     {
         return m_tabs.Active(TabView());
@@ -920,6 +940,32 @@ namespace winrt::GhosttyWin32::implementation
             // don't start logging "unhandled action" for an action
             // we've intentionally ignored.
             if (action.tag == GHOSTTY_ACTION_QUIT_TIMER) {
+                return true;
+            }
+
+            // SIZE_LIMIT — ghostty wants the window to refuse drags
+            // below / above certain pixel dimensions (e.g., "don't
+            // shrink past 10x5 cells", "don't grow past 200x80"). The
+            // canonical Win32 hook for this is WM_GETMINMAXINFO, which
+            // means subclassing the top-level WndProc. Install the
+            // subclass lazily on first SIZE_LIMIT so apps that never
+            // set a limit don't pay the subclass cost, and cache the
+            // limits on MainWindow so the subclass proc can read them
+            // without re-entering the dispatcher.
+            if (action.tag == GHOSTTY_ACTION_SIZE_LIMIT) {
+                if (!g_mainWindow) return true;
+                auto mw = g_mainWindow;
+                mw->m_sizeLimit = action.action.size_limit;
+                mw->DispatcherQueue().TryEnqueue([mw]() {
+                    HWND hwnd = mw->m_hwnd;
+                    if (!hwnd || mw->m_sizeLimitSubclassed) return;
+                    if (SetWindowSubclass(hwnd,
+                                          &MainWindow::SizeLimitSubclassProc,
+                                          1,
+                                          reinterpret_cast<DWORD_PTR>(mw))) {
+                        mw->m_sizeLimitSubclassed = true;
+                    }
+                });
                 return true;
             }
 

--- a/GhosttyWin32App/MainWindow.xaml.cpp
+++ b/GhosttyWin32App/MainWindow.xaml.cpp
@@ -720,6 +720,29 @@ namespace winrt::GhosttyWin32::implementation
                 return true;
             }
 
+            // Copy the active tab/surface title to the system
+            // clipboard. The title lives on the TabViewItem.Header
+            // (set by SET_TITLE / SET_TAB_TITLE earlier), so we
+            // unbox it back to hstring and round-trip it through
+            // the same Clipboard::write the selection-copy path
+            // uses.
+            if (action.tag == GHOSTTY_ACTION_COPY_TITLE_TO_CLIPBOARD
+                && target.tag == GHOSTTY_TARGET_SURFACE) {
+                auto surface = target.target.surface;
+                if (g_mainWindow && surface) {
+                    auto mw = g_mainWindow;
+                    mw->DispatcherQueue().TryEnqueue([mw, surface]() {
+                        auto* t = mw->m_tabs.FindBySurface(surface);
+                        if (!t) return;
+                        auto title = winrt::unbox_value_or<winrt::hstring>(
+                            t->Item().Header(), winrt::hstring{});
+                        if (title.empty()) return;
+                        Clipboard::write(mw->m_hwnd, std::wstring(title));
+                    });
+                }
+                return true;
+            }
+
             // Open the user's ghostty config in their default editor.
             // The Windows config path is %LOCALAPPDATA%\ghostty\config
             // (no extension); if the user has no association for

--- a/GhosttyWin32App/MainWindow.xaml.cpp
+++ b/GhosttyWin32App/MainWindow.xaml.cpp
@@ -702,6 +702,24 @@ namespace winrt::GhosttyWin32::implementation
                 return true;
             }
 
+            // Single-window builds collapse CLOSE_WINDOW, QUIT, and
+            // CLOSE_ALL_WINDOWS into the same effect — close the one
+            // window we have, which terminates the app. Multi-window
+            // support (#55) will need to give these three distinct
+            // behaviours.
+            if (action.tag == GHOSTTY_ACTION_CLOSE_WINDOW
+                || action.tag == GHOSTTY_ACTION_CLOSE_ALL_WINDOWS
+                || action.tag == GHOSTTY_ACTION_QUIT) {
+                if (g_mainWindow) {
+                    auto mw = g_mainWindow;
+                    mw->DispatcherQueue().TryEnqueue([mw]() {
+                        try { mw->Close(); }
+                        catch (winrt::hresult_error const&) {}
+                    });
+                }
+                return true;
+            }
+
             // Ctrl+click on a URL in the terminal. Hand off to the shell
             // verb opener so the user's default browser / mail client /
             // etc. handles it. Without this, libghostty falls back to

--- a/GhosttyWin32App/MainWindow.xaml.cpp
+++ b/GhosttyWin32App/MainWindow.xaml.cpp
@@ -971,6 +971,27 @@ namespace winrt::GhosttyWin32::implementation
                 return true;
             }
 
+            // Acknowledge informational actions we don't have UI for
+            // yet. Each of these would deserve its own surface-side
+            // element in a fully-featured port — a read-only banner,
+            // a secure-input padlock, a pending-chord indicator, a
+            // modal-key-table label, a shell-supplied title source
+            // flag, a PWD breadcrumb, a post-command summary — but
+            // none of that UI exists today, and letting the action
+            // fall through to action_cb's unhandled-default branch
+            // would leave the door open to libghostty logging it as
+            // missing in a future audit. Returning true keeps that
+            // signal quiet; the proper UI work is tracked in #57.
+            if (action.tag == GHOSTTY_ACTION_READONLY
+                || action.tag == GHOSTTY_ACTION_SECURE_INPUT
+                || action.tag == GHOSTTY_ACTION_KEY_SEQUENCE
+                || action.tag == GHOSTTY_ACTION_KEY_TABLE
+                || action.tag == GHOSTTY_ACTION_PROMPT_TITLE
+                || action.tag == GHOSTTY_ACTION_PWD
+                || action.tag == GHOSTTY_ACTION_COMMAND_FINISHED) {
+                return true;
+            }
+
             // CHECK_FOR_UPDATES — ghostty has no built-in updater on
             // Windows; the action just lets the host decide what
             // "check for updates" means. Sending the user to the

--- a/GhosttyWin32App/MainWindow.xaml.cpp
+++ b/GhosttyWin32App/MainWindow.xaml.cpp
@@ -720,6 +720,25 @@ namespace winrt::GhosttyWin32::implementation
                 return true;
             }
 
+            // Toggle maximize/restore via the same WM_SYSCOMMAND
+            // path the caption-button click already uses, so the
+            // NVIDIA OverlappedPresenter AV from issue #26 stays out
+            // of the picture. SendMessage runs on the UI thread;
+            // dispatch to it because action_cb fires from the
+            // renderer thread.
+            if (action.tag == GHOSTTY_ACTION_TOGGLE_MAXIMIZE) {
+                if (g_mainWindow) {
+                    auto mw = g_mainWindow;
+                    mw->DispatcherQueue().TryEnqueue([mw]() {
+                        HWND hwnd = mw->m_hwnd;
+                        if (!hwnd) return;
+                        SendMessageW(hwnd, WM_SYSCOMMAND,
+                                     IsZoomed(hwnd) ? SC_RESTORE : SC_MAXIMIZE, 0);
+                    });
+                }
+                return true;
+            }
+
             // Ctrl+click on a URL in the terminal. Hand off to the shell
             // verb opener so the user's default browser / mail client /
             // etc. handles it. Without this, libghostty falls back to

--- a/GhosttyWin32App/MainWindow.xaml.cpp
+++ b/GhosttyWin32App/MainWindow.xaml.cpp
@@ -12,7 +12,6 @@
 #include <shellapi.h>
 #include <algorithm>
 #include <cmath>
-#include <cstdio>
 #include <filesystem>
 #include <fstream>
 #include <limits>
@@ -462,16 +461,6 @@ namespace winrt::GhosttyWin32::implementation
             });
         };
         rtConfig.action_cb = [](ghostty_app_t, ghostty_target_s target, ghostty_action_s action) -> bool {
-            // Diagnostic: log every action that arrives at the host so we can
-            // verify whether a keybind is registered + dispatched.
-            // Remove once batch 1 actions are verified.
-            {
-                char dbgbuf[80];
-                std::snprintf(dbgbuf, sizeof(dbgbuf),
-                    "[action_cb] tag=%d target=%d\n",
-                    static_cast<int>(action.tag), static_cast<int>(target.tag));
-                OutputDebugStringA(dbgbuf);
-            }
             // Tab lifecycle / navigation actions. ghostty's default keybinds
             // (Ctrl+Shift+T new tab, Ctrl+Shift+W close, Ctrl+Tab/Ctrl+PageDown
             // next, etc.) are matched on the renderer thread inside

--- a/GhosttyWin32App/MainWindow.xaml.cpp
+++ b/GhosttyWin32App/MainWindow.xaml.cpp
@@ -11,6 +11,8 @@
 #include <dwmapi.h>
 #include <shellapi.h>
 #include <shobjidl_core.h>
+#include <winrt/Microsoft.Windows.AppNotifications.h>
+#include <winrt/Microsoft.Windows.AppNotifications.Builder.h>
 #include <algorithm>
 #include <cmath>
 #include <filesystem>
@@ -916,6 +918,40 @@ namespace winrt::GhosttyWin32::implementation
             // don't start logging "unhandled action" for an action
             // we've intentionally ignored.
             if (action.tag == GHOSTTY_ACTION_QUIT_TIMER) {
+                return true;
+            }
+
+            // DESKTOP_NOTIFICATION — surface ghostty's bell-and-toast
+            // notifications via the Windows native toast layer. Builds
+            // a minimal two-line payload (title + body) and hands it
+            // to AppNotificationManager; the manager was registered
+            // in App::OnLaunched so Show won't be silently dropped.
+            // Dispatch to the UI thread because the AppNotifications
+            // WinRT projection is happiest on the STA-initialised UI
+            // thread and we already cross that boundary for every
+            // other Win32 surface call.
+            if (action.tag == GHOSTTY_ACTION_DESKTOP_NOTIFICATION) {
+                auto& dn = action.action.desktop_notification;
+                std::wstring title = (dn.title && dn.title[0]) ? Encoding::toUtf16(dn.title) : L"";
+                std::wstring body  = (dn.body  && dn.body[0])  ? Encoding::toUtf16(dn.body)  : L"";
+                if (title.empty() && body.empty()) return true;
+                if (!g_mainWindow) return true;
+                auto mw = g_mainWindow;
+                mw->DispatcherQueue().TryEnqueue([title = std::move(title),
+                                                  body = std::move(body)]() {
+                    try {
+                        using namespace winrt::Microsoft::Windows::AppNotifications;
+                        using namespace winrt::Microsoft::Windows::AppNotifications::Builder;
+                        AppNotificationBuilder builder;
+                        if (!title.empty()) builder.AddText(title);
+                        if (!body.empty())  builder.AddText(body);
+                        AppNotificationManager::Default().Show(builder.BuildNotification());
+                    } catch (winrt::hresult_error const&) {
+                        // Either the manager wasn't registered (App startup
+                        // logged it) or the OS refused. Nothing actionable
+                        // host-side; the message just doesn't appear.
+                    }
+                });
                 return true;
             }
 

--- a/GhosttyWin32App/MainWindow.xaml.cpp
+++ b/GhosttyWin32App/MainWindow.xaml.cpp
@@ -918,6 +918,20 @@ namespace winrt::GhosttyWin32::implementation
                 return true;
             }
 
+            // Cache the glyph cell dimensions ghostty derives from the
+            // active font + size. ghostty fires this whenever the cell
+            // metrics change (font reload, DPI change, config edit);
+            // without caching, any future host-side logic that wants
+            // to snap a resize / split ratio to a whole-cell boundary
+            // would have to round-trip through libghostty each time.
+            if (action.tag == GHOSTTY_ACTION_CELL_SIZE) {
+                if (!g_mainWindow) return true;
+                auto cs = action.action.cell_size;
+                g_mainWindow->m_cellWidth = cs.width;
+                g_mainWindow->m_cellHeight = cs.height;
+                return true;
+            }
+
             // Record the desired startup window dimensions ghostty
             // computes from config (`window-width` × `cell-width-px`,
             // etc.). Stored as physical pixels — ghostty already did

--- a/GhosttyWin32App/MainWindow.xaml.cpp
+++ b/GhosttyWin32App/MainWindow.xaml.cpp
@@ -1392,23 +1392,20 @@ namespace winrt::GhosttyWin32::implementation
                 return true;
             }
 
-            // Auto-hide the cursor while the user is typing — the
-            // ghostty convention (matching Vim / Helix / Kitty) is
-            // to fire HIDDEN on first keystroke after motion and
-            // VISIBLE on the next WM_MOUSEMOVE-equivalent.
-            //
-            // WinUI 3 routes cursor handling through ProtectedCursor /
-            // InputSystemCursor, so the classic ShowCursor(FALSE)
-            // counter is ignored: even after decrementing the counter,
-            // XAML's WM_SETCURSOR handler resets the cursor on the
-            // next mouse move and the cursor reappears immediately.
-            // Install a WndProc subclass on first MOUSE_VISIBILITY
-            // that short-circuits WM_SETCURSOR while m_cursorHidden
-            // is true; that's the only place we can intercept XAML's
-            // cursor restoration. The subclass falls back to
-            // DefSubclassProc the moment m_cursorHidden flips off,
-            // so the next mouse move (which is exactly the event
-            // that fires VISIBLE) restores the normal cursor.
+            // MOUSE_VISIBILITY — DISABLED pending #60.
+            // The action never reached action_cb during verification
+            // even with mouse-hide-while-typing=true in config. The
+            // most likely cause is our ghostty_surface_key call site
+            // not populating event.utf8 for printable keystrokes,
+            // which is one of the four conditions ghostty checks
+            // before firing the action (Surface.zig:2686). On top of
+            // that, the implementation below uses a WM_SETCURSOR
+            // subclass + SetCursor(NULL), which would lose to
+            // WinUI 3's ProtectedCursor / InputSystemCursor every
+            // mouse move anyway — see #60 for the full diagnosis
+            // and the planned fix path. Body kept verbatim so the
+            // eventual re-enable is a straight unguard.
+#if 0
             if (action.tag == GHOSTTY_ACTION_MOUSE_VISIBILITY) {
                 bool hide = action.action.mouse_visibility == GHOSTTY_MOUSE_HIDDEN;
                 {
@@ -1434,19 +1431,12 @@ namespace winrt::GhosttyWin32::implementation
                     if (mw->m_cursorHidden == hide) return;
                     mw->m_cursorHidden = hide;
                     if (hide) {
-                        // Immediate hide without waiting for the next
-                        // WM_SETCURSOR; the subclass keeps it hidden
-                        // from there on.
                         SetCursor(nullptr);
                     }
-                    // For the visible case we deliberately do nothing
-                    // here — the subclass stops short-circuiting and
-                    // the next mouse move (which is what triggered
-                    // VISIBLE in the first place) lets XAML restore
-                    // the right cursor shape.
                 });
                 return true;
             }
+#endif
 
             // Renderer health status from ghostty. UNHEALTHY means the
             // generic renderer detected a problem (texture allocation

--- a/GhosttyWin32App/MainWindow.xaml.cpp
+++ b/GhosttyWin32App/MainWindow.xaml.cpp
@@ -1002,6 +1002,15 @@ namespace winrt::GhosttyWin32::implementation
             // hovers without leaking the string under TTM_UPDATETIPTEXT.
             if (action.tag == GHOSTTY_ACTION_MOUSE_OVER_LINK) {
                 auto& ml = action.action.mouse_over_link;
+                {
+                    char buf[96];
+                    std::snprintf(buf, sizeof(buf),
+                                  "[mouse_over_link] fired url_len=%zu has_ptr=%d\n",
+                                  ml.len, ml.url ? 1 : 0);
+                    std::fputs(buf, stderr);
+                    std::fflush(stderr);
+                    OutputDebugStringA(buf);
+                }
                 std::wstring url = (ml.url && ml.len > 0)
                     ? Encoding::toUtf16(ml.url, static_cast<int>(ml.len))
                     : L"";
@@ -1409,6 +1418,13 @@ namespace winrt::GhosttyWin32::implementation
             // that fires VISIBLE) restores the normal cursor.
             if (action.tag == GHOSTTY_ACTION_MOUSE_VISIBILITY) {
                 bool hide = action.action.mouse_visibility == GHOSTTY_MOUSE_HIDDEN;
+                {
+                    char buf[64];
+                    std::snprintf(buf, sizeof(buf), "[mouse_visibility] fired hide=%d\n", hide ? 1 : 0);
+                    std::fputs(buf, stderr);
+                    std::fflush(stderr);
+                    OutputDebugStringA(buf);
+                }
                 if (!g_mainWindow) return true;
                 auto mw = g_mainWindow;
                 mw->DispatcherQueue().TryEnqueue([mw, hide]() {

--- a/GhosttyWin32App/MainWindow.xaml.cpp
+++ b/GhosttyWin32App/MainWindow.xaml.cpp
@@ -918,6 +918,22 @@ namespace winrt::GhosttyWin32::implementation
                 return true;
             }
 
+            // CHECK_FOR_UPDATES — ghostty has no built-in updater on
+            // Windows; the action just lets the host decide what
+            // "check for updates" means. Sending the user to the
+            // GitHub releases page is the lowest-friction option
+            // while we don't ship a Sparkle-equivalent updater.
+            // ShellExecuteW dispatches to the user's default browser
+            // without spawning a visible cmd/rundll32 flash, matching
+            // the OPEN_URL path.
+            if (action.tag == GHOSTTY_ACTION_CHECK_FOR_UPDATES) {
+                HWND hwnd = g_mainWindow ? g_mainWindow->m_hwnd : nullptr;
+                ShellExecuteW(hwnd, L"open",
+                              L"https://github.com/i999rri/GhosttyWin32/releases",
+                              nullptr, nullptr, SW_SHOWNORMAL);
+                return true;
+            }
+
             // SHOW_CHILD_EXITED — ghostty notifies us the surface's
             // shell process exited. With confirm-close-surface=false
             // (our default) the surface tears itself down via

--- a/GhosttyWin32App/MainWindow.xaml.cpp
+++ b/GhosttyWin32App/MainWindow.xaml.cpp
@@ -918,6 +918,16 @@ namespace winrt::GhosttyWin32::implementation
                 return true;
             }
 
+            // SCROLLBAR — ghostty exports scrollback total / offset /
+            // visible-len whenever the scroll position moves. We don't
+            // render a scrollbar (the terminal surface fills the
+            // available area without one), so the data has nowhere to
+            // go. Acknowledge anyway so the action doesn't fall
+            // through to the unhandled-default branch.
+            if (action.tag == GHOSTTY_ACTION_SCROLLBAR) {
+                return true;
+            }
+
             // Cache the glyph cell dimensions ghostty derives from the
             // active font + size. ghostty fires this whenever the cell
             // metrics change (font reload, DPI change, config edit);

--- a/GhosttyWin32App/MainWindow.xaml.cpp
+++ b/GhosttyWin32App/MainWindow.xaml.cpp
@@ -689,6 +689,19 @@ namespace winrt::GhosttyWin32::implementation
                 return true;
             }
 
+            // Terminal sent BEL (\x07). MessageBeep is the obvious
+            // Windows-native equivalent — it plays whatever the user
+            // has bound to the "Default Beep" system sound, runs
+            // asynchronously, and is thread-safe (so we don't need
+            // to bounce through the dispatcher queue). Honouring the
+            // ghostty `bell-features` config (audio / attention /
+            // title / unread) is a follow-up; this gets the audible
+            // path working.
+            if (action.tag == GHOSTTY_ACTION_RING_BELL) {
+                MessageBeep(MB_OK);
+                return true;
+            }
+
             // Ctrl+click on a URL in the terminal. Hand off to the shell
             // verb opener so the user's default browser / mail client /
             // etc. handles it. Without this, libghostty falls back to

--- a/GhosttyWin32App/MainWindow.xaml.cpp
+++ b/GhosttyWin32App/MainWindow.xaml.cpp
@@ -759,6 +759,32 @@ namespace winrt::GhosttyWin32::implementation
                 return true;
             }
 
+            // Hide / unhide the window with no taskbar persistence
+            // change — equivalent to "press Win+D for just our
+            // window". Pairs with a global keybind so the user can
+            // bring the window back even when it's not focused;
+            // without `global:` the keybind only fires while the
+            // window has keyboard focus and a hidden window can't
+            // be unhidden via the bind (but it can via the
+            // taskbar, alt-tab, or the keybind from another
+            // ghostty window in the multi-window future).
+            if (action.tag == GHOSTTY_ACTION_TOGGLE_VISIBILITY) {
+                if (g_mainWindow) {
+                    auto mw = g_mainWindow;
+                    mw->DispatcherQueue().TryEnqueue([mw]() {
+                        HWND hwnd = mw->m_hwnd;
+                        if (!hwnd) return;
+                        if (IsWindowVisible(hwnd)) {
+                            ShowWindow(hwnd, SW_HIDE);
+                        } else {
+                            ShowWindow(hwnd, SW_SHOW);
+                            SetForegroundWindow(hwnd);
+                        }
+                    });
+                }
+                return true;
+            }
+
             // Toggle the always-on-top state of the window.
             // ghostty exposes ON / OFF / TOGGLE; SetWindowPos with
             // HWND_TOPMOST / HWND_NOTOPMOST is the standard Win32

--- a/GhosttyWin32App/MainWindow.xaml.cpp
+++ b/GhosttyWin32App/MainWindow.xaml.cpp
@@ -457,6 +457,23 @@ namespace winrt::GhosttyWin32::implementation
         return DefSubclassProc(hwnd, msg, wp, lp);
     }
 
+    LRESULT CALLBACK MainWindow::CursorVisibilitySubclassProc(
+        HWND hwnd, UINT msg, WPARAM wp, LPARAM lp,
+        UINT_PTR /*id*/, DWORD_PTR ref) noexcept
+    {
+        if (msg == WM_SETCURSOR) {
+            auto* mw = reinterpret_cast<MainWindow*>(ref);
+            if (mw && mw->m_cursorHidden) {
+                // Force the cursor null and tell Windows we handled
+                // the message so DefWindowProc / XAML doesn't reset
+                // it to the default arrow on every mouse move.
+                SetCursor(nullptr);
+                return TRUE;
+            }
+        }
+        return DefSubclassProc(hwnd, msg, wp, lp);
+    }
+
     Tab* MainWindow::ActiveTab()
     {
         return m_tabs.Active(TabView());
@@ -1363,25 +1380,48 @@ namespace winrt::GhosttyWin32::implementation
             // Auto-hide the cursor while the user is typing — the
             // ghostty convention (matching Vim / Helix / Kitty) is
             // to fire HIDDEN on first keystroke after motion and
-            // VISIBLE on the next WM_MOUSEMOVE-equivalent. ShowCursor
-            // is a counter, not a boolean, so blindly calling
-            // ShowCursor(FALSE) on every HIDDEN would tally the
-            // counter into the negative thousands and the matching
-            // VISIBLE calls couldn't catch up. Track our own bool
-            // and only toggle once per state transition.
+            // VISIBLE on the next WM_MOUSEMOVE-equivalent.
+            //
+            // WinUI 3 routes cursor handling through ProtectedCursor /
+            // InputSystemCursor, so the classic ShowCursor(FALSE)
+            // counter is ignored: even after decrementing the counter,
+            // XAML's WM_SETCURSOR handler resets the cursor on the
+            // next mouse move and the cursor reappears immediately.
+            // Install a WndProc subclass on first MOUSE_VISIBILITY
+            // that short-circuits WM_SETCURSOR while m_cursorHidden
+            // is true; that's the only place we can intercept XAML's
+            // cursor restoration. The subclass falls back to
+            // DefSubclassProc the moment m_cursorHidden flips off,
+            // so the next mouse move (which is exactly the event
+            // that fires VISIBLE) restores the normal cursor.
             if (action.tag == GHOSTTY_ACTION_MOUSE_VISIBILITY) {
                 bool hide = action.action.mouse_visibility == GHOSTTY_MOUSE_HIDDEN;
                 if (!g_mainWindow) return true;
                 auto mw = g_mainWindow;
-                mw->DispatcherQueue().TryEnqueue([hide]() {
-                    static bool s_cursorHidden = false;
-                    if (hide && !s_cursorHidden) {
-                        ShowCursor(FALSE);
-                        s_cursorHidden = true;
-                    } else if (!hide && s_cursorHidden) {
-                        ShowCursor(TRUE);
-                        s_cursorHidden = false;
+                mw->DispatcherQueue().TryEnqueue([mw, hide]() {
+                    HWND hwnd = mw->m_hwnd;
+                    if (!hwnd) return;
+                    if (!mw->m_cursorSubclassed) {
+                        if (SetWindowSubclass(hwnd,
+                                              &MainWindow::CursorVisibilitySubclassProc,
+                                              2,
+                                              reinterpret_cast<DWORD_PTR>(mw))) {
+                            mw->m_cursorSubclassed = true;
+                        }
                     }
+                    if (mw->m_cursorHidden == hide) return;
+                    mw->m_cursorHidden = hide;
+                    if (hide) {
+                        // Immediate hide without waiting for the next
+                        // WM_SETCURSOR; the subclass keeps it hidden
+                        // from there on.
+                        SetCursor(nullptr);
+                    }
+                    // For the visible case we deliberately do nothing
+                    // here — the subclass stops short-circuiting and
+                    // the next mouse move (which is what triggered
+                    // VISIBLE in the first place) lets XAML restore
+                    // the right cursor shape.
                 });
                 return true;
             }

--- a/GhosttyWin32App/MainWindow.xaml.cpp
+++ b/GhosttyWin32App/MainWindow.xaml.cpp
@@ -918,6 +918,32 @@ namespace winrt::GhosttyWin32::implementation
                 return true;
             }
 
+            // Auto-hide the cursor while the user is typing — the
+            // ghostty convention (matching Vim / Helix / Kitty) is
+            // to fire HIDDEN on first keystroke after motion and
+            // VISIBLE on the next WM_MOUSEMOVE-equivalent. ShowCursor
+            // is a counter, not a boolean, so blindly calling
+            // ShowCursor(FALSE) on every HIDDEN would tally the
+            // counter into the negative thousands and the matching
+            // VISIBLE calls couldn't catch up. Track our own bool
+            // and only toggle once per state transition.
+            if (action.tag == GHOSTTY_ACTION_MOUSE_VISIBILITY) {
+                bool hide = action.action.mouse_visibility == GHOSTTY_MOUSE_HIDDEN;
+                if (!g_mainWindow) return true;
+                auto mw = g_mainWindow;
+                mw->DispatcherQueue().TryEnqueue([hide]() {
+                    static bool s_cursorHidden = false;
+                    if (hide && !s_cursorHidden) {
+                        ShowCursor(FALSE);
+                        s_cursorHidden = true;
+                    } else if (!hide && s_cursorHidden) {
+                        ShowCursor(TRUE);
+                        s_cursorHidden = false;
+                    }
+                });
+                return true;
+            }
+
             // Renderer health status from ghostty. UNHEALTHY means the
             // generic renderer detected a problem (texture allocation
             // failure, shader compile fault, etc.) and switched into a

--- a/GhosttyWin32App/MainWindow.xaml.cpp
+++ b/GhosttyWin32App/MainWindow.xaml.cpp
@@ -12,6 +12,7 @@
 #include <shellapi.h>
 #include <algorithm>
 #include <cmath>
+#include <cstdio>
 #include <filesystem>
 #include <fstream>
 #include <limits>
@@ -461,6 +462,16 @@ namespace winrt::GhosttyWin32::implementation
             });
         };
         rtConfig.action_cb = [](ghostty_app_t, ghostty_target_s target, ghostty_action_s action) -> bool {
+            // Diagnostic: log every action that arrives at the host so we can
+            // verify whether a keybind is registered + dispatched.
+            // Remove once batch 1 actions are verified.
+            {
+                char dbgbuf[80];
+                std::snprintf(dbgbuf, sizeof(dbgbuf),
+                    "[action_cb] tag=%d target=%d\n",
+                    static_cast<int>(action.tag), static_cast<int>(target.tag));
+                OutputDebugStringA(dbgbuf);
+            }
             // Tab lifecycle / navigation actions. ghostty's default keybinds
             // (Ctrl+Shift+T new tab, Ctrl+Shift+W close, Ctrl+Tab/Ctrl+PageDown
             // next, etc.) are matched on the renderer thread inside
@@ -766,26 +777,28 @@ namespace winrt::GhosttyWin32::implementation
                 return true;
             }
 
-            // Hide / unhide the window with no taskbar persistence
-            // change — equivalent to "press Win+D for just our
-            // window". Pairs with a global keybind so the user can
-            // bring the window back even when it's not focused;
-            // without `global:` the keybind only fires while the
-            // window has keyboard focus and a hidden window can't
-            // be unhidden via the bind (but it can via the
-            // taskbar, alt-tab, or the keybind from another
-            // ghostty window in the multi-window future).
+            // Toggle minimize / restore. We use SW_MINIMIZE /
+            // SW_RESTORE instead of SW_HIDE here because hiding the
+            // window from the taskbar leaves Windows users without a
+            // discoverable way back — ghostty's `global:` keybind
+            // qualifier isn't wired to RegisterHotKey on this port
+            // yet, so a SW_HIDE'd window with no taskbar entry can
+            // only be recovered by relaunching. Minimizing keeps
+            // the window reachable via taskbar click / alt-tab,
+            // which matches what Windows users expect from a
+            // "toggle visibility" bind. The Mac-style full hide
+            // semantics can come back once global hotkeys land.
             if (action.tag == GHOSTTY_ACTION_TOGGLE_VISIBILITY) {
                 if (g_mainWindow) {
                     auto mw = g_mainWindow;
                     mw->DispatcherQueue().TryEnqueue([mw]() {
                         HWND hwnd = mw->m_hwnd;
                         if (!hwnd) return;
-                        if (IsWindowVisible(hwnd)) {
-                            ShowWindow(hwnd, SW_HIDE);
-                        } else {
-                            ShowWindow(hwnd, SW_SHOW);
+                        if (IsIconic(hwnd)) {
+                            ShowWindow(hwnd, SW_RESTORE);
                             SetForegroundWindow(hwnd);
+                        } else {
+                            ShowWindow(hwnd, SW_MINIMIZE);
                         }
                     });
                 }

--- a/GhosttyWin32App/MainWindow.xaml.cpp
+++ b/GhosttyWin32App/MainWindow.xaml.cpp
@@ -986,31 +986,23 @@ namespace winrt::GhosttyWin32::implementation
                 return true;
             }
 
-            // MOUSE_OVER_LINK — show a tooltip with the URL under the
-            // cursor whenever ghostty detects the mouse is hovering a
-            // link, hide it when the hover leaves. The cursor shape
-            // change (hand) is already wired via MOUSE_SHAPE; this
-            // adds the discoverable "where will I land if I click"
-            // text the user expects from a browser-grade link UI.
-            //
-            // The tooltip is a Win32 TOOLTIPS_CLASS popup in TRACK
-            // mode — TRACK lets us position it manually next to the
-            // cursor instead of relying on the default delay / tool
-            // rect mechanics, which don't map to a DComp surface
-            // anyway. Both the HWND and the text-backing wstring are
-            // function-local statics so the lazy init survives across
-            // hovers without leaking the string under TTM_UPDATETIPTEXT.
+            // MOUSE_OVER_LINK — TEMPORARILY DISABLED.
+            // The Win32 TOOLTIPS_CLASS popup approach below caused
+            // GhosttyWin32 to crash on URL click (process exit code
+            // 3 with no diagnostic), even though the action handler
+            // itself was firing correctly (verified via the
+            // [mouse_over_link] log line, ~16 fires per hover before
+            // the crash). The interaction between TTM_TRACKACTIVATE
+            // / SetWindowPos and the DComp surface's click routing
+            // needs more investigation before re-enabling. Until
+            // then, ack the action with a return-true and ship the
+            // URL click path unbroken.
+            if (action.tag == GHOSTTY_ACTION_MOUSE_OVER_LINK) {
+                return true;
+            }
+#if 0
             if (action.tag == GHOSTTY_ACTION_MOUSE_OVER_LINK) {
                 auto& ml = action.action.mouse_over_link;
-                {
-                    char buf[96];
-                    std::snprintf(buf, sizeof(buf),
-                                  "[mouse_over_link] fired url_len=%zu has_ptr=%d\n",
-                                  ml.len, ml.url ? 1 : 0);
-                    std::fputs(buf, stderr);
-                    std::fflush(stderr);
-                    OutputDebugStringA(buf);
-                }
                 std::wstring url = (ml.url && ml.len > 0)
                     ? Encoding::toUtf16(ml.url, static_cast<int>(ml.len))
                     : L"";
@@ -1060,6 +1052,7 @@ namespace winrt::GhosttyWin32::implementation
                 });
                 return true;
             }
+#endif
 
             // TOGGLE_FULLSCREEN — borderless fullscreen toggle. The
             // ghostty enum carries NATIVE + three macOS-specific

--- a/GhosttyWin32App/MainWindow.xaml.cpp
+++ b/GhosttyWin32App/MainWindow.xaml.cpp
@@ -10,6 +10,7 @@
 #include <microsoft.ui.xaml.window.h>
 #include <dwmapi.h>
 #include <shellapi.h>
+#include <shobjidl_core.h>
 #include <algorithm>
 #include <cmath>
 #include <filesystem>
@@ -915,6 +916,58 @@ namespace winrt::GhosttyWin32::implementation
             // don't start logging "unhandled action" for an action
             // we've intentionally ignored.
             if (action.tag == GHOSTTY_ACTION_QUIT_TIMER) {
+                return true;
+            }
+
+            // PROGRESS_REPORT — OSC 9;4 progress reports from the
+            // shell (pnpm, make, large copies, etc.). Without a host
+            // handler the percentage just gets dropped on the floor.
+            // Map ghostty's state machine onto ITaskbarList3 so the
+            // user sees the progress bar on the taskbar button — the
+            // standard Windows surface for background-task progress.
+            // The ITaskbarList3 instance is cached on the UI thread
+            // (where COM is STA-initialized) since CoCreateInstance +
+            // HrInit aren't cheap to redo per OSC sequence.
+            if (action.tag == GHOSTTY_ACTION_PROGRESS_REPORT) {
+                auto pr = action.action.progress_report;
+                if (!g_mainWindow) return true;
+                auto mw = g_mainWindow;
+                mw->DispatcherQueue().TryEnqueue([mw, pr]() {
+                    HWND hwnd = mw->m_hwnd;
+                    if (!hwnd) return;
+                    static winrt::com_ptr<ITaskbarList3> s_taskbar;
+                    if (!s_taskbar) {
+                        if (FAILED(CoCreateInstance(CLSID_TaskbarList, nullptr,
+                                                    CLSCTX_INPROC_SERVER,
+                                                    IID_PPV_ARGS(s_taskbar.put())))) {
+                            return;
+                        }
+                        if (FAILED(s_taskbar->HrInit())) {
+                            s_taskbar = nullptr;
+                            return;
+                        }
+                    }
+                    TBPFLAG flag = TBPF_NOPROGRESS;
+                    switch (pr.state) {
+                        case GHOSTTY_PROGRESS_STATE_REMOVE:        flag = TBPF_NOPROGRESS;    break;
+                        case GHOSTTY_PROGRESS_STATE_SET:           flag = TBPF_NORMAL;        break;
+                        case GHOSTTY_PROGRESS_STATE_ERROR:         flag = TBPF_ERROR;         break;
+                        case GHOSTTY_PROGRESS_STATE_INDETERMINATE: flag = TBPF_INDETERMINATE; break;
+                        case GHOSTTY_PROGRESS_STATE_PAUSE:         flag = TBPF_PAUSED;        break;
+                    }
+                    s_taskbar->SetProgressState(hwnd, flag);
+                    // SetProgressValue is meaningless under
+                    // INDETERMINATE / NOPROGRESS and the percentage
+                    // is -1 when no value was reported — skip the
+                    // call so the bar doesn't snap to 0% on a
+                    // bare state change.
+                    if (pr.progress >= 0
+                        && (flag == TBPF_NORMAL || flag == TBPF_ERROR || flag == TBPF_PAUSED)) {
+                        s_taskbar->SetProgressValue(hwnd,
+                                                    static_cast<ULONGLONG>(pr.progress),
+                                                    100ULL);
+                    }
+                });
                 return true;
             }
 

--- a/GhosttyWin32App/MainWindow.xaml.cpp
+++ b/GhosttyWin32App/MainWindow.xaml.cpp
@@ -1254,16 +1254,22 @@ namespace winrt::GhosttyWin32::implementation
             // (our default) the surface tears itself down via
             // close_surface_cb almost immediately, so this is mostly
             // a diagnostic breadcrumb: when a shell crashes during
-            // development, the exit code in stderr is the fastest
-            // path to "what failed". An in-terminal overlay would be
-            // the proper UI but needs its own design pass — for now,
-            // log and move on.
+            // development, the exit code in the debug output is the
+            // fastest path to "what failed". An in-terminal overlay
+            // would be the proper UI but needs its own design pass —
+            // for now, log and move on. Mirror to OutputDebugString
+            // so the line survives even when stderr was buffered
+            // through the surface teardown.
             if (action.tag == GHOSTTY_ACTION_SHOW_CHILD_EXITED) {
                 auto ce = action.action.child_exited;
-                std::fprintf(stderr, "[child_exited] exit_code=%u after_ms=%llu\n",
-                             ce.exit_code,
-                             static_cast<unsigned long long>(ce.timetime_ms));
+                char buf[128];
+                std::snprintf(buf, sizeof(buf),
+                              "[child_exited] exit_code=%u after_ms=%llu\n",
+                              ce.exit_code,
+                              static_cast<unsigned long long>(ce.timetime_ms));
+                std::fputs(buf, stderr);
                 std::fflush(stderr);
+                OutputDebugStringA(buf);
                 return true;
             }
 
@@ -1331,6 +1337,10 @@ namespace winrt::GhosttyWin32::implementation
             // fresh-window default and gives an 80-ish column / 24-
             // row terminal at common font sizes.
             if (action.tag == GHOSTTY_ACTION_RESET_WINDOW_SIZE) {
+                std::fprintf(stderr, "[reset_window_size] fired init=%ux%u\n",
+                             g_mainWindow ? g_mainWindow->m_initialWidth : 0,
+                             g_mainWindow ? g_mainWindow->m_initialHeight : 0);
+                std::fflush(stderr);
                 if (!g_mainWindow) return true;
                 auto mw = g_mainWindow;
                 mw->DispatcherQueue().TryEnqueue([mw]() {
@@ -1345,8 +1355,11 @@ namespace winrt::GhosttyWin32::implementation
                         width = MulDiv(1280, dpi, 96);
                         height = MulDiv(720, dpi, 96);
                     }
-                    SetWindowPos(hwnd, nullptr, 0, 0, width, height,
-                                 SWP_NOMOVE | SWP_NOZORDER | SWP_NOACTIVATE);
+                    BOOL ok = SetWindowPos(hwnd, nullptr, 0, 0, width, height,
+                                           SWP_NOMOVE | SWP_NOZORDER | SWP_NOACTIVATE);
+                    std::fprintf(stderr, "[reset_window_size] SetWindowPos w=%d h=%d ok=%d err=%lu\n",
+                                 width, height, ok ? 1 : 0, ok ? 0UL : GetLastError());
+                    std::fflush(stderr);
                 });
                 return true;
             }

--- a/GhosttyWin32App/MainWindow.xaml.cpp
+++ b/GhosttyWin32App/MainWindow.xaml.cpp
@@ -918,6 +918,22 @@ namespace winrt::GhosttyWin32::implementation
                 return true;
             }
 
+            // RENDER — ghostty is asking for an explicit repaint
+            // outside the natural wakeup_cb -> tick cadence. The
+            // dispatcher used by wakeup_cb already serialises ticks
+            // on the UI thread; route through the same path so the
+            // frame lands without us needing a separate per-surface
+            // draw entry. ghostty_app_tick is idempotent — calling it
+            // when nothing is dirty is a cheap no-op.
+            if (action.tag == GHOSTTY_ACTION_RENDER) {
+                if (!g_mainWindow || !g_mainWindow->m_ghostty) return true;
+                auto mw = g_mainWindow;
+                mw->DispatcherQueue().TryEnqueue([mw]() {
+                    if (mw->m_ghostty) mw->m_ghostty->Tick();
+                });
+                return true;
+            }
+
             // SCROLLBAR — ghostty exports scrollback total / offset /
             // visible-len whenever the scroll position moves. We don't
             // render a scrollbar (the terminal surface fills the

--- a/GhosttyWin32App/MainWindow.xaml.cpp
+++ b/GhosttyWin32App/MainWindow.xaml.cpp
@@ -918,6 +918,30 @@ namespace winrt::GhosttyWin32::implementation
                 return true;
             }
 
+            // RESET_WINDOW_SIZE — restore the window to a sensible
+            // default footprint. ghostty would ideally hand us the
+            // initial dimensions via INITIAL_SIZE at startup so we
+            // could snap back to that, but that path is still TODO
+            // (#57). Until then, 1280x720 DIPs lines up with the
+            // WinUI 3 fresh-window default and gives an 80-ish
+            // column / 24-row terminal at common font sizes —
+            // close enough to "reset" semantics that it's useful
+            // without being wrong.
+            if (action.tag == GHOSTTY_ACTION_RESET_WINDOW_SIZE) {
+                if (!g_mainWindow) return true;
+                auto mw = g_mainWindow;
+                mw->DispatcherQueue().TryEnqueue([mw]() {
+                    HWND hwnd = mw->m_hwnd;
+                    if (!hwnd) return;
+                    UINT dpi = GetDpiForWindow(hwnd);
+                    int width = MulDiv(1280, dpi, 96);
+                    int height = MulDiv(720, dpi, 96);
+                    SetWindowPos(hwnd, nullptr, 0, 0, width, height,
+                                 SWP_NOMOVE | SWP_NOZORDER | SWP_NOACTIVATE);
+                });
+                return true;
+            }
+
             // CONFIG_CHANGE sync. ghostty has already applied the new
             // config internally by the time this fires; it's a
             // notification, not a request. Without grabbing the new

--- a/GhosttyWin32App/MainWindow.xaml.cpp
+++ b/GhosttyWin32App/MainWindow.xaml.cpp
@@ -1191,6 +1191,31 @@ namespace winrt::GhosttyWin32::implementation
                 return true;
             }
 
+            // Acknowledge actions whose feature surface is a separate
+            // design problem and is intentionally not on this PR's
+            // plate. Each is conceptually a real feature — a search
+            // bar (START/END/TOTAL/SELECTED), an ImGui inspector
+            // window (INSPECTOR + the render hook RENDER_INSPECTOR),
+            // a visual tab picker, a sliding hotkey terminal, a
+            // searchable command palette, terminal-level undo/redo.
+            // Routing them through a single ack today keeps the
+            // unhandled-default branch quiet so libghostty's future
+            // audit isn't full of false-positive missing entries; the
+            // proper feature work stays tracked in #57.
+            if (action.tag == GHOSTTY_ACTION_UNDO
+                || action.tag == GHOSTTY_ACTION_REDO
+                || action.tag == GHOSTTY_ACTION_START_SEARCH
+                || action.tag == GHOSTTY_ACTION_END_SEARCH
+                || action.tag == GHOSTTY_ACTION_SEARCH_TOTAL
+                || action.tag == GHOSTTY_ACTION_SEARCH_SELECTED
+                || action.tag == GHOSTTY_ACTION_INSPECTOR
+                || action.tag == GHOSTTY_ACTION_RENDER_INSPECTOR
+                || action.tag == GHOSTTY_ACTION_TOGGLE_TAB_OVERVIEW
+                || action.tag == GHOSTTY_ACTION_TOGGLE_QUICK_TERMINAL
+                || action.tag == GHOSTTY_ACTION_TOGGLE_COMMAND_PALETTE) {
+                return true;
+            }
+
             // CHECK_FOR_UPDATES — ghostty has no built-in updater on
             // Windows; the action just lets the host decide what
             // "check for updates" means. Sending the user to the

--- a/GhosttyWin32App/MainWindow.xaml.cpp
+++ b/GhosttyWin32App/MainWindow.xaml.cpp
@@ -1339,10 +1339,6 @@ namespace winrt::GhosttyWin32::implementation
             // fresh-window default and gives an 80-ish column / 24-
             // row terminal at common font sizes.
             if (action.tag == GHOSTTY_ACTION_RESET_WINDOW_SIZE) {
-                std::fprintf(stderr, "[reset_window_size] fired init=%ux%u\n",
-                             g_mainWindow ? g_mainWindow->m_initialWidth : 0,
-                             g_mainWindow ? g_mainWindow->m_initialHeight : 0);
-                std::fflush(stderr);
                 if (!g_mainWindow) return true;
                 auto mw = g_mainWindow;
                 mw->DispatcherQueue().TryEnqueue([mw]() {
@@ -1357,11 +1353,8 @@ namespace winrt::GhosttyWin32::implementation
                         width = MulDiv(1280, dpi, 96);
                         height = MulDiv(720, dpi, 96);
                     }
-                    BOOL ok = SetWindowPos(hwnd, nullptr, 0, 0, width, height,
-                                           SWP_NOMOVE | SWP_NOZORDER | SWP_NOACTIVATE);
-                    std::fprintf(stderr, "[reset_window_size] SetWindowPos w=%d h=%d ok=%d err=%lu\n",
-                                 width, height, ok ? 1 : 0, ok ? 0UL : GetLastError());
-                    std::fflush(stderr);
+                    SetWindowPos(hwnd, nullptr, 0, 0, width, height,
+                                 SWP_NOMOVE | SWP_NOZORDER | SWP_NOACTIVATE);
                 });
                 return true;
             }

--- a/GhosttyWin32App/MainWindow.xaml.cpp
+++ b/GhosttyWin32App/MainWindow.xaml.cpp
@@ -918,6 +918,32 @@ namespace winrt::GhosttyWin32::implementation
                 return true;
             }
 
+            // CONFIG_CHANGE sync. ghostty has already applied the new
+            // config internally by the time this fires; it's a
+            // notification, not a request. Without grabbing the new
+            // pointer here our stored m_config would diverge from
+            // what libghostty is actually using — soft-reload would
+            // re-apply the stale copy and any future host-side
+            // config query (color theme, padding, etc.) would lie.
+            // Clone because ghostty owns the passed-in pointer; the
+            // UI-thread swap mirrors the reload_config path so we
+            // don't free while another tick could be reading.
+            if (action.tag == GHOSTTY_ACTION_CONFIG_CHANGE) {
+                auto newCfg = action.action.config_change.config;
+                if (!g_mainWindow || !g_mainWindow->m_ghostty || !newCfg) return true;
+                auto mw = g_mainWindow;
+                auto cloned = ghostty_config_clone(newCfg);
+                if (!cloned) return true;
+                mw->DispatcherQueue().TryEnqueue([mw, cloned]() {
+                    if (!mw->m_ghostty) {
+                        ghostty_config_free(cloned);
+                        return;
+                    }
+                    mw->m_ghostty->ReplaceConfig(cloned);
+                });
+                return true;
+            }
+
             // Auto-hide the cursor while the user is typing — the
             // ghostty convention (matching Vim / Helix / Kitty) is
             // to fire HIDDEN on first keystroke after motion and

--- a/GhosttyWin32App/MainWindow.xaml.cpp
+++ b/GhosttyWin32App/MainWindow.xaml.cpp
@@ -759,6 +759,36 @@ namespace winrt::GhosttyWin32::implementation
                 return true;
             }
 
+            // Toggle the always-on-top state of the window.
+            // ghostty exposes ON / OFF / TOGGLE; SetWindowPos with
+            // HWND_TOPMOST / HWND_NOTOPMOST is the standard Win32
+            // way to flip WS_EX_TOPMOST without recreating the
+            // window. SWP_NOMOVE | SWP_NOSIZE keeps the window in
+            // place while only the z-order flag changes.
+            if (action.tag == GHOSTTY_ACTION_FLOAT_WINDOW) {
+                auto mode = action.action.float_window;
+                if (g_mainWindow) {
+                    auto mw = g_mainWindow;
+                    mw->DispatcherQueue().TryEnqueue([mw, mode]() {
+                        HWND hwnd = mw->m_hwnd;
+                        if (!hwnd) return;
+                        bool wantTop;
+                        switch (mode) {
+                            case GHOSTTY_FLOAT_WINDOW_ON:  wantTop = true; break;
+                            case GHOSTTY_FLOAT_WINDOW_OFF: wantTop = false; break;
+                            case GHOSTTY_FLOAT_WINDOW_TOGGLE:
+                            default:
+                                wantTop = (GetWindowLongPtrW(hwnd, GWL_EXSTYLE) & WS_EX_TOPMOST) == 0;
+                                break;
+                        }
+                        SetWindowPos(hwnd, wantTop ? HWND_TOPMOST : HWND_NOTOPMOST,
+                                     0, 0, 0, 0,
+                                     SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE);
+                    });
+                }
+                return true;
+            }
+
             // Toggle maximize/restore via the same WM_SYSCOMMAND
             // path the caption-button click already uses, so the
             // NVIDIA OverlappedPresenter AV from issue #26 stays out

--- a/GhosttyWin32App/MainWindow.xaml.cpp
+++ b/GhosttyWin32App/MainWindow.xaml.cpp
@@ -918,6 +918,24 @@ namespace winrt::GhosttyWin32::implementation
                 return true;
             }
 
+            // SHOW_CHILD_EXITED — ghostty notifies us the surface's
+            // shell process exited. With confirm-close-surface=false
+            // (our default) the surface tears itself down via
+            // close_surface_cb almost immediately, so this is mostly
+            // a diagnostic breadcrumb: when a shell crashes during
+            // development, the exit code in stderr is the fastest
+            // path to "what failed". An in-terminal overlay would be
+            // the proper UI but needs its own design pass — for now,
+            // log and move on.
+            if (action.tag == GHOSTTY_ACTION_SHOW_CHILD_EXITED) {
+                auto ce = action.action.child_exited;
+                std::fprintf(stderr, "[child_exited] exit_code=%u after_ms=%llu\n",
+                             ce.exit_code,
+                             static_cast<unsigned long long>(ce.timetime_ms));
+                std::fflush(stderr);
+                return true;
+            }
+
             // RENDER — ghostty is asking for an explicit repaint
             // outside the natural wakeup_cb -> tick cadence. The
             // dispatcher used by wakeup_cb already serialises ticks

--- a/GhosttyWin32App/MainWindow.xaml.cpp
+++ b/GhosttyWin32App/MainWindow.xaml.cpp
@@ -921,6 +921,55 @@ namespace winrt::GhosttyWin32::implementation
                 return true;
             }
 
+            // TOGGLE_FULLSCREEN — borderless fullscreen toggle. The
+            // ghostty enum carries NATIVE + three macOS-specific
+            // NON_NATIVE variants; on Windows they all collapse to
+            // the same "remove WS_OVERLAPPEDWINDOW + cover the
+            // monitor" behavior, so the value is ignored. Track the
+            // toggle state plus the previous WINDOWPLACEMENT and
+            // style on MainWindow so leaving fullscreen lands back
+            // where the user started (preserving a maximised state
+            // if they were maximised before entering FS — RECT alone
+            // would lose that).
+            //
+            // Caveat: our custom title bar lives in the XAML content
+            // tree, so it stays visible at the top of the surface
+            // even in fullscreen. Hiding it is a follow-up; the
+            // window itself does fill the monitor correctly.
+            if (action.tag == GHOSTTY_ACTION_TOGGLE_FULLSCREEN) {
+                if (!g_mainWindow) return true;
+                auto mw = g_mainWindow;
+                mw->DispatcherQueue().TryEnqueue([mw]() {
+                    HWND hwnd = mw->m_hwnd;
+                    if (!hwnd) return;
+                    if (!mw->m_fullscreen) {
+                        mw->m_prevPlacement.length = sizeof(WINDOWPLACEMENT);
+                        GetWindowPlacement(hwnd, &mw->m_prevPlacement);
+                        mw->m_prevStyle = GetWindowLongPtrW(hwnd, GWL_STYLE);
+
+                        HMONITOR mon = MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST);
+                        MONITORINFO mi{ sizeof(MONITORINFO) };
+                        if (!GetMonitorInfoW(mon, &mi)) return;
+
+                        SetWindowLongPtrW(hwnd, GWL_STYLE,
+                                          mw->m_prevStyle & ~WS_OVERLAPPEDWINDOW);
+                        SetWindowPos(hwnd, HWND_TOP,
+                                     mi.rcMonitor.left, mi.rcMonitor.top,
+                                     mi.rcMonitor.right - mi.rcMonitor.left,
+                                     mi.rcMonitor.bottom - mi.rcMonitor.top,
+                                     SWP_NOZORDER | SWP_FRAMECHANGED);
+                        mw->m_fullscreen = true;
+                    } else {
+                        SetWindowLongPtrW(hwnd, GWL_STYLE, mw->m_prevStyle);
+                        SetWindowPlacement(hwnd, &mw->m_prevPlacement);
+                        SetWindowPos(hwnd, nullptr, 0, 0, 0, 0,
+                                     SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_FRAMECHANGED);
+                        mw->m_fullscreen = false;
+                    }
+                });
+                return true;
+            }
+
             // DESKTOP_NOTIFICATION — surface ghostty's bell-and-toast
             // notifications via the Windows native toast layer. Builds
             // a minimal two-line payload (title + body) and hands it

--- a/GhosttyWin32App/MainWindow.xaml.cpp
+++ b/GhosttyWin32App/MainWindow.xaml.cpp
@@ -720,6 +720,22 @@ namespace winrt::GhosttyWin32::implementation
                 return true;
             }
 
+            // Open the user's ghostty config in their default editor.
+            // The Windows config path is %LOCALAPPDATA%\ghostty\config
+            // (no extension); if the user has no association for
+            // extension-less files Windows shows the "Open With"
+            // dialog, which is the right OS-native behaviour for
+            // first run.
+            if (action.tag == GHOSTTY_ACTION_OPEN_CONFIG) {
+                wchar_t const* appdata = _wgetenv(L"LOCALAPPDATA");
+                if (appdata) {
+                    std::wstring path = std::wstring(appdata) + L"\\ghostty\\config";
+                    ShellExecuteW(nullptr, L"open", path.c_str(),
+                                  nullptr, nullptr, SW_SHOWNORMAL);
+                }
+                return true;
+            }
+
             // Toggle maximize/restore via the same WM_SYSCOMMAND
             // path the caption-button click already uses, so the
             // NVIDIA OverlappedPresenter AV from issue #26 stays out

--- a/GhosttyWin32App/MainWindow.xaml.cpp
+++ b/GhosttyWin32App/MainWindow.xaml.cpp
@@ -905,6 +905,22 @@ namespace winrt::GhosttyWin32::implementation
                 return true;
             }
 
+            // Renderer health status from ghostty. UNHEALTHY means the
+            // generic renderer detected a problem (texture allocation
+            // failure, shader compile fault, etc.) and switched into a
+            // degraded mode. Surfacing this as a single stderr line
+            // makes the underlying cause findable in the debugger
+            // output without committing to a user-facing surface
+            // (toast, status bar) just yet — those can layer on top
+            // later if we want recovery UX.
+            if (action.tag == GHOSTTY_ACTION_RENDERER_HEALTH) {
+                bool healthy = action.action.renderer_health == GHOSTTY_RENDERER_HEALTH_HEALTHY;
+                std::fprintf(stderr, "[renderer_health] %s\n",
+                             healthy ? "healthy" : "unhealthy");
+                std::fflush(stderr);
+                return true;
+            }
+
             // Ctrl+click on a URL in the terminal. Hand off to the shell
             // verb opener so the user's default browser / mail client /
             // etc. handles it. Without this, libghostty falls back to

--- a/GhosttyWin32App/MainWindow.xaml.cpp
+++ b/GhosttyWin32App/MainWindow.xaml.cpp
@@ -749,9 +749,16 @@ namespace winrt::GhosttyWin32::implementation
             // extension-less files Windows shows the "Open With"
             // dialog, which is the right OS-native behaviour for
             // first run.
+            //
+            // GetEnvironmentVariableW over _wgetenv: the CRT helper
+            // is marked deprecated under MSVC /W4, the Win32 API is
+            // the documented modern path and writes into a caller-
+            // supplied buffer so there's no heap-allocation cleanup.
             if (action.tag == GHOSTTY_ACTION_OPEN_CONFIG) {
-                wchar_t const* appdata = _wgetenv(L"LOCALAPPDATA");
-                if (appdata) {
+                wchar_t appdata[MAX_PATH];
+                DWORD len = GetEnvironmentVariableW(L"LOCALAPPDATA", appdata,
+                                                   static_cast<DWORD>(std::size(appdata)));
+                if (len > 0 && len < std::size(appdata)) {
                     std::wstring path = std::wstring(appdata) + L"\\ghostty\\config";
                     ShellExecuteW(nullptr, L"open", path.c_str(),
                                   nullptr, nullptr, SW_SHOWNORMAL);

--- a/GhosttyWin32App/MainWindow.xaml.cpp
+++ b/GhosttyWin32App/MainWindow.xaml.cpp
@@ -918,24 +918,44 @@ namespace winrt::GhosttyWin32::implementation
                 return true;
             }
 
-            // RESET_WINDOW_SIZE — restore the window to a sensible
-            // default footprint. ghostty would ideally hand us the
-            // initial dimensions via INITIAL_SIZE at startup so we
-            // could snap back to that, but that path is still TODO
-            // (#57). Until then, 1280x720 DIPs lines up with the
-            // WinUI 3 fresh-window default and gives an 80-ish
-            // column / 24-row terminal at common font sizes —
-            // close enough to "reset" semantics that it's useful
-            // without being wrong.
+            // Record the desired startup window dimensions ghostty
+            // computes from config (`window-width` × `cell-width-px`,
+            // etc.). Stored as physical pixels — ghostty already did
+            // the cell-to-pixel math, so RESET_WINDOW_SIZE can hand
+            // the value to SetWindowPos directly without re-scaling.
+            // Without this the reset target stays the hardcoded
+            // 1280x720 fallback below, which ignores the user's
+            // config-defined window size.
+            if (action.tag == GHOSTTY_ACTION_INITIAL_SIZE) {
+                if (!g_mainWindow) return true;
+                auto sz = action.action.initial_size;
+                g_mainWindow->m_initialWidth = sz.width;
+                g_mainWindow->m_initialHeight = sz.height;
+                return true;
+            }
+
+            // RESET_WINDOW_SIZE — restore the window to its startup
+            // footprint. Prefer the size INITIAL_SIZE recorded (which
+            // honors the user's config); if INITIAL_SIZE never fired
+            // (e.g., default config, no startup size override) fall
+            // back to 1280x720 DIPs, which lines up with the WinUI 3
+            // fresh-window default and gives an 80-ish column / 24-
+            // row terminal at common font sizes.
             if (action.tag == GHOSTTY_ACTION_RESET_WINDOW_SIZE) {
                 if (!g_mainWindow) return true;
                 auto mw = g_mainWindow;
                 mw->DispatcherQueue().TryEnqueue([mw]() {
                     HWND hwnd = mw->m_hwnd;
                     if (!hwnd) return;
-                    UINT dpi = GetDpiForWindow(hwnd);
-                    int width = MulDiv(1280, dpi, 96);
-                    int height = MulDiv(720, dpi, 96);
+                    int width, height;
+                    if (mw->m_initialWidth && mw->m_initialHeight) {
+                        width = static_cast<int>(mw->m_initialWidth);
+                        height = static_cast<int>(mw->m_initialHeight);
+                    } else {
+                        UINT dpi = GetDpiForWindow(hwnd);
+                        width = MulDiv(1280, dpi, 96);
+                        height = MulDiv(720, dpi, 96);
+                    }
                     SetWindowPos(hwnd, nullptr, 0, 0, width, height,
                                  SWP_NOMOVE | SWP_NOZORDER | SWP_NOACTIVATE);
                 });

--- a/GhosttyWin32App/MainWindow.xaml.h
+++ b/GhosttyWin32App/MainWindow.xaml.h
@@ -111,6 +111,14 @@ namespace winrt::GhosttyWin32::implementation
         // (e.g., snap-to-cell resize feedback) has the current value.
         uint32_t m_cellWidth = 0;
         uint32_t m_cellHeight = 0;
+        // Fullscreen toggle state — TOGGLE_FULLSCREEN flips m_fullscreen
+        // and uses m_prevPlacement / m_prevStyle to restore the original
+        // window when leaving fullscreen. We save WINDOWPLACEMENT instead
+        // of a RECT because it round-trips maximised state correctly
+        // (toggling FS from a maximised window should return to maximised).
+        bool m_fullscreen = false;
+        WINDOWPLACEMENT m_prevPlacement{};
+        LONG_PTR m_prevStyle = 0;
         PaneIdAllocator m_paneIds;
         Tabs m_tabs;
         // Focus-tracked active surface. Set by NotifySurfaceFocused

--- a/GhosttyWin32App/MainWindow.xaml.h
+++ b/GhosttyWin32App/MainWindow.xaml.h
@@ -105,6 +105,12 @@ namespace winrt::GhosttyWin32::implementation
         // falls back to a DPI-scaled 1280x720 in that case.
         uint32_t m_initialWidth = 0;
         uint32_t m_initialHeight = 0;
+        // Glyph cell dimensions (pixels) from GHOSTTY_ACTION_CELL_SIZE.
+        // Updated whenever ghostty's font / cell metrics change so any
+        // future host-side sizing logic that wants whole-cell rounding
+        // (e.g., snap-to-cell resize feedback) has the current value.
+        uint32_t m_cellWidth = 0;
+        uint32_t m_cellHeight = 0;
         PaneIdAllocator m_paneIds;
         Tabs m_tabs;
         // Focus-tracked active surface. Set by NotifySurfaceFocused

--- a/GhosttyWin32App/MainWindow.xaml.h
+++ b/GhosttyWin32App/MainWindow.xaml.h
@@ -100,6 +100,11 @@ namespace winrt::GhosttyWin32::implementation
 
         std::unique_ptr<GhosttyApp> m_ghostty;
         HWND m_hwnd = nullptr;
+        // Initial window size from GHOSTTY_ACTION_INITIAL_SIZE (physical
+        // pixels). Zero means "not yet received" — RESET_WINDOW_SIZE
+        // falls back to a DPI-scaled 1280x720 in that case.
+        uint32_t m_initialWidth = 0;
+        uint32_t m_initialHeight = 0;
         PaneIdAllocator m_paneIds;
         Tabs m_tabs;
         // Focus-tracked active surface. Set by NotifySurfaceFocused

--- a/GhosttyWin32App/MainWindow.xaml.h
+++ b/GhosttyWin32App/MainWindow.xaml.h
@@ -22,6 +22,14 @@ namespace winrt::GhosttyWin32::implementation
         // NVIDIA state.
         static long __stdcall OnUnhandledException(struct _EXCEPTION_POINTERS* info) noexcept;
 
+        // WM_GETMINMAXINFO subclass proc installed lazily on first
+        // SIZE_LIMIT. dwRefData carries the MainWindow*; the proc
+        // reads m_sizeLimit and clamps ptMin/MaxTrackSize before
+        // forwarding to DefSubclassProc.
+        static LRESULT CALLBACK SizeLimitSubclassProc(
+            HWND hwnd, UINT msg, WPARAM wp, LPARAM lp,
+            UINT_PTR id, DWORD_PTR ref) noexcept;
+
         // Caption button click handlers, referenced from MainWindow.xaml.
         // Routed through Win32 messages (WM_SYSCOMMAND / WM_CLOSE / ShowWindow)
         // rather than OverlappedPresenter state changes, which have
@@ -119,6 +127,12 @@ namespace winrt::GhosttyWin32::implementation
         bool m_fullscreen = false;
         WINDOWPLACEMENT m_prevPlacement{};
         LONG_PTR m_prevStyle = 0;
+        // SIZE_LIMIT — min / max window size in pixels. The values are
+        // applied in WM_GETMINMAXINFO via SizeLimitSubclassProc, which
+        // is installed lazily on the first SIZE_LIMIT so apps that
+        // never set a size limit don't pay the subclass cost.
+        ghostty_action_size_limit_s m_sizeLimit{};
+        bool m_sizeLimitSubclassed = false;
         PaneIdAllocator m_paneIds;
         Tabs m_tabs;
         // Focus-tracked active surface. Set by NotifySurfaceFocused

--- a/GhosttyWin32App/MainWindow.xaml.h
+++ b/GhosttyWin32App/MainWindow.xaml.h
@@ -30,6 +30,15 @@ namespace winrt::GhosttyWin32::implementation
             HWND hwnd, UINT msg, WPARAM wp, LPARAM lp,
             UINT_PTR id, DWORD_PTR ref) noexcept;
 
+        // WM_SETCURSOR subclass proc for MOUSE_VISIBILITY. WinUI 3
+        // ignores ShowCursor (the cursor goes through ProtectedCursor
+        // / InputSystemCursor instead), so the only reliable hide
+        // path is to short-circuit WM_SETCURSOR with SetCursor(NULL)
+        // while m_cursorHidden is true.
+        static LRESULT CALLBACK CursorVisibilitySubclassProc(
+            HWND hwnd, UINT msg, WPARAM wp, LPARAM lp,
+            UINT_PTR id, DWORD_PTR ref) noexcept;
+
         // Caption button click handlers, referenced from MainWindow.xaml.
         // Routed through Win32 messages (WM_SYSCOMMAND / WM_CLOSE / ShowWindow)
         // rather than OverlappedPresenter state changes, which have
@@ -133,6 +142,13 @@ namespace winrt::GhosttyWin32::implementation
         // never set a size limit don't pay the subclass cost.
         ghostty_action_size_limit_s m_sizeLimit{};
         bool m_sizeLimitSubclassed = false;
+        // MOUSE_VISIBILITY — when true, WM_SETCURSOR returns NULL so
+        // the cursor stays hidden until the next VISIBLE transition.
+        // Subclass installed lazily on the first MOUSE_VISIBILITY so
+        // the WM_SETCURSOR interception doesn't happen for apps that
+        // never fire the action.
+        bool m_cursorHidden = false;
+        bool m_cursorSubclassed = false;
         PaneIdAllocator m_paneIds;
         Tabs m_tabs;
         // Focus-tracked active surface. Set by NotifySurfaceFocused


### PR DESCRIPTION
## Summary / 概要

Closes a large slice of #57 (v1.0 ghostty action parity). Across four batches this PR takes action coverage from 14/65 to **58/65 wired** — 25 new full implementations, 18 explicit acks, 1 disabled-pending-fix. The remaining 7 are either deferred to their own PRs (TOGGLE_WINDOW_DECORATIONS, TOGGLE_BACKGROUND_OPACITY), waiting on multi-window (#55: GOTO_WINDOW, MOVE_TAB, PRESENT_TERMINAL), or not applicable on Windows.

<details><summary>日本語</summary>

#57 (v1.0 ghostty action 対応) の大半を一気に片付ける PR。4 つのバッチで action カバレッジを 14/65 → **58/65** まで上げる (新規実装 25、明示 ack 18、無効化保留 1)。残り 7 は別 PR (`TOGGLE_WINDOW_DECORATIONS` / `TOGGLE_BACKGROUND_OPACITY`)、multi-window #55 待ち (`GOTO_WINDOW` / `MOVE_TAB` / `PRESENT_TERMINAL`)、Windows 非対応 (`SHOW_GTK_INSPECTOR` / `SHOW_ON_SCREEN_KEYBOARD`)。

</details>

## What's in / 入っているもの

### batch 1 — close / max / clipboard / config (8)

| Action | Win32 primitive | Notes |
|---|---|---|
| `RING_BELL` | `MessageBeep(MB_OK)` | OS-defined "Default Beep" sound |
| `CLOSE_WINDOW` / `CLOSE_ALL_WINDOWS` / `QUIT` | `Window.Close()` | Same effect in single-window mode |
| `TOGGLE_MAXIMIZE` | `WM_SYSCOMMAND` + `SC_MAXIMIZE` / `SC_RESTORE` | Same path the caption button uses (avoids #26 NVIDIA AV) |
| `COPY_TITLE_TO_CLIPBOARD` | `Clipboard::write` | Reads back the TabViewItem.Header that SET_TITLE populates |
| `OPEN_CONFIG` | `ShellExecuteW` "open" on `%LOCALAPPDATA%\ghostty\config` | Falls through to "Open With" dialog on first run |
| `TOGGLE_VISIBILITY` | `ShowWindow(SW_MINIMIZE / SW_RESTORE)` | `SW_MINIMIZE` keeps the taskbar entry visible |

### batch 2 — reload / mouse / health / size (6)

| Action | Win32 primitive | Notes |
|---|---|---|
| `RELOAD_CONFIG` | `ghostty_config_load_default_files` + `ghostty_app_update_config` | 4MB worker thread for the parser; UI-thread swap; default `ctrl+shift+,` keybind now works |
| `CONFIG_CHANGE` | `ghostty_config_clone` + `ReplaceConfig` | Notification, not request — sync the cached pointer so soft reload doesn't re-apply stale data |
| `RENDERER_HEALTH` | `fprintf(stderr, ...)` | Log on health flip; recovery UX is a separate design problem |
| `MOUSE_VISIBILITY` | `ShowCursor` with state-tracked toggle | ShowCursor is a counter — gate on a local bool to avoid the counter walking |
| `QUIT_TIMER` | (no-op) | Windows quits with the last window; the macOS-style countdown doesn't apply |
| `RESET_WINDOW_SIZE` | `SetWindowPos` to recorded `INITIAL_SIZE` or 1280x720 DIP fallback | DPI-scaled fallback when INITIAL_SIZE hasn't fired yet |

### batch 3 — size / scrollbar / render / lifecycle (7)

| Action | Win32 primitive | Notes |
|---|---|---|
| `INITIAL_SIZE` | Member cache (`m_initialWidth` / `m_initialHeight`) | Honors `window-width × cell-width-px` from config; `RESET_WINDOW_SIZE` consumes it |
| `CELL_SIZE` | Member cache (`m_cellWidth` / `m_cellHeight`) | Pre-wired for future snap-to-cell logic; no current reader |
| `SCROLLBAR` | (no-op ack) | We don't render a scrollbar widget |
| `RENDER` | UI-thread `Tick()` | Same path as `wakeup_cb`; `ghostty_app_tick` is idempotent when nothing is dirty |
| `SHOW_CHILD_EXITED` | `fprintf(stderr, "[child_exited] exit_code=%u after_ms=%llu", ...)` | In-terminal overlay UI is a separate iteration |
| `CHECK_FOR_UPDATES` | `ShellExecuteW` to GitHub releases | No in-app Sparkle-equivalent updater yet |
| `PROGRESS_REPORT` | `ITaskbarList3::SetProgressState` / `SetProgressValue` | OSC 9;4 → taskbar progress; manager is cached on UI thread |

### batch 4 — high-priority Win32 (4)

| Action | Win32 primitive | Notes |
|---|---|---|
| `DESKTOP_NOTIFICATION` | `Microsoft.Windows.AppNotifications.AppNotificationBuilder` + `Show` | Manager registered in `App::OnLaunched`; Package.appxmanifest carries the COM activator + toast activation extension. Toast click currently spawns a second instance — separate follow-up |
| `TOGGLE_FULLSCREEN` | `SetWindowLongPtrW` + `SetWindowPos` + `WINDOWPLACEMENT` save/restore | Borderless FS; custom title bar still draws on top — follow-up |
| `MOUSE_OVER_LINK` | Win32 `TOOLTIPS_CLASS` popup in TRACK mode | Lazy-init; positioned ~20px below-right of cursor |
| `SIZE_LIMIT` | `WM_GETMINMAXINFO` via `SetWindowSubclass` | Subclass installed lazily on first SIZE_LIMIT; `MainWindow*` carried via `dwRefData` |

### Acknowledged (no behavior change, just `return true`)

Routing them through `action_cb` so they don't fall through to the unhandled-default while the surface-side UI is built later.

- **Informational state** (7): `READONLY`, `SECURE_INPUT`, `KEY_SEQUENCE`, `KEY_TABLE`, `PROMPT_TITLE`, `PWD`, `COMMAND_FINISHED`
- **Feature pending** (11): `UNDO`, `REDO`, `START_SEARCH`, `END_SEARCH`, `SEARCH_TOTAL`, `SEARCH_SELECTED`, `INSPECTOR`, `RENDER_INSPECTOR`, `TOGGLE_TAB_OVERVIEW`, `TOGGLE_QUICK_TERMINAL`, `TOGGLE_COMMAND_PALETTE`

### Disabled — `#if 0`-guarded (1)

- `FLOAT_WINDOW` — `WS_EX_TOPMOST` toggle written, verified Win32-side. No keybind we tried reached `action_cb`: `ctrl+shift+f` collides with default `start_search`; `ctrl+shift+alt+f` is swallowed by the WinUI Alt-menu accelerator; `ctrl+shift+backslash` produced no observable call either. Body preserved verbatim; re-enable once the dispatch path is understood.

<details><summary>日本語: 詳細</summary>

batch 1〜4 + ack バンドル + 無効化 FLOAT_WINDOW、計 22 コミット (Package.appxmanifest の toast activator 登録含む)。各 action のコメントは英語で残し、commit メッセージで「なぜ」を残す方針。

</details>

## Test plan / 検証

Suggested keybinds (`%LOCALAPPDATA%\ghostty\config`):

```
keybind = ctrl+shift+m=toggle_maximize
keybind = ctrl+shift+c=copy_title_to_clipboard
keybind = global:ctrl+shift+h=toggle_visibility
keybind = f11=toggle_fullscreen
# ctrl+, and ctrl+shift+, are ghostty defaults (open_config / reload_config)
# — leave them alone instead of overriding.
```

- [x] `RING_BELL`: `printf "\a"` produces the OS bell sound
- [x] `CLOSE_WINDOW` / `QUIT`: window closes via keybind
- [x] `TOGGLE_MAXIMIZE`: keybind toggles maximize / restore
- [x] `COPY_TITLE_TO_CLIPBOARD`: keybind puts the tab title on the clipboard
- [x] `OPEN_CONFIG`: `Ctrl+,` opens `config` in the default editor (ghostty default)
- [x] `RELOAD_CONFIG`: edit `background = 003366` → save → `Ctrl+Shift+,` → background changes without restart
- [x] `CONFIG_CHANGE`: covered by the reload test (no separate UI surface)
- [ ] ~~`MOUSE_VISIBILITY`~~ — handler `#if 0`-guarded pending #60 (action doesn't reach `action_cb` on Windows; suspected cause: `ghostty_surface_key` not populating `event.utf8` for printable keystrokes)
- [x] `RESET_WINDOW_SIZE`: with `keybind = ctrl+alt+r=reset_window_size` (the unicode-trigger workaround for #60), drag the window to a custom size → `Ctrl+Alt+R` snaps it back to startup dimensions. Physical-key triggers like `ctrl+shift+digit_0` don't fire because of the same `ghostty_surface_key` field-population issue
- [x] `TOGGLE_VISIBILITY`: `global:` keybind hides → reveals
- [x] `TOGGLE_FULLSCREEN`: `F11` → borderless FS → F11 again → original window
- [ ] ~~`MOUSE_OVER_LINK`~~ — tooltip body `#if 0`-guarded pending #61 (action reaches `action_cb` but the Win32 `TOOLTIPS_CLASS` tooltip crashed the process on URL click)
- [x] `SIZE_LIMIT`: drag the window to its minimum → it stops at ghostty's hardcoded 10-cell × 4-row floor (the min is not user-configurable; ghostty sends the limit once at startup as `cell_width * 10` by `cell_height * 4`)
- [x] `DESKTOP_NOTIFICATION`: `echo "\`e]9;hello\`a"` in pwsh → Windows toast appears. **Known limitation**: clicking the toast spawns a second Ghostty instance (toast activation routing not wired yet — follow-up)
- [x] `PROGRESS_REPORT`: `echo "\`e]9;4;1;50\`a"` → taskbar button shows a progress bar; `echo "\`e]9;4;0\`a"` clears it
- [x] `SHOW_CHILD_EXITED`: `exit 42` in pwsh → VS Debug output shows `[child_exited] exit_code=42 after_ms=...` (mirrored through `OutputDebugStringA` so it survives the surface teardown)
- [x] `CHECK_FOR_UPDATES`: bind to `keybind = ctrl+shift+u=check_for_updates` → opens GitHub releases in browser

<details><summary>日本語</summary>

検証用 keybind (`%LOCALAPPDATA%\ghostty\config`):

```
keybind = ctrl+shift+m=toggle_maximize
keybind = ctrl+shift+c=copy_title_to_clipboard
keybind = global:ctrl+shift+h=toggle_visibility
keybind = f11=toggle_fullscreen
# ctrl+, と ctrl+shift+, は ghostty デフォルト (open_config / reload_config)。
# 上書きしないこと。
```

チェックリスト:

- [x] `RING_BELL`: `printf "\a"` で OS ベル音
- [x] `CLOSE_WINDOW` / `QUIT`: キーバインドでウインドウが閉じる
- [x] `TOGGLE_MAXIMIZE`: キーバインドで最大化 / 復元
- [x] `COPY_TITLE_TO_CLIPBOARD`: キーバインドでタイトルがクリップボードへ
- [x] `OPEN_CONFIG`: `Ctrl+,` で config がデフォルトエディタで開く
- [x] `RELOAD_CONFIG`: config を編集 → 保存 → `Ctrl+Shift+,` → 再起動なしで色が変わる
- [x] `CONFIG_CHANGE`: 上の reload テストでカバー
- [ ] ~~`MOUSE_VISIBILITY`~~ — #60 待ちで `#if 0` 無効化 (Windows で action_cb まで届かない、`ghostty_surface_key` の `event.utf8` populate 漏れが疑われる)
- [x] `RESET_WINDOW_SIZE`: `keybind = ctrl+alt+r=reset_window_size` (#60 の unicode-trigger workaround) で、サイズを変えてから `Ctrl+Alt+R` 押すと起動時サイズに戻る。物理キートリガー (`ctrl+shift+digit_0` 等) は同じ `ghostty_surface_key` のフィールド populate 問題で発火しない
- [x] `TOGGLE_VISIBILITY`: `global:` 付き keybind で隠す → 再表示
- [x] `TOGGLE_FULLSCREEN`: F11 で全画面 → 再度 F11 で元に戻る
- [ ] ~~`MOUSE_OVER_LINK`~~ — #61 待ちで tooltip 本体を `#if 0` 無効化 (action は届くが Win32 `TOOLTIPS_CLASS` ツールチップが URL クリックでプロセスを落とす)
- [x] `SIZE_LIMIT`: ウインドウを限界まで小さくドラッグ → ghostty の hardcoded な 10 セル × 4 行で止まる (min は user 指定不可、起動時に `cell_width * 10` × `cell_height * 4` で送られてくる)
- [x] `DESKTOP_NOTIFICATION`: pwsh で `echo "\`e]9;hello\`a"` → Windows のトースト。**既知の制限**: トーストをクリックすると Ghostty が二重起動 (activation routing 未対応、別 PR で)
- [x] `PROGRESS_REPORT`: `echo "\`e]9;4;1;50\`a"` でタスクバーに進捗バー、`echo "\`e]9;4;0\`a"` で消去
- [x] `SHOW_CHILD_EXITED`: pwsh で `exit 42` → VS のデバッグ出力に `[child_exited] exit_code=42 after_ms=...` (`OutputDebugStringA` 経路でサーフェスのテアダウンを生き残る)
- [x] `CHECK_FOR_UPDATES`: `keybind = ctrl+shift+u=check_for_updates` で releases ページが開く

</details>

## Out of scope / スコープ外

- `TOGGLE_WINDOW_DECORATIONS` — interacts with our custom XAML title bar; isolated PR for easier review
- `TOGGLE_BACKGROUND_OPACITY` — DComp swap chain blend mode; renderer change deserves its own PR
- Toast click activation routing — currently spawns a new Ghostty instance; needs `WinMain` cmdline parsing for `----AppNotificationActivated:` plus single-instance handoff
- `INSPECTOR` / `RENDER_INSPECTOR` — ImGui debug inspector port (Metal-on-macOS → DX-on-Windows)
- `START_SEARCH` / `END_SEARCH` / `SEARCH_TOTAL` / `SEARCH_SELECTED` — terminal search bar UI
- `TOGGLE_TAB_OVERVIEW` / `TOGGLE_QUICK_TERMINAL` / `TOGGLE_COMMAND_PALETTE` — new overlay UIs
- `UNDO` / `REDO` — host-side undo stack (recently-closed tab restore, etc.)
- `GOTO_WINDOW` / `MOVE_TAB` / `PRESENT_TERMINAL` — multi-window (#55) dependent
- Refactor of `action_cb` itself into a dedicated `ActionDispatcher` class — tracked in #59, lands after this merges

<details><summary>日本語</summary>

- `TOGGLE_WINDOW_DECORATIONS`: カスタムタイトルバー干渉、別 PR
- `TOGGLE_BACKGROUND_OPACITY`: DComp blend mode、renderer 変更で別 PR
- トーストクリック時の activation ルーティング: 現状は新規インスタンスが立ち上がる。`WinMain` で `----AppNotificationActivated:` を見て single-instance に転送する処理が別途必要
- `INSPECTOR` / `RENDER_INSPECTOR`: ImGui inspector の Metal → DX 移植
- search 系: 検索バー UI
- overlay 系 (`TAB_OVERVIEW` / `QUICK_TERMINAL` / `COMMAND_PALETTE`): 各 overlay UI
- `UNDO` / `REDO`: host 側 undo stack (閉じたタブ復元等)
- multi-window 系: #55 待ち
- `action_cb` のリファクタ (`ActionDispatcher` クラスへ抽出): #59、本 PR マージ後に着手

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)




