### PR TITLE
Wire notification click → present-pane round-trip (closes #70)

### DIFF
--- a/App/App.vcxproj
+++ b/App/App.vcxproj
@@ -115,12 +115,18 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">
     <ClCompile>
-      <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <!--
+        DISABLE_XAML_GENERATED_MAIN suppresses the wWinMain stub
+        the XAML compiler emits into App.xaml.g.hpp; our own
+        wWinMain in main.cpp runs AppInstance single-instance
+        redirect before Application::Start.
+      -->
+      <PreprocessorDefinitions>_DEBUG;DISABLE_XAML_GENERATED_MAIN;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Release'">
     <ClCompile>
-      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NDEBUG;DISABLE_XAML_GENERATED_MAIN;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
@@ -170,6 +176,7 @@
     <ClCompile Include="pch.cpp">
       <PrecompiledHeader>Create</PrecompiledHeader>
     </ClCompile>
+    <ClCompile Include="main.cpp" />
     <ClCompile Include="App.xaml.cpp">
       <DependentUpon>App.xaml</DependentUpon>
     </ClCompile>

--- a/App/App.xaml.cpp
+++ b/App/App.xaml.cpp
@@ -3,7 +3,9 @@
 #include "MainWindow.xaml.h"
 #include <filesystem>
 #include <fstream>
+#include <string>
 #include <windows.h>
+#include <winrt/Microsoft.Windows.AppLifecycle.h>
 #include <winrt/Microsoft.Windows.AppNotifications.h>
 
 using namespace winrt;
@@ -23,12 +25,15 @@ namespace {
 
 namespace winrt::GhosttyWin32::implementation
 {
+    App* App::g_app = nullptr;
+
     /// <summary>
     /// Initializes the singleton application object.  This is the first line of authored code
     /// executed, and as such is the logical equivalent of main() or WinMain().
     /// </summary>
     App::App()
     {
+        g_app = this;
         // Xaml objects should not call InitializeComponent during construction.
         // See https://github.com/microsoft/cppwinrt/tree/master/nuget#initializecomponent
 
@@ -45,12 +50,118 @@ namespace winrt::GhosttyWin32::implementation
 #endif
     }
 
+    void App::OnInstanceActivated(
+        winrt::Windows::Foundation::IInspectable const&,
+        winrt::Microsoft::Windows::AppLifecycle::AppActivationArguments const& args)
+    {
+        // Activated fires on a worker — bounce to the UI thread before
+        // touching the window. If the redirect happened before OnLaunched
+        // wired up `window`, just drop it; OnLaunched will run normally
+        // and present the terminal as a first-launch effect.
+        if (!window) return;
+        window.DispatcherQueue().TryEnqueue([weak = get_weak(), args]() {
+            if (auto self = weak.get()) {
+                self->HandleActivation(args);
+            }
+        });
+    }
+
+    void App::HandleActivation(
+        winrt::Microsoft::Windows::AppLifecycle::AppActivationArguments const&)
+    {
+        // The activation args delivered through AppInstance::Activated
+        // are a cross-process proxy back to the redirecting instance —
+        // which has already exited by the time we get here, so any
+        // Kind() / Data() call would throw RPC_S_SERVER_UNAVAILABLE.
+        // We deliberately ignore the args and just bring the window
+        // forward; the surface-targeted route (clicks on toasts we
+        // raised ourselves) is handled by OnNotificationInvoked, where
+        // the args are in-process and safe to read.
+        if (auto mwProj = window.try_as<winrt::GhosttyWin32::MainWindow>()) {
+            if (auto* mw = winrt::get_self<implementation::MainWindow>(mwProj)) {
+                mw->PresentNotification(implementation::PaneId{ 0 });
+            }
+        }
+    }
+
+    void App::RouteNotificationClick(uint64_t paneIdValue)
+    {
+        // Called from the wWinMain-side NotificationInvoked subscriber
+        // on a worker thread. Bounce to the UI thread before touching
+        // the window. If the click arrives before OnLaunched has
+        // wired `window`, drop it — the user just gets the regular
+        // foreground from AppInstance::Activated.
+        if (!window) return;
+        window.DispatcherQueue().TryEnqueue(
+            [weak = get_weak(), paneIdValue]()
+            {
+                auto self = weak.get();
+                if (!self) return;
+                if (auto mwProj = self->window.try_as<winrt::GhosttyWin32::MainWindow>()) {
+                    if (auto* mw = winrt::get_self<implementation::MainWindow>(mwProj)) {
+                        mw->PresentNotification(implementation::PaneId{ paneIdValue });
+                    }
+                }
+            });
+    }
+
+    uint64_t App::ParseSurfaceIdFromArguments(std::wstring const& arguments)
+    {
+        // Argument format is `key=value;key=value`. Today only
+        // `surfaceId=<u64>` is emitted; the generic loop lets future
+        // fields piggy-back without a rewrite.
+        uint64_t paneIdValue = 0;
+        size_t pos = 0;
+        while (pos < arguments.size()) {
+            auto sep = arguments.find(L';', pos);
+            std::wstring pair = arguments.substr(pos, sep == std::wstring::npos
+                                                 ? std::wstring::npos
+                                                 : sep - pos);
+            auto eq = pair.find(L'=');
+            if (eq != std::wstring::npos) {
+                auto key = pair.substr(0, eq);
+                auto val = pair.substr(eq + 1);
+                if (key == L"surfaceId" && !val.empty()) {
+                    try {
+                        paneIdValue = std::stoull(val);
+                    } catch (...) {
+                        paneIdValue = 0;
+                    }
+                }
+            }
+            if (sep == std::wstring::npos) break;
+            pos = sep + 1;
+        }
+        return paneIdValue;
+    }
+
     /// <summary>
     /// Invoked when the application is launched.
     /// </summary>
     /// <param name="e">Details about the launch request and process.</param>
     void App::OnLaunched([[maybe_unused]] LaunchActivatedEventArgs const& e)
     {
+        // Single-instance redirect already ran in wWinMain (see main.cpp);
+        // if we got here, we're the primary instance. Just wire the
+        // Activated event so subsequent launches (which wWinMain bounced
+        // back to us via RedirectActivationToAsync) land in
+        // HandleActivation instead of being silently dropped. We
+        // re-acquire `primary` via FindOrRegisterForKey — same key, same
+        // holder, idempotent.
+        {
+            namespace appLifecycle = winrt::Microsoft::Windows::AppLifecycle;
+            auto primary = appLifecycle::AppInstance::FindOrRegisterForKey(L"GhosttyWin32-Main");
+            auto weak = get_weak();
+            m_activatedToken = primary.Activated(
+                [weak](winrt::Windows::Foundation::IInspectable const& sender,
+                       appLifecycle::AppActivationArguments const& a)
+                {
+                    if (auto self = weak.get()) {
+                        self->OnInstanceActivated(sender, a);
+                    }
+                });
+        }
+
         // Crash recovery BEFORE creating the window: if the previous run
         // didn't reach clean shutdown, give the GPU driver time to recover
         // its kernel-side state. Doing this here (no XAML window yet) avoids
@@ -66,17 +177,12 @@ namespace winrt::GhosttyWin32::implementation
             std::ofstream(flag).close();
         }
 
-        // Register with the AppNotifications service so the
-        // GHOSTTY_ACTION_DESKTOP_NOTIFICATION handler can later call
-        // AppNotificationManager::Show without being silently dropped.
-        // Register is idempotent; the catch is a belt-and-suspenders
-        // hedge against MSIX activation edge cases that throw here on
-        // some Windows builds.
-        try {
-            Microsoft::Windows::AppNotifications::AppNotificationManager::Default().Register();
-        } catch (winrt::hresult_error const&) {
-            OutputDebugStringA("GhosttyWin32: AppNotificationManager::Register failed; desktop notifications disabled\n");
-        }
+        // AppNotificationManager::Default().Register() and the
+        // NotificationInvoked subscription both already happened in
+        // wWinMain (see main.cpp). Windows App SDK 1.8 throws and
+        // fail-fasts if we try to re-subscribe NotificationInvoked
+        // here after Register(), so the routing path goes via the
+        // wWinMain-side subscriber calling App::RouteNotificationClick.
 
         window = make<MainWindow>();
         window.Activate();

--- a/App/App.xaml.h
+++ b/App/App.xaml.h
@@ -1,6 +1,9 @@
 #pragma once
 
 #include "App.xaml.g.h"
+#include <winrt/Microsoft.Windows.AppLifecycle.h>
+#include <winrt/Microsoft.Windows.AppNotifications.h>
+#include <string>
 
 namespace winrt::GhosttyWin32::implementation
 {
@@ -10,7 +13,53 @@ namespace winrt::GhosttyWin32::implementation
 
         void OnLaunched(Microsoft::UI::Xaml::LaunchActivatedEventArgs const&);
 
+        // Single live App instance used by the wWinMain-side
+        // AppNotificationManager subscriber to call back into us.
+        // Application::Start runs `make<App>` once for the process, so
+        // we cache that one pointer in a global on ctor / clear on
+        // exit. Raw pointer (not weak_ref) because the
+        // NotificationInvoked subscriber runs from a worker thread
+        // where touching a com_ptr isn't always safe.
+        static App* g_app;
+
+        // Called from the wWinMain-side AppNotificationManager
+        // subscriber. Public because that subscriber is a free
+        // function in main.cpp — it can't reach a private member.
+        // Windows App SDK 1.8 forbids a second NotificationInvoked
+        // subscription after Register() (it fatal-fasts), so the
+        // single subscriber has to be the one in wWinMain.
+        void RouteNotificationClick(uint64_t paneIdValue);
+
+        // Shared parse of a notification's argument string into a
+        // PaneId value. Public for the same reason as above —
+        // wWinMain calls this before routing into RouteNotificationClick.
+        // Argument format is `key=value;key=value`; currently the only
+        // key is `surfaceId`. Returns 0 (no retargeting) on any
+        // decode failure.
+        static uint64_t ParseSurfaceIdFromArguments(std::wstring const& arguments);
+
     private:
+        // Subsequent-activation handler. The first activation runs through
+        // OnLaunched; later activations (a second click of a notification,
+        // a relaunch from the Start menu, etc.) get redirected to this
+        // primary instance by `AppInstance::RedirectActivationToAsync` in
+        // the ctor and arrive here.
+        void OnInstanceActivated(
+            winrt::Windows::Foundation::IInspectable const&,
+            winrt::Microsoft::Windows::AppLifecycle::AppActivationArguments const& args);
+
+        // Foreground the window without touching the activation args.
+        // Used for the AppInstance::Activated redirect path where the
+        // args are a cross-process proxy whose forwarder has already
+        // exited (so Kind() / Data() throw RPC_S_SERVER_UNAVAILABLE).
+        // Tab-switching by surface id happens through the in-process
+        // NotificationInvoked path below, where args are valid.
+        void HandleActivation(
+            winrt::Microsoft::Windows::AppLifecycle::AppActivationArguments const& args);
+
         winrt::Microsoft::UI::Xaml::Window window{ nullptr };
+        // Token for the primary AppInstance's Activated event; the
+        // subscription lives for the lifetime of the App.
+        winrt::event_token m_activatedToken{};
     };
 }

--- a/App/MainWindow.xaml.cpp
+++ b/App/MainWindow.xaml.cpp
@@ -929,7 +929,8 @@ namespace winrt::GhosttyWin32::implementation
         if (hThread) CloseHandle(hThread); else delete ctx;
     }
 
-    void MainWindow::ShowDesktopNotification(std::wstring title, std::wstring body)
+    void MainWindow::ShowDesktopNotification(ghostty_surface_t surface,
+                                             std::wstring title, std::wstring body)
     {
         if (title.empty() && body.empty()) return;
         try {
@@ -938,12 +939,49 @@ namespace winrt::GhosttyWin32::implementation
             AppNotificationBuilder builder;
             if (!title.empty()) builder.AddText(title);
             if (!body.empty())  builder.AddText(body);
+            // Embed the originating pane's id in the toast arguments
+            // so a later click routes back to the right pane via
+            // PresentNotification. Encoded as semicolon-separated
+            // key=value pairs to leave room for future fields.
+            if (auto lookup = m_tabs.FindLeafBySurface(surface);
+                lookup.leaf && lookup.leaf->Id())
+            {
+                auto idStr = std::to_wstring(lookup.leaf->Id().value);
+                builder.AddArgument(L"action", L"present");
+                builder.AddArgument(L"surfaceId", winrt::hstring(idStr));
+            }
             AppNotificationManager::Default().Show(builder.BuildNotification());
         } catch (winrt::hresult_error const&) {
             // Either the manager wasn't registered (App startup
             // logged it) or the OS refused. Nothing actionable
             // host-side; the message just doesn't appear.
         }
+    }
+
+    void MainWindow::PresentNotification(PaneId id)
+    {
+        // Step 1: retarget the active tab + leaf if we know which
+        // pane the notification belonged to. A zero PaneId (launch
+        // activation, missing argument, etc.) skips this and we just
+        // foreground the window.
+        if (id) {
+            auto lookup = m_tabs.FindByPaneId(id);
+            if (lookup.tab) {
+                auto tabView = TabView();
+                if (tabView) {
+                    tabView.SelectedItem(lookup.tab->Item());
+                }
+                if (lookup.leaf) {
+                    lookup.tab->SetActiveLeaf(lookup.leaf);
+                }
+                lookup.tab->Focus();
+            }
+        }
+        // Step 2: bring the window to the foreground. PresentTerminal
+        // handles the IsIconic / SW_RESTORE / SetForegroundWindow
+        // dance; reusing it keeps the foreground-rule workaround in
+        // one place.
+        PresentTerminal();
     }
 
     void MainWindow::ReportProgress(ghostty_action_progress_report_s pr)

--- a/App/MainWindow.xaml.h
+++ b/App/MainWindow.xaml.h
@@ -115,8 +115,16 @@ namespace winrt::GhosttyWin32::implementation
                                       ghostty_action_mouse_shape_e shape) override;
         void ReplaceConfig(ghostty_config_t cloned) override;
         void ReloadConfig(bool soft) override;
-        void ShowDesktopNotification(std::wstring title,
+        void ShowDesktopNotification(ghostty_surface_t surface,
+                                     std::wstring title,
                                      std::wstring body) override;
+
+        // Notification-click entry point. Called by App's
+        // AppInstance::Activated handler after a desktop notification
+        // is clicked: locate the originating pane (when known), make
+        // its tab active, then bring the window forward. Falls back
+        // to a plain foreground if `id` is the zero sentinel.
+        void PresentNotification(PaneId id);
         void ReportProgress(ghostty_action_progress_report_s pr) override;
 
     private:

--- a/App/Tabs/Tabs.h
+++ b/App/Tabs/Tabs.h
@@ -45,16 +45,7 @@ public:
     // configuration. O(N * leaves) — both factors are small enough
     // that a flat scan is strictly cheaper than maintaining an index.
     Tab* FindBySurface(ghostty_surface_t surface) const {
-        if (!surface) return nullptr;
-        for (auto& t : m_tabs) {
-            if (!t) continue;
-            auto* panelImpl = winrt::get_self<implementation::SplitPanel>(t->Panel());
-            if (!panelImpl) continue;
-            if (LeafMatchesSurface(panelImpl->Root(), surface)) {
-                return t.get();
-            }
-        }
-        return nullptr;
+        return FindLeafBySurface(surface).tab;
     }
 
     // Look up the Tab + leaf for the pane carrying `id`. Used by the
@@ -75,6 +66,24 @@ public:
             auto* panelImpl = winrt::get_self<implementation::SplitPanel>(t->Panel());
             if (!panelImpl) continue;
             if (auto* leaf = FindLeafByPaneId(panelImpl->Root(), id)) {
+                return { t.get(), leaf };
+            }
+        }
+        return { nullptr, nullptr };
+    }
+
+    // Surface-driven leaf lookup. Mirrors FindBySurface but returns the
+    // specific leaf in addition to the owning Tab, so callers that need
+    // both (e.g. desktop notification routing — find the pane that
+    // emitted the toast and embed its PaneId in the click argument)
+    // don't repeat the tree walk.
+    PaneLookup FindLeafBySurface(ghostty_surface_t surface) const {
+        if (!surface) return { nullptr, nullptr };
+        for (auto& t : m_tabs) {
+            if (!t) continue;
+            auto* panelImpl = winrt::get_self<implementation::SplitPanel>(t->Panel());
+            if (!panelImpl) continue;
+            if (auto* leaf = FindLeafBySurfaceRecursive(panelImpl->Root(), surface)) {
                 return { t.get(), leaf };
             }
         }
@@ -118,20 +127,21 @@ public:
     auto end() const noexcept { return m_tabs.end(); }
 
 private:
-    // Depth-first search for a leaf whose TerminalControl owns
-    // `surface`. Returns true on first match. Used by FindBySurface
-    // so each tab's tree is searched independently and the caller can
-    // map back to the owning Tab.
-    static bool LeafMatchesSurface(Pane const* node, ghostty_surface_t surface) {
-        if (!node) return false;
+    // Depth-first search for the leaf whose TerminalControl owns
+    // `surface`. Returns the leaf node (mutable so callers updating
+    // the active-leaf pointer can do so) or nullptr. Used by both
+    // FindBySurface (which only cares whether the leaf exists) and
+    // FindLeafBySurface (which needs the leaf itself).
+    static Pane* FindLeafBySurfaceRecursive(Pane* node, ghostty_surface_t surface) {
+        if (!node) return nullptr;
         if (node->IsLeaf()) {
             if (auto* c = Tab::LeafToTerminalControl(*node); c && c->Surface() == surface) {
-                return true;
+                return node;
             }
-            return false;
+            return nullptr;
         }
-        return LeafMatchesSurface(node->First(), surface)
-            || LeafMatchesSurface(node->Second(), surface);
+        if (auto* p = FindLeafBySurfaceRecursive(node->First(), surface)) return p;
+        return FindLeafBySurfaceRecursive(node->Second(), surface);
     }
 
     // Depth-first search for a leaf carrying `id`. Returns the leaf

--- a/App/main.cpp
+++ b/App/main.cpp
@@ -1,0 +1,118 @@
+#include "pch.h"
+
+#include <windows.h>
+#include <combaseapi.h>
+
+#include <winrt/Windows.Foundation.h>
+#include <winrt/Microsoft.UI.Xaml.h>
+#include <winrt/Microsoft.Windows.AppLifecycle.h>
+#include <winrt/Microsoft.Windows.AppNotifications.h>
+
+#include "App.xaml.h"
+
+// Custom wWinMain so the AppInstance single-instance redirect runs
+// BEFORE Microsoft::UI::Xaml::Application::Start. Doing the redirect
+// after Application::Start (the XAML compiler's default entry point
+// is structured that way) trips a WIL fail-fast inside
+// Microsoft.WindowsAppRuntime.dll at wil/resource.h:2772 — the cross-
+// process shared-memory event AppInstance uses races on
+// WaitForSingleObjectEx once the XAML / COM context has been brought
+// up. See microsoft/WindowsAppSDK issues #1709 / #1766.
+int APIENTRY wWinMain(_In_ HINSTANCE,
+                      _In_opt_ HINSTANCE,
+                      _In_ LPWSTR,
+                      _In_ int)
+{
+    winrt::init_apartment(winrt::apartment_type::single_threaded);
+
+    // Register the AppNotificationManager BEFORE AppInstance::GetActivatedEventArgs
+    // is called. Second-launch activations arrive wrapped in
+    // IProtocolActivatedEventArgs, and AppInstance's GetActivatedEventArgs
+    // implementation decodes them by routing through
+    // AppNotificationManager::AppNotificationDeserialize. Inside that path
+    // a wil::event_t::wait() blocks for the AppNotifications COM server to
+    // be ready — if Register() hasn't been called yet the wait never
+    // completes and WIL fail-fasts at resource.h:2772 (E_UNEXPECTED).
+    //
+    // Register() in turn requires NotificationInvoked to already have at
+    // least one subscriber, otherwise it throws "Must register event
+    // handlers before calling Register()" (ERROR_NOT_FOUND). The App
+    // instance doesn't exist yet, so we install a no-op handler now to
+    // satisfy that invariant; App::OnLaunched adds the real one on top
+    // afterwards (both handlers fire on a real click — the dummy is a
+    // safe extra no-op).
+    {
+        namespace appNotif = winrt::Microsoft::Windows::AppNotifications;
+        // Subscribe BEFORE Register so the SDK's "Must register event
+        // handlers before calling Register()" invariant is satisfied.
+        // Windows App SDK 1.8 also fail-fasts if anything tries to
+        // re-subscribe after Register(), so this is also the ONLY
+        // NotificationInvoked subscription in the whole app — the
+        // routing into the live App instance happens via the global
+        // App::g_app pointer set in App::App() (no member-function
+        // capture needed here since the App doesn't exist yet).
+        appNotif::AppNotificationManager::Default().NotificationInvoked(
+            [](appNotif::AppNotificationManager const&,
+               appNotif::AppNotificationActivatedEventArgs const& args)
+            {
+                std::wstring arguments = std::wstring(args.Argument());
+                uint64_t paneIdValue =
+                    winrt::GhosttyWin32::implementation::App::ParseSurfaceIdFromArguments(arguments);
+                if (auto* app = winrt::GhosttyWin32::implementation::App::g_app) {
+                    app->RouteNotificationClick(paneIdValue);
+                }
+            });
+        try {
+            appNotif::AppNotificationManager::Default().Register();
+        } catch (winrt::hresult_error const&) {
+            // Best-effort; if registration fails the toast subsystem just
+            // doesn't show toasts. We let AppInstance try anyway.
+        }
+    }
+
+    {
+        namespace AL = winrt::Microsoft::Windows::AppLifecycle;
+        auto args = AL::AppInstance::GetCurrent().GetActivatedEventArgs();
+        auto primary = AL::AppInstance::FindOrRegisterForKey(L"GhosttyWin32-Main");
+        if (!primary.IsCurrent()) {
+            // RedirectActivationToAsync's IAsyncAction can't be
+            // awaited from this thread directly — the call only
+            // completes once the primary instance dispatches our
+            // incoming RPC, and that requires *us* to keep pumping
+            // COM messages. Run .get() on a worker thread and
+            // CoWaitForMultipleObjects(CWMO_DISPATCH_CALLS) here so
+            // the wait both pumps and unblocks on the worker's
+            // completion event.
+            HANDLE done = ::CreateEventW(nullptr, TRUE, FALSE, nullptr);
+            struct Ctx {
+                AL::AppInstance primary;
+                AL::AppActivationArguments args;
+                HANDLE done;
+            };
+            auto* ctx = new Ctx{ primary, args, done };
+            HANDLE thread = ::CreateThread(nullptr, 0,
+                [](LPVOID p) -> DWORD {
+                    auto* c = static_cast<Ctx*>(p);
+                    c->primary.RedirectActivationToAsync(c->args).get();
+                    ::SetEvent(c->done);
+                    delete c;
+                    return 0;
+                }, ctx, 0, nullptr);
+            DWORD idx = 0;
+            HANDLE waits[1] = { done };
+            ::CoWaitForMultipleObjects(CWMO_DISPATCH_CALLS, INFINITE, 1, waits, &idx);
+            if (thread) ::CloseHandle(thread);
+            ::CloseHandle(done);
+            ::ExitProcess(0);
+        }
+        // We're primary; the App class subscribes to primary.Activated
+        // from OnLaunched (it can't subscribe here — the App instance
+        // doesn't exist until Application::Start runs the lambda below).
+    }
+
+    winrt::Microsoft::UI::Xaml::Application::Start(
+        [](auto&&) {
+            winrt::make<winrt::GhosttyWin32::implementation::App>();
+        });
+    return 0;
+}

--- a/Core/Ghostty/Actions/Actions.cpp
+++ b/Core/Ghostty/Actions/Actions.cpp
@@ -320,15 +320,16 @@ bool Actions::OnConfigChange(ghostty_config_t newCfg) {
     return true;
 }
 
-bool Actions::OnDesktopNotification(ghostty_action_desktop_notification_s dn) {
+bool Actions::OnDesktopNotification(ghostty_surface_t surface,
+                                    ghostty_action_desktop_notification_s dn) {
     // Convert UTF-8 to UTF-16 on the renderer thread so the
     // captured lambda carries native strings.
     std::wstring title = (dn.title && dn.title[0]) ? interop::Encoding::toUtf16(dn.title) : L"";
     std::wstring body  = (dn.body  && dn.body[0])  ? interop::Encoding::toUtf16(dn.body)  : L"";
     if (title.empty() && body.empty()) return true;
-    m_view.Dispatch([this, title = std::move(title),
+    m_view.Dispatch([this, surface, title = std::move(title),
                                     body = std::move(body)]() mutable {
-        m_view.ShowDesktopNotification(std::move(title), std::move(body));
+        m_view.ShowDesktopNotification(surface, std::move(title), std::move(body));
     });
     return true;
 }

--- a/Core/Ghostty/Actions/Actions.h
+++ b/Core/Ghostty/Actions/Actions.h
@@ -68,7 +68,8 @@ public:
                       ghostty_action_mouse_shape_e shape);
     bool OnReloadConfig(bool soft);
     bool OnConfigChange(ghostty_config_t newCfg);
-    bool OnDesktopNotification(ghostty_action_desktop_notification_s dn);
+    bool OnDesktopNotification(ghostty_surface_t surface,
+                               ghostty_action_desktop_notification_s dn);
     bool OnProgressReport(ghostty_action_progress_report_s pr);
 
     // ----- window state -----

--- a/Core/Ghostty/CallbackDispatcher.cpp
+++ b/Core/Ghostty/CallbackDispatcher.cpp
@@ -90,8 +90,14 @@ bool CallbackDispatcher::DispatchAction(ghostty_target_s target, ghostty_action_
             return m_actions.OnReloadConfig(action.action.reload_config.soft);
         case GHOSTTY_ACTION_CONFIG_CHANGE:
             return m_actions.OnConfigChange(action.action.config_change.config);
-        case GHOSTTY_ACTION_DESKTOP_NOTIFICATION:
-            return m_actions.OnDesktopNotification(action.action.desktop_notification);
+        case GHOSTTY_ACTION_DESKTOP_NOTIFICATION: {
+            // ghostty sets target.surface to the pane that emitted the
+            // notification; a null surface is legal (the toast still
+            // shows, the click handler just doesn't retarget tabs).
+            ghostty_surface_t s = target.tag == GHOSTTY_TARGET_SURFACE
+                ? target.target.surface : nullptr;
+            return m_actions.OnDesktopNotification(s, action.action.desktop_notification);
+        }
         case GHOSTTY_ACTION_PROGRESS_REPORT:
             return m_actions.OnProgressReport(action.action.progress_report);
 

--- a/Core/Host/IWindow.h
+++ b/Core/Host/IWindow.h
@@ -167,7 +167,13 @@ struct IWindow {
 
     // Show a Windows toast for the given two-line payload. Either
     // string may be empty; if both are empty the call is a no-op.
-    virtual void ShowDesktopNotification(std::wstring title,
+    // `surface` identifies the pane that requested the notification —
+    // the view side embeds it in the toast's `surfaceId` argument so
+    // a later click can route back to the originating pane. A null
+    // surface is allowed (the toast still shows; the click handler
+    // falls back to a plain foreground without retargeting tabs).
+    virtual void ShowDesktopNotification(ghostty_surface_t surface,
+                                         std::wstring title,
                                          std::wstring body) = 0;
 
     // Update the host window's taskbar progress indicator. The

--- a/Tests/MockMainWindowView.h
+++ b/Tests/MockMainWindowView.h
@@ -171,10 +171,13 @@ struct MockMainWindowView : core::host::IWindow {
     }
 
     int showDesktopNotificationCalls = 0;
+    ghostty_surface_t lastNotificationSurface = nullptr;
     std::wstring lastNotificationTitle;
     std::wstring lastNotificationBody;
-    void ShowDesktopNotification(std::wstring title, std::wstring body) override {
+    void ShowDesktopNotification(ghostty_surface_t surface,
+                                 std::wstring title, std::wstring body) override {
         ++showDesktopNotificationCalls;
+        lastNotificationSurface = surface;
         lastNotificationTitle = std::move(title);
         lastNotificationBody = std::move(body);
     }

--- a/Tests/test_ghostty_actions.cpp
+++ b/Tests/test_ghostty_actions.cpp
@@ -335,11 +335,13 @@ TEST(GhosttyActionsTest, OnConfigChangeIgnoresNull) {
 TEST(GhosttyActionsTest, OnDesktopNotificationConvertsBothLines) {
     MockMainWindowView view;
     Actions actions(view);
+    auto surface = FakeSurface(0xCAFE);
     ghostty_action_desktop_notification_s dn{};
     dn.title = "Title";
     dn.body = "Body";
-    EXPECT_TRUE(actions.OnDesktopNotification(dn));
+    EXPECT_TRUE(actions.OnDesktopNotification(surface, dn));
     EXPECT_EQ(view.showDesktopNotificationCalls, 1);
+    EXPECT_EQ(view.lastNotificationSurface, surface);
     EXPECT_EQ(view.lastNotificationTitle, L"Title");
     EXPECT_EQ(view.lastNotificationBody, L"Body");
 }
@@ -351,7 +353,7 @@ TEST(GhosttyActionsTest, OnDesktopNotificationDropsAllEmpty) {
     ghostty_action_desktop_notification_s dn{};
     dn.title = "";
     dn.body = nullptr;
-    EXPECT_TRUE(actions.OnDesktopNotification(dn));
+    EXPECT_TRUE(actions.OnDesktopNotification(FakeSurface(0xCAFE), dn));
     EXPECT_EQ(view.showDesktopNotificationCalls, 0);
 }
 


### PR DESCRIPTION
Closes #70.

## Why

Before this, clicking one of our desktop toasts kicked off a fresh MSIX activation: Windows would spin up a new GhosttyWin32 process, paint a new MainWindow, and leave the existing terminal stranded behind it. The `MainWindow::PresentTerminal` we landed in batch 5 (#71) sat there unreachable because nothing fed it.

Without the wiring this PR adds, every toast a user clicks adds a window instead of focusing the one that emitted it, and the `PRESENT_TERMINAL` host action stays an unused stub.

<details><summary>日本語</summary>

通知をクリックするたびに MSIX が新 process を起動して新 window が出る = ウィンドウ増殖。#71 で実装した `MainWindow::PresentTerminal` も feeder がなくて到達不能だった。

</details>

## What

End-to-end click round-trip implemented across three layers:

### Layer 1: Single-instancing via `AppInstance` in a custom `wWinMain`

The XAML compiler's default `wWinMain` calls `Application::Start` before `AppInstance` is reachable, but `AppInstance::GetActivatedEventArgs` has to run *before* the WinUI / COM context comes up — otherwise it hits a WIL fail-fast inside `Microsoft.WindowsAppRuntime.dll`'s cross-process shared-memory wait (`resource.h:2772`).

- `DISABLE_XAML_GENERATED_MAIN` suppresses the generated `wWinMain`
- New `App/main.cpp` calls `AppInstance::FindOrRegisterForKey("GhosttyWin32-Main")` → redirect → `Application::Start`
- Redirect runs on a worker thread with `CoWaitForMultipleObjects(CWMO_DISPATCH_CALLS)` so the main thread keeps pumping COM messages while the primary instance receives our forwarded activation

### Layer 2: One `NotificationInvoked` subscription, in `wWinMain`

Windows App SDK 1.8 fatal-fasts if anything tries to subscribe a second time after `Register()`. So the App class can't add a member-function subscriber later — instead the `wWinMain` lambda routes through a global `App*` (`App::g_app`, set in `App`'s ctor):

```
wWinMain:
  AppNotificationManager::Default().NotificationInvoked(<lambda>);  // first & only
  AppNotificationManager::Default().Register();                     // requires a handler to exist
  AppInstance::FindOrRegisterForKey(…) / Redirect / etc.
  Application::Start(...);
```

`Register()` also has to happen before `AppInstance::GetActivatedEventArgs` (its internal decode path waits on the AppNotifications COM server), which dictates the ordering above.

### Layer 3: Surface routing

- `ShowDesktopNotification` now takes the originating `ghostty_surface_t` (Actions / CallbackDispatcher / `IWindow` / mock all updated)
- Looks up the leaf via the new `Tabs::FindLeafBySurface(surface)`
- Embeds the leaf's `PaneId` in the toast's Arguments as `surfaceId=<u64>`
- On click, the `wWinMain`-side lambda runs `App::ParseSurfaceIdFromArguments(arguments)` → `App::RouteNotificationClick(paneIdValue)`
- That bounces to the UI thread and runs `MainWindow::PresentNotification(PaneId)` — switches the `TabView` to the right item, retargets the active leaf, then invokes the existing `PresentTerminal` (`IsIconic` → `SW_RESTORE` → `BringWindowToTop` → `SetForegroundWindow`)

The `AppInstance::Activated` path (the redirected activation arriving at the primary instance) deliberately doesn't try to parse args: by the time it fires, the forwarding process has already exited, so the args proxy is dead and any `Kind()` / `Data()` call throws `RPC_S_SERVER_UNAVAILABLE`. `HandleActivation` just brings the window forward with `PaneId{0}` and lets the `NotificationInvoked` subscriber own the surface-routing case.

## Gotchas (future-self / reviewer notes)

A long road to get here. Things that bit us:

1. **AppInstance can't be called from `App::App()` / `App::OnLaunched`** — must be in `wWinMain` before `Application::Start`. Symptom: fail-fast inside `wil::handle_wait` at `resource.h:2772` (E_UNEXPECTED).
2. **`Register()` requires a `NotificationInvoked` subscription to already exist** in Windows App SDK 1.8. Symptom: "Must register event handlers before calling Register()" (0x80070490).
3. **Only one `NotificationInvoked` subscription per process** in 1.8. A second `add_*` call after `Register()` walks straight into a XAML fail-fast — `e.Handled(true)` doesn't save it. So the App class can't subscribe its own member function; routing has to go via a global app pointer set in the ctor.
4. **The `AppActivationArguments` delivered through `AppInstance::Activated` is a cross-process proxy** back to the redirecting instance, which has already exited. Calling `Kind()` / `Data()` raises `RPC_S_SERVER_UNAVAILABLE`. The redirect path uses none of that — it just calls `PresentTerminal()`.
5. **AppInstance redirect needs `CoWaitForMultipleObjects(CWMO_DISPATCH_CALLS)` not raw `.get()`**. Naive `.get()` on the UI thread blocks the COM pump, and the primary's RPC server can't dispatch our incoming `Redirect…` call, so the async never completes.

<details><summary>日本語</summary>

ハマりどころメモ:

1. `AppInstance::GetActivatedEventArgs` は **Application::Start の前** (= custom wWinMain) でしか呼べない
2. `Register()` は `NotificationInvoked` の subscriber 必須 (SDK 1.8 から)
3. `NotificationInvoked` は **process 全体で 1 subscribe のみ** (2 度目は fatal-fast)
4. AppInstance redirect 経由の args は cross-process proxy で dead 確定。`Kind()` 触っちゃダメ
5. Redirect の `.get()` は **worker thread で**、main thread は `CoWaitForMultipleObjects(CWMO_DISPATCH_CALLS)` で pump-and-wait

</details>

## Test plan

- [x] Local: 1st launch starts normally, paints terminal
- [x] Local: 2nd launch (Start Menu / Explorer) → no new window, primary foregrounded
- [x] Local: notification raised by `printf '\e]9;…\a'` in tab A, switch focus to tab B manually, click toast → tab A reactivated + window foregrounded
- [ ] CI: unit tests still pass (signatures of `Actions::OnDesktopNotification` / `IWindow::ShowDesktopNotification` / mock all updated together)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
