### PR TITLE
v1.0 actions batch 5: wire 3, ack-stub 2 (MOVE_TAB / SHOW_OSK / PRESENT_TERMINAL + 2 stubs)

### DIFF
--- a/App/MainWindow.xaml.cpp
+++ b/App/MainWindow.xaml.cpp
@@ -776,6 +776,29 @@ namespace winrt::GhosttyWin32::implementation
         win32::Clipboard::write(m_hwnd, std::wstring(title));
     }
 
+    void MainWindow::MoveActiveTabBy(ssize_t amount)
+    {
+        // Shift the currently-selected tab by `amount` positions
+        // along the TabView's items collection. Clamped to the
+        // bounds — out-of-range values are a no-op rather than a
+        // wrap-around (matches the upstream MoveTab semantics).
+        auto tabView = TabView();
+        if (!tabView) return;
+        auto items = tabView.TabItems();
+        if (items.Size() == 0 || amount == 0) return;
+        int current = tabView.SelectedIndex();
+        if (current < 0) return;
+        ssize_t target = static_cast<ssize_t>(current) + amount;
+        ssize_t maxIdx = static_cast<ssize_t>(items.Size()) - 1;
+        if (target < 0) target = 0;
+        if (target > maxIdx) target = maxIdx;
+        if (target == current) return;
+        auto item = items.GetAt(static_cast<uint32_t>(current));
+        items.RemoveAt(static_cast<uint32_t>(current));
+        items.InsertAt(static_cast<uint32_t>(target), item);
+        tabView.SelectedIndex(static_cast<int>(target));
+    }
+
     // ----- IMainWindowView: state-owner delegating overrides -----
 
     void MainWindow::ApplySizeLimit(ghostty_action_size_limit_s limit)
@@ -786,6 +809,33 @@ namespace winrt::GhosttyWin32::implementation
     void MainWindow::ToggleFullscreen()
     {
         m_fullscreen.Toggle(m_hwnd);
+    }
+
+    void MainWindow::PresentTerminal()
+    {
+        // Restore from minimized first so SetForegroundWindow has
+        // something to focus. BringWindowToTop reorders the Z stack
+        // even when foreground stealing is blocked by Win32's
+        // SPI_GETFOREGROUNDLOCKTIMEOUT rule; the user notices the
+        // taskbar flash even if focus is denied.
+        if (!m_hwnd) return;
+        if (IsIconic(m_hwnd)) {
+            ShowWindow(m_hwnd, SW_RESTORE);
+        }
+        BringWindowToTop(m_hwnd);
+        SetForegroundWindow(m_hwnd);
+    }
+
+    void MainWindow::ShowOnScreenKeyboard()
+    {
+        // osk.exe (the Accessibility on-screen keyboard) ships with
+        // every supported Windows version and is the documented
+        // entry point for keyboard-less input. TabTip.exe (the
+        // touch keyboard) would be slightly nicer on tablets but
+        // its path and launch contract changed across Win10
+        // builds; osk.exe is the portable choice.
+        ShellExecuteW(m_hwnd, L"open", L"osk.exe",
+                      nullptr, nullptr, SW_SHOWNORMAL);
     }
 
     // ----- IMainWindowView: terminal-driven appearance + lifecycle -----

--- a/App/MainWindow.xaml.h
+++ b/App/MainWindow.xaml.h
@@ -96,6 +96,7 @@ namespace winrt::GhosttyWin32::implementation
         void SetTabTitleForSurface(ghostty_surface_t surface,
                                    std::wstring title) override;
         void CopyTabTitleForSurface(ghostty_surface_t surface) override;
+        void MoveActiveTabBy(ssize_t amount) override;
 
         // State-owner delegating overrides. Each is a one-liner;
         // the actual logic lives in the dedicated value (m_sizeLimit,
@@ -103,6 +104,8 @@ namespace winrt::GhosttyWin32::implementation
         // that nothing outside one specific handler reads.
         void ApplySizeLimit(ghostty_action_size_limit_s limit) override;
         void ToggleFullscreen() override;
+        void PresentTerminal() override;
+        void ShowOnScreenKeyboard() override;
 
         // Terminal-driven appearance / lifecycle overrides. Bodies
         // are in MainWindow.xaml.cpp; the logic moved verbatim

--- a/Core/Ghostty/Actions/Actions.cpp
+++ b/Core/Ghostty/Actions/Actions.cpp
@@ -140,6 +140,28 @@ bool Actions::OnToggleMaximize() {
     return true;
 }
 
+bool Actions::OnPresentTerminal() {
+    // Used by external notification "click-to-focus" paths. The
+    // view restores minimized state and grabs foreground; raw
+    // SetForegroundWindow alone would silently fail when our
+    // window isn't already in the allowed-set per Win32's
+    // foreground rules.
+    m_view.Dispatch([this]() {
+        m_view.PresentTerminal();
+    });
+    return true;
+}
+
+bool Actions::OnShowOnScreenKeyboard() {
+    // Touch / pen users without a physical keyboard. The OSK is
+    // its own top-level window; we just launch it and let the user
+    // dismiss it normally.
+    m_view.Dispatch([this]() {
+        m_view.ShowOnScreenKeyboard();
+    });
+    return true;
+}
+
 bool Actions::OnOpenConfig() {
     // Open the user's ghostty config in their default editor.
     // The Windows config path is %LOCALAPPDATA%\ghostty\config
@@ -219,6 +241,16 @@ bool Actions::OnCloseTab(ghostty_surface_t surface) {
 bool Actions::OnGotoTab(int requested) {
     m_view.Dispatch([this, requested]() {
         m_view.GoToTab(requested);
+    });
+    return true;
+}
+
+bool Actions::OnMoveTab(ghostty_action_move_tab_s move) {
+    // ghostty hands us a signed offset; semantics are "shift the
+    // currently selected tab by N positions, clamped to the
+    // TabView's bounds" (no wrap-around — matches upstream).
+    m_view.Dispatch([this, move]() {
+        m_view.MoveActiveTabBy(move.amount);
     });
     return true;
 }

--- a/Core/Ghostty/Actions/Actions.h
+++ b/Core/Ghostty/Actions/Actions.h
@@ -42,6 +42,8 @@ public:
     bool OnCloseWindow();
     bool OnToggleVisibility();
     bool OnToggleMaximize();
+    bool OnPresentTerminal();
+    bool OnShowOnScreenKeyboard();
     bool OnOpenConfig();
 
     // ----- sizing -----
@@ -54,6 +56,7 @@ public:
     bool OnNewTab();
     bool OnCloseTab(ghostty_surface_t surface);
     bool OnGotoTab(int requested);
+    bool OnMoveTab(ghostty_action_move_tab_s move);
     // SET_TITLE and SET_TAB_TITLE collapse to the same handler —
     // this port has one title surface per tab.
     bool OnSetTitle(ghostty_surface_t surface, const char* utf8Title);

--- a/Core/Ghostty/CallbackDispatcher.cpp
+++ b/Core/Ghostty/CallbackDispatcher.cpp
@@ -37,6 +37,10 @@ bool CallbackDispatcher::DispatchAction(ghostty_target_s target, ghostty_action_
             return m_actions.OnToggleVisibility();
         case GHOSTTY_ACTION_TOGGLE_MAXIMIZE:
             return m_actions.OnToggleMaximize();
+        case GHOSTTY_ACTION_PRESENT_TERMINAL:
+            return m_actions.OnPresentTerminal();
+        case GHOSTTY_ACTION_SHOW_ON_SCREEN_KEYBOARD:
+            return m_actions.OnShowOnScreenKeyboard();
         case GHOSTTY_ACTION_OPEN_CONFIG:
             return m_actions.OnOpenConfig();
 
@@ -58,6 +62,8 @@ bool CallbackDispatcher::DispatchAction(ghostty_target_s target, ghostty_action_
             return false;
         case GHOSTTY_ACTION_GOTO_TAB:
             return m_actions.OnGotoTab(static_cast<int>(action.action.goto_tab));
+        case GHOSTTY_ACTION_MOVE_TAB:
+            return m_actions.OnMoveTab(action.action.move_tab);
         // SET_TITLE / SET_TAB_TITLE: this port treats them
         // identically (one title surface per tab); the action union
         // happens to share `set_title` for both tags.
@@ -168,6 +174,16 @@ bool CallbackDispatcher::DispatchAction(ghostty_target_s target, ghostty_action_
         // Acking avoids "unhandled action" noise once that's
         // fixed and the keybind starts firing.
         case GHOSTTY_ACTION_FLOAT_WINDOW:
+        // TOGGLE_WINDOW_DECORATIONS / TOGGLE_BACKGROUND_OPACITY:
+        // dispatched but not yet implemented to match upstream
+        // semantics — tracked separately so the action_cb stays
+        // quiet until the real implementations land:
+        //   #68 — TOGGLE_WINDOW_DECORATIONS (per-window override,
+        //         3-state, mirroring upstream GTK)
+        //   #69 — TOGGLE_BACKGROUND_OPACITY (layered-alpha flip
+        //         against config value, with macOS-style guards)
+        case GHOSTTY_ACTION_TOGGLE_WINDOW_DECORATIONS:
+        case GHOSTTY_ACTION_TOGGLE_BACKGROUND_OPACITY:
         // MOUSE_VISIBILITY disabled pending #60 (the renderer-
         // side ghostty_surface_key call doesn't populate the
         // event fields ghostty checks before firing this).

--- a/Core/Host/IWindow.h
+++ b/Core/Host/IWindow.h
@@ -110,6 +110,13 @@ struct IWindow {
     // system clipboard. No-op when the tab has no title yet.
     virtual void CopyTabTitleForSurface(ghostty_surface_t surface) = 0;
 
+    // Move the currently-selected tab by `amount` positions (signed).
+    // Positive shifts toward higher indices, negative toward lower.
+    // The value is clamped to the TabView's bounds; out-of-range
+    // values are a no-op rather than a wrap-around — matches the
+    // upstream MoveTab semantics.
+    virtual void MoveActiveTabBy(ssize_t amount) = 0;
+
     // ----- window state helpers (delegated to dedicated state
     // owners on MainWindow's side) -----
 
@@ -121,6 +128,17 @@ struct IWindow {
     // Toggle borderless fullscreen on/off. Restores the exact
     // pre-fullscreen placement + style when leaving.
     virtual void ToggleFullscreen() = 0;
+
+    // Bring the window to the foreground (restoring it from a
+    // minimized state first) and give it focus. Used by
+    // PRESENT_TERMINAL — typically triggered by an external
+    // notification "click me" path.
+    virtual void PresentTerminal() = 0;
+
+    // Show the Windows on-screen keyboard so a touch / pen user can
+    // type without a physical keyboard. The OSK is its own top-level
+    // window; we don't track it and the user dismisses it normally.
+    virtual void ShowOnScreenKeyboard() = 0;
 
     // ----- terminal-driven appearance + lifecycle -----
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,9 @@ A WinUI 3 + C++/WinRT shell that hosts the libghostty C API. Each tab owns its o
 - `COLOR_CHANGE`: sync title bar tint with terminal background
 - `TOGGLE_FULLSCREEN` / `TOGGLE_MAXIMIZE`
 - `SIZE_LIMIT` / `INITIAL_SIZE` / `RESET_WINDOW_SIZE`
-- `NEW_TAB` / `CLOSE_TAB` / `GOTO_TAB`
+- `NEW_TAB` / `CLOSE_TAB` / `GOTO_TAB` / `MOVE_TAB`
+- `PRESENT_TERMINAL`: restore + foreground the window
+- `SHOW_ON_SCREEN_KEYBOARD`: launch the Windows OSK
 - `QUIT`: clean shutdown
 - Clipboard read / write
 - Wakeup: thread-safe `PostMessage` to the UI thread

--- a/Tests/MockMainWindowView.h
+++ b/Tests/MockMainWindowView.h
@@ -108,6 +108,13 @@ struct MockMainWindowView : core::host::IWindow {
         lastCopyTitleSurface = s;
     }
 
+    int moveActiveTabByCalls = 0;
+    ssize_t lastMoveTabAmount = 0;
+    void MoveActiveTabBy(ssize_t amount) override {
+        ++moveActiveTabByCalls;
+        lastMoveTabAmount = amount;
+    }
+
     // ----- window state -----
     int applySizeLimitCalls = 0;
     ghostty_action_size_limit_s lastSizeLimit{};
@@ -118,6 +125,12 @@ struct MockMainWindowView : core::host::IWindow {
 
     int toggleFullscreenCalls = 0;
     void ToggleFullscreen() override { ++toggleFullscreenCalls; }
+
+    int presentTerminalCalls = 0;
+    void PresentTerminal() override { ++presentTerminalCalls; }
+
+    int showOnScreenKeyboardCalls = 0;
+    void ShowOnScreenKeyboard() override { ++showOnScreenKeyboardCalls; }
 
     // ----- terminal-driven appearance + lifecycle -----
     int applyBackgroundColorCalls = 0;

--- a/Tests/test_ghostty_actions.cpp
+++ b/Tests/test_ghostty_actions.cpp
@@ -47,6 +47,20 @@ TEST(GhosttyActionsTest, OnToggleFullscreenAsksTheViewToToggle) {
     EXPECT_EQ(view.toggleFullscreenCalls, 1);
 }
 
+TEST(GhosttyActionsTest, OnPresentTerminalAsksTheView) {
+    MockMainWindowView view;
+    Actions actions(view);
+    EXPECT_TRUE(actions.OnPresentTerminal());
+    EXPECT_EQ(view.presentTerminalCalls, 1);
+}
+
+TEST(GhosttyActionsTest, OnShowOnScreenKeyboardAsksTheView) {
+    MockMainWindowView view;
+    Actions actions(view);
+    EXPECT_TRUE(actions.OnShowOnScreenKeyboard());
+    EXPECT_EQ(view.showOnScreenKeyboardCalls, 1);
+}
+
 // ----- tab lifecycle / navigation / title -----
 
 TEST(GhosttyActionsTest, OnNewTabCreatesATab) {
@@ -72,6 +86,27 @@ TEST(GhosttyActionsTest, OnCloseTabIgnoresNullSurface) {
     Actions actions(view);
     EXPECT_TRUE(actions.OnCloseTab(nullptr));
     EXPECT_EQ(view.closeTabBySurfaceCalls, 0);
+}
+
+TEST(GhosttyActionsTest, OnMoveTabForwardsTheAmount) {
+    MockMainWindowView view;
+    Actions actions(view);
+    ghostty_action_move_tab_s move{};
+    move.amount = 2;
+    EXPECT_TRUE(actions.OnMoveTab(move));
+    EXPECT_EQ(view.moveActiveTabByCalls, 1);
+    EXPECT_EQ(view.lastMoveTabAmount, 2);
+}
+
+TEST(GhosttyActionsTest, OnMoveTabAllowsNegativeAmount) {
+    // Negative amount = shift toward lower indices. The action
+    // handler itself doesn't clamp — that's the view's job.
+    MockMainWindowView view;
+    Actions actions(view);
+    ghostty_action_move_tab_s move{};
+    move.amount = -3;
+    EXPECT_TRUE(actions.OnMoveTab(move));
+    EXPECT_EQ(view.lastMoveTabAmount, -3);
 }
 
 TEST(GhosttyActionsTest, OnGotoTabForwardsTheIndex) {


### PR DESCRIPTION
## Why

Five `v1.0` actions were still falling through `CallbackDispatcher`'s default switch arm. Three are shaped well enough to wire here; the other two need upstream-faithful semantics that are bigger design / behaviour calls, so they get explicit acks + tracking issues.

Without this, any keybind that resolves to one of the five either silently does nothing or — worse — gets intercepted by ghostty's default keybindings while the host's `action_cb` never sees it. We hit exactly that during verification: `ctrl+alt+left/right` was acting like `goto_tab` rather than `move_tab` because the default config beat our override.

<details><summary>日本語</summary>

batch 1–4 (#58) で 58/65 actions wired 済み。残りの v1.0 actions のうち 5 個 (MOVE_TAB / SHOW_ON_SCREEN_KEYBOARD / PRESENT_TERMINAL / TOGGLE_WINDOW_DECORATIONS / TOGGLE_BACKGROUND_OPACITY) が `CallbackDispatcher` の default に落ちて unhandled になっていた。

3 個は素直に実装、残り 2 個は upstream の semantics 再現に追加の設計判断が要るため、現状は dispatcher で ack だけして no-op、フォローアップ issue で追跡。

</details>

## What

### Wired (3)

| Action | Implementation |
|---|---|
| **`MOVE_TAB`** | Signed offset shifts the selected `TabView` item by N positions, clamped to bounds (no wrap — matches upstream) |
| **`SHOW_ON_SCREEN_KEYBOARD`** | `ShellExecuteW("osk.exe")` launches the Accessibility on-screen keyboard. Portable across Win10/11; `TabTip.exe` (touch keyboard) was rejected because its launch contract drifted across Win10 builds |
| **`PRESENT_TERMINAL`** | `IsIconic → SW_RESTORE → BringWindowToTop → SetForegroundWindow`. The action itself is **not keybind-fireable upstream** — it only flows through the OS desktop-notification click path on GTK. Our `PresentTerminal()` is ready but currently unreachable until #70 wires the AppNotification side |

### Ack-stubbed (2)

Acked in `CallbackDispatcher`'s "intentionally acked no-ops" arm with issue refs inline. The dispatcher returns `true` so libghostty doesn't treat these as unhandled, but no host-side mutation happens until the real impl lands.

| Action | Why stubbed | Tracking |
|---|---|---|
| **`TOGGLE_WINDOW_DECORATIONS`** | Upstream GTK is a **3-state per-window override** via `Gtk.Window.setDecorated()` (`null` / `.none` / `.auto`). A 2-state caption-button visibility toggle was prototyped and worked, but the 3-state semantics need a separate design pass | #68 |
| **`TOGGLE_BACKGROUND_OPACITY`** | Upstream macOS flips `window.alphaValue` between `1.0` and config's `background-opacity`, with no-op guards when config is `1.0` or fullscreen. A `SystemBackdrop` on/off prototype was tried but only changes chrome backdrop, not cell-area opacity — diverges from upstream intent | #69 |

### Test coverage

Each wired action gets a routing test against `MockMainWindowView` (`Tests/test_ghostty_actions.cpp`). The stubs have no test so the dispatcher's intentionally-acked switch arm is the only behaviour contract.

### Docs

`README.md` libghostty callbacks list updated with the 3 wired actions.

## Verification recipe

Add to `%LOCALAPPDATA%\ghostty\config` (PRESENT_TERMINAL isn't keybind-fireable, so it's omitted from the recipe — see #70 for the proper trigger):

```ini
keybind = ctrl+shift+k=show_on_screen_keyboard
keybind = ctrl+shift+page_up=move_tab:1
keybind = ctrl+shift+page_down=move_tab:-1
```

**Note on key choice**: `ctrl+alt+left/right` looks tempting for `move_tab` but ghostty's default keybind set intercepts it for `goto_tab`-equivalent behaviour, so our config-level override never reaches `action_cb`. `ctrl+shift+page_up/down` doesn't conflict.

Expected:

- **`SHOW_ON_SCREEN_KEYBOARD`** — `osk.exe` (Windows accessibility OSK) opens
- **`MOVE_TAB`** — with 2+ tabs open, selected tab's *position* shifts ±1 (not the same as `goto_tab` which moves *focus*; bounds clamped, no wrap)

For the two stubs:

```ini
keybind = ctrl+shift+d=toggle_window_decorations
keybind = ctrl+shift+b=toggle_background_opacity
```

Expected: **nothing happens** in the UI (dispatcher acks, no-op). If you see a visible change, the stub got bypassed somehow and that's a bug.

## Test plan

- [ ] Build solution (App / Core / Tests / Package) — `Release | x64`
- [ ] `Tests.exe` — new tests `OnMoveTab*`, `OnShowOnScreenKeyboardAsksTheView`, `OnPresentTerminalAsksTheView` pass
- [ ] Run the verification recipe above on the packaged MSIX
- [ ] Confirm no regression on existing batches' keybinds (`ctrl+shift+m=toggle_maximize`, `ctrl+f=start_search`, splits, etc.)

## Follow-ups

- **#68** — implement `TOGGLE_WINDOW_DECORATIONS` to match upstream GTK 3-state semantics
- **#69** — implement `TOGGLE_BACKGROUND_OPACITY` via `WS_EX_LAYERED` + `SetLayeredWindowAttributes`, with macOS-style guards
- **#70** — wire AppNotification click → existing-instance redirect → `PRESENT_TERMINAL` round-trip so the action this PR landed is actually reachable

🤖 Generated with [Claude Code](https://claude.com/claude-code)
