### PR TITLE
Fix oversized text and clipped background on HiDPI/RDP sessions

### DIFF
--- a/App/MainWindow.xaml.cpp
+++ b/App/MainWindow.xaml.cpp
@@ -254,21 +254,21 @@ namespace winrt::GhosttyWin32::implementation
             // itself and forwards directly to its own ghostty surface.
             // No window-level input handler is needed here.
 
-            // DPI change handling (deferred until XamlRoot is available)
+            // DPI / scale handling now lives per-leaf in TerminalControl:
+            // each control subscribes to its own
+            // SwapChainPanel.CompositionScaleChanged and pushes the
+            // current scale into ghostty via
+            // ghostty_surface_set_content_scale. The panel's
+            // composition scale is what the panel actually composites
+            // the swap chain at, so matching that (rather than
+            // GetDpiForWindow on the window) keeps the swap chain's
+            // render scale and the panel's display scale in sync. On
+            // RDP these two values transiently diverge — composition
+            // scale starts at 1.0 even when the window DPI is 192,
+            // then jumps to the real value once the composition
+            // pipeline has run — which is the case that motivated the
+            // switch.
             Content().as<winrt::Microsoft::UI::Xaml::FrameworkElement>().Loaded([this](auto&&, auto&&) {
-                Content().XamlRoot().Changed([this](auto&&, winrt::Microsoft::UI::Xaml::XamlRootChangedEventArgs const&) {
-                    if (!m_hwnd) return;
-                    UINT dpi = GetDpiForWindow(m_hwnd);
-                    double scale = (double)dpi / 96.0;
-                    // Today every tab has a single TerminalControl. With
-                    // future pane support this would walk each tab's
-                    // pane tree and apply the scale to every leaf.
-                    for (auto& t : m_tabs) {
-                        if (auto* tc = t->ActiveControl(); tc && tc->Surface()) {
-                            ghostty_surface_set_content_scale(tc->Surface(), scale, scale);
-                        }
-                    }
-                });
                 // Track window state so the maximize button glyph swaps
                 // between Maximize (E922) and Restore (E923). DidSizeChange
                 // covers the SC_MAXIMIZE / SC_RESTORE round trip we send

--- a/App/Tabs/TabFactory.h
+++ b/App/Tabs/TabFactory.h
@@ -163,12 +163,27 @@ public:
         // surface_new fails).
         auto* attachOwned = new std::shared_ptr<SwapChainAttachRequest>(attach);
 
+        // SwapChainChangedContext: receives swap_chain_changed_cb on the
+        // renderer thread so the host can install an
+        // IDXGISwapChain2::SetMatrixTransform that cancels XAML
+        // SwapChainPanel's implicit upscale. Initial scale is taken
+        // from panel.CompositionScaleX (initial value used in
+        // cfg.scale_factor below; CompositionScaleChanged later
+        // publishes updates atomically). Raw pointer is handed to
+        // libghostty as userdata; TerminalControl owns the shared_ptr
+        // and releases it on Detach (after surface_free has joined the
+        // renderer thread).
+        auto swapChainChanged = std::make_shared<
+            winrt::GhosttyWin32::implementation::SwapChainChangedContext>();
+
         ghostty_surface_config_s cfg = ghostty_surface_config_new();
         cfg.platform_tag = GHOSTTY_PLATFORM_WINDOWS;
         cfg.platform.windows.hwnd = m_hwnd;
         cfg.platform.windows.composition_surface_handle = handle;
         cfg.platform.windows.swap_chain_ready_cb = &TerminalControl::OnSwapChainReady;
         cfg.platform.windows.swap_chain_ready_userdata = attachOwned;
+        cfg.platform.windows.swap_chain_changed_cb = &TerminalControl::OnSwapChainChanged;
+        cfg.platform.windows.swap_chain_changed_userdata = swapChainChanged.get();
         cfg.userdata = paneId.ToUserdata();
         // Initial swap chain size: prefer the host's caller-supplied
         // estimate (typically the active tab/pane's panel size, since
@@ -187,8 +202,31 @@ public:
                                        : static_cast<uint32_t>(panel.ActualHeight());
         cfg.platform.windows.initial_width = initW;
         cfg.platform.windows.initial_height = initH;
-        UINT dpi = GetDpiForWindow(m_hwnd);
-        cfg.scale_factor = static_cast<double>(dpi) / 96.0;
+        // Use the SwapChainPanel's own composition scale rather than
+        // GetDpiForWindow(hwnd): the panel is what actually composites
+        // the swap chain, so its scale is the value we have to match
+        // to avoid a "rendered at 2x, composited at 1x" stretch. On
+        // RDP the panel may not have settled yet at this point and
+        // can report 1.0 even when the window is at 192 DPI; that's
+        // fine — TerminalControl subscribes to CompositionScaleChanged
+        // and re-issues ghostty_surface_set_content_scale once the
+        // real value arrives. Fall back to GetDpiForWindow only when
+        // the panel reports a non-positive value (composition pipeline
+        // hasn't run at all yet); using a sane positive scale at
+        // surface_new time prevents libghostty from starting at 0/NaN.
+        double scaleX = panel.CompositionScaleX();
+        double scaleY = panel.CompositionScaleY();
+        if (scaleX <= 0.0 || scaleY <= 0.0) {
+            UINT dpi = GetDpiForWindow(m_hwnd);
+            scaleX = scaleY = static_cast<double>(dpi) / 96.0;
+        }
+        cfg.scale_factor = scaleX;
+        // Publish the same initial scale to the renderer-thread context
+        // so the very first swap_chain_changed_cb fire (during
+        // threadEnter) installs the correct matrix instead of the 1.0
+        // default. CompositionScaleChanged later publishes updates if
+        // the panel's settled scale changes.
+        swapChainChanged->compositionScale.store(scaleX, std::memory_order_release);
 
         ghostty_surface_t surface = ghostty_surface_new(m_app, &cfg);
         if (!surface) {
@@ -202,7 +240,7 @@ public:
         // Hand surface ownership to the control. From here on the
         // control's Detach() is responsible for freeing the surface
         // and closing the handle.
-        controlImpl->Attach(m_app, surface, handle, m_hwnd, attach);
+        controlImpl->Attach(m_app, surface, handle, m_hwnd, attach, std::move(swapChainChanged));
 
         // Wire the host-supplied focus callback so the control can
         // notify MainWindow whenever it gains keyboard focus without

--- a/App/TerminalControl.xaml.cpp
+++ b/App/TerminalControl.xaml.cpp
@@ -3,9 +3,11 @@
 #include "Interop/Encoding.h"
 #include "Host/KeyModifiers.h"
 #include "Win32/Clipboard.h"
+#include <dxgi1_3.h>
 #if __has_include("TerminalControl.g.cpp")
 #include "TerminalControl.g.cpp"
 #endif
+
 
 namespace winrt::GhosttyWin32::implementation
 {
@@ -372,13 +374,15 @@ namespace winrt::GhosttyWin32::implementation
                                  ghostty_surface_t surface,
                                  HANDLE compositionHandle,
                                  HWND hostHwnd,
-                                 std::shared_ptr<SwapChainAttachRequest> attachRequest)
+                                 std::shared_ptr<SwapChainAttachRequest> attachRequest,
+                                 std::shared_ptr<SwapChainChangedContext> swapChainChangedContext)
     {
         m_app = app;
         m_surface = surface;
         m_compositionHandle = compositionHandle;
         m_hostHwnd = hostHwnd;
         m_attachRequest = std::move(attachRequest);
+        m_swapChainChangedContext = std::move(swapChainChangedContext);
         // IME setup is deferred to Loaded — see the Loaded handler
         // comment in the ctor. CreateEditContext only registers
         // properly when the owning element is in the live visual
@@ -393,14 +397,78 @@ namespace winrt::GhosttyWin32::implementation
         // m_surface inside the handler under a strong lock.
         auto weakSelf = get_weak();
         m_sizeChangedToken = Panel().SizeChanged(
-            [weakSelf](auto&&, Microsoft::UI::Xaml::SizeChangedEventArgs const& args) {
+            [weakSelf](Windows::Foundation::IInspectable const& sender,
+                       Microsoft::UI::Xaml::SizeChangedEventArgs const& args) {
                 auto self = weakSelf.get();
                 if (!self || !self->m_surface) return;
                 auto sz = args.NewSize();
-                uint32_t w = static_cast<uint32_t>(sz.Width);
-                uint32_t h = static_cast<uint32_t>(sz.Height);
+                // ghostty_surface_set_size takes physical pixels (the
+                // renderer creates swap-chain buffers at exactly this
+                // resolution), but SizeChangedEventArgs.NewSize is in
+                // DIPs. On 200% DPI a 1067 DIP panel needs a 2134 px
+                // swap chain; passing the DIP value through directly
+                // makes the renderer create a half-resolution buffer
+                // and the (DPI-scaled) glyphs land on it at too few
+                // pixels per cell, so text reads as ~2x oversized.
+                // Multiply by CompositionScale so the swap chain
+                // resolution matches the panel's physical pixel
+                // footprint. CompositionScale == 0 means the panel
+                // hasn't been picked up by composition yet — leave
+                // it at 1.0 and rely on the next SizeChanged once
+                // composition settles.
+                auto panel = sender.as<Microsoft::UI::Xaml::Controls::SwapChainPanel>();
+                double scaleX = panel.CompositionScaleX();
+                double scaleY = panel.CompositionScaleY();
+                if (scaleX <= 0.0) scaleX = 1.0;
+                if (scaleY <= 0.0) scaleY = 1.0;
+                uint32_t w = static_cast<uint32_t>(sz.Width * scaleX);
+                uint32_t h = static_cast<uint32_t>(sz.Height * scaleY);
                 if (w > 0 && h > 0) {
                     ghostty_surface_set_size(self->m_surface, w, h);
+                }
+            });
+
+        // Follow the panel's actual composition scale. On RDP and on
+        // first-launch this lags behind the window DPI — the panel
+        // initially reports 1.0 even when GetDpiForWindow says 192
+        // — and only settles to the real value after the composition
+        // pipeline has picked it up. Without this hook, the swap chain
+        // created by ghostty at the higher scale_factor would be
+        // composited at the panel's lower scale, causing the rendered
+        // content (in particular text) to appear at roughly double
+        // size. Same weak_ref + surface recheck guard as SizeChanged.
+        m_compositionScaleChangedToken = Panel().CompositionScaleChanged(
+            [weakSelf](Microsoft::UI::Xaml::Controls::SwapChainPanel const& panel, auto&&) {
+                auto self = weakSelf.get();
+                if (!self || !self->m_surface) return;
+                double sx = panel.CompositionScaleX();
+                double sy = panel.CompositionScaleY();
+                if (sx <= 0.0 || sy <= 0.0) return;
+                // Publish the new scale to the renderer-thread callback so
+                // the next swap_chain_changed_cb fire installs an
+                // up-to-date inverse-scale matrix. Atomic store; the
+                // callback reads it next time libghostty triggers it
+                // (e.g. via the set_content_scale below flowing into
+                // setFontGrid -> applyFontDpiToTransforms).
+                if (self->m_swapChainChangedContext) {
+                    self->m_swapChainChangedContext->compositionScale.store(
+                        sx, std::memory_order_release);
+                }
+                ghostty_surface_set_content_scale(self->m_surface, sx, sy);
+                // ghostty_surface_set_size takes physical pixels — when
+                // the composition scale changes, the panel's logical
+                // size in DIPs hasn't necessarily changed (so XAML may
+                // not fire SizeChanged) but the physical-pixel footprint
+                // has. Re-push it so the swap-chain resolution matches
+                // the new composition scale; otherwise the glyphs end up
+                // at the new font size on the old (lower-resolution)
+                // swap chain and read as oversized.
+                double dipW = panel.ActualWidth();
+                double dipH = panel.ActualHeight();
+                uint32_t pw = static_cast<uint32_t>(dipW * sx);
+                uint32_t ph = static_cast<uint32_t>(dipH * sy);
+                if (pw > 0 && ph > 0) {
+                    ghostty_surface_set_size(self->m_surface, pw, ph);
                 }
             });
     }
@@ -413,6 +481,17 @@ namespace winrt::GhosttyWin32::implementation
         if (m_attachRequest) {
             m_attachRequest->cancelled.store(true);
             m_attachRequest.reset();
+        }
+
+        // Stop the swap-chain-changed callback from touching the swap
+        // chain before libghostty drops it (ghostty_surface_free below
+        // joins the renderer thread, so any fire that races us no-ops).
+        // We deliberately hold the shared_ptr until *after* surface_free
+        // so the renderer thread can dereference the userdata safely
+        // through the in-flight call — the shared_ptr is released
+        // automatically when this TerminalControl is destroyed.
+        if (m_swapChainChangedContext) {
+            m_swapChainChangedContext->cancelled.store(true);
         }
 
         if (m_editContext) {
@@ -428,6 +507,10 @@ namespace winrt::GhosttyWin32::implementation
             if (m_sizeChangedToken.value != 0) {
                 panel.SizeChanged(m_sizeChangedToken);
                 m_sizeChangedToken = {};
+            }
+            if (m_compositionScaleChangedToken.value != 0) {
+                panel.CompositionScaleChanged(m_compositionScaleChangedToken);
+                m_compositionScaleChangedToken = {};
             }
             // We deliberately skip the symmetric
             // ISwapChainPanelNative2::SetSwapChainHandle(nullptr) that
@@ -593,5 +676,28 @@ namespace winrt::GhosttyWin32::implementation
         } catch (...) {
             // Window torn down — request is implicitly cancelled.
         }
+    }
+
+    void TerminalControl::OnSwapChainChanged(void* swap_chain, void* userdata) noexcept
+    {
+        // Renderer thread. Fired by libghostty on every (re-)bind /
+        // ResizeBuffers / DPI change. We undo XAML SwapChainPanel's
+        // implicit upscale of the attached swap chain by installing
+        // an inverse-scale matrix on the chain — the host owns this
+        // policy, libghostty itself is unaware of WinUI 3.
+        if (!swap_chain || !userdata) return;
+        auto* ctx = static_cast<SwapChainChangedContext*>(userdata);
+        if (ctx->cancelled.load(std::memory_order_acquire)) return;
+        double scale = ctx->compositionScale.load(std::memory_order_acquire);
+        if (scale <= 0.0) return;
+
+        auto* sc1 = static_cast<IDXGISwapChain1*>(swap_chain);
+        winrt::com_ptr<IDXGISwapChain2> sc2;
+        if (FAILED(sc1->QueryInterface(IID_PPV_ARGS(sc2.put())))) return;
+
+        DXGI_MATRIX_3X2_F matrix{};
+        matrix._11 = static_cast<float>(1.0 / scale);
+        matrix._22 = static_cast<float>(1.0 / scale);
+        (void)sc2->SetMatrixTransform(&matrix);
     }
 }

--- a/App/TerminalControl.xaml.h
+++ b/App/TerminalControl.xaml.h
@@ -38,6 +38,33 @@ namespace winrt::GhosttyWin32::implementation
         std::function<void()> onActivated;
     };
 
+    // Renderer-thread context for libghostty's `swap_chain_changed_cb`.
+    // ghostty fires that callback on every (re-)bind / resize / DPI
+    // change with the IDXGISwapChain1*; we use it to install an
+    // IDXGISwapChain2::SetMatrixTransform of {1/scale, 1/scale} that
+    // cancels XAML SwapChainPanel's implicit upscale of attached
+    // content. Without that workaround text and the background image
+    // come out at ~2x size on HiDPI displays — most visibly on
+    // RDP-from-a-high-DPI-client sessions.
+    //
+    // Lifetime: heap-allocated on Attach, raw pointer is passed to
+    // libghostty as the callback's userdata, owned by TerminalControl
+    // via shared_ptr. Detach sets `cancelled` so any in-flight
+    // callback no-ops; the shared_ptr is released after
+    // ghostty_surface_free has returned (so the renderer thread is
+    // guaranteed not to fire the callback again).
+    //
+    // CompositionScale is stored as an atomic so the UI-thread
+    // CompositionScaleChanged handler can publish updates the
+    // renderer thread reads on the next callback fire without
+    // locking. Defaults to 1.0 (identity matrix) so the very first
+    // fire — before the panel's CompositionScale has settled — is a
+    // no-op rather than installing a bogus transform.
+    struct SwapChainChangedContext {
+        std::atomic<bool> cancelled{ false };
+        std::atomic<double> compositionScale{ 1.0 };
+    };
+
     // UserControl wrapper around a SwapChainPanel for one terminal surface.
     //
     // SwapChainPanel inherits from Grid (not Control) and is not a
@@ -80,7 +107,8 @@ namespace winrt::GhosttyWin32::implementation
                     ghostty_surface_t surface,
                     HANDLE compositionHandle,
                     HWND hostHwnd,
-                    std::shared_ptr<SwapChainAttachRequest> attachRequest);
+                    std::shared_ptr<SwapChainAttachRequest> attachRequest,
+                    std::shared_ptr<SwapChainChangedContext> swapChainChangedContext);
 
         // Forwarded by MainWindow's window-Activated handler. XAML's
         // GotFocus / LostFocus don't fire on window de/activation
@@ -101,6 +129,16 @@ namespace winrt::GhosttyWin32::implementation
         // Called as a free function with the SwapChainAttachRequest
         // pointer as userdata — no `this` involved.
         static void OnSwapChainReady(void* userdata) noexcept;
+
+        // Renderer-thread callback registered with ghostty as
+        // cfg.swap_chain_changed_cb. Fired after initial bind, after
+        // every dx_resize, and after every DPI / font change.
+        // userdata is a raw pointer to a SwapChainChangedContext
+        // owned by a shared_ptr on this control. Queries the swap
+        // chain to IDXGISwapChain2 and installs a (1/scale, 1/scale)
+        // SetMatrixTransform that cancels XAML SwapChainPanel's
+        // implicit upscale. No `this` involved.
+        static void OnSwapChainChanged(void* swap_chain, void* userdata) noexcept;
 
         // Implementation-only accessors used by Tab.
         ghostty_surface_t Surface() const noexcept { return m_surface; }
@@ -160,7 +198,20 @@ namespace winrt::GhosttyWin32::implementation
         // from input handlers.
         HWND m_hostHwnd{ nullptr };
         winrt::event_token m_sizeChangedToken{};
+        // SwapChainPanel composition scale (DPI / per-monitor scale)
+        // tracking. The panel's CompositionScale can lag behind the
+        // window's DPI on RDP — initially the panel reports 1.0 even
+        // when the desktop is at 200% — and only settles once the
+        // composition pipeline has picked it up. Subscribing here per-
+        // leaf is more reliable than driving everything from
+        // MainWindow's XamlRoot.Changed broadcast: it fires exactly
+        // when the panel's own display scale changes, and the value we
+        // read back is what the panel will actually composite at.
+        winrt::event_token m_compositionScaleChangedToken{};
         std::shared_ptr<SwapChainAttachRequest> m_attachRequest;
+        // Renderer-thread context for libghostty's swap_chain_changed_cb.
+        // See SwapChainChangedContext docs at the top of this file.
+        std::shared_ptr<SwapChainChangedContext> m_swapChainChangedContext;
 
         // IME plumbing. Each TerminalControl gets its own EditContext
         // so a composition started in one tab doesn't leak preedit


### PR DESCRIPTION
## Summary
Text and background images rendered at ~2× their intended physical size on HiDPI sessions — most visible via RDP from a high-DPI client (e.g. a Retina Mac) into a low-DPI Windows server. XAML `SwapChainPanel` implicitly upscales attached swap-chain content by its `CompositionScale` at composition time, and our swap chain is already sized to physical pixels, so the implicit upscale stacks on top of pixel-accurate output.

The fix cancels that upscale with an `IDXGISwapChain2` inverse-scale matrix (`{1/scale, 1/scale}`) — the same workaround Windows Terminal applies in its AtlasEngine.

## Design: libghostty stays host-agnostic
libghostty must not know about WinUI 3 / SwapChainPanel. So the split is:

- **libghostty (submodule bump, ghostty #41):** exposes a renderer-thread `swap_chain_changed_cb(swap_chain, userdata)` that fires on (re-)bind / after `ResizeBuffers` / after DPI change. It only reports *when* the swap chain changed and hands over the `IDXGISwapChain1*`. It has no opinion on what the host installs.
- **host (this PR):** registers that callback and installs the inverse-scale matrix. All WinUI-specific policy lives here.

This addresses the layering concern that an earlier approach (matrix logic inside libghostty's DirectX renderer) mixed XAML-specific policy into the cross-platform library.

## Commits
1. `submodule: bump external/ghostty for swap_chain_changed_cb hook` — pointer bump to windows-port's merge of the callback API. API-additive, backward compatible.
2. `fix: oversized text and clipped background image on HiDPI/RDP sessions` — host wiring:
   - `SwapChainChangedContext` (per-leaf, atomics for cancelled flag + live composition scale)
   - `TerminalControl::OnSwapChainChanged` renderer-thread callback → installs the matrix
   - `CompositionScaleChanged` publishes the scale + pushes `set_content_scale`
   - `SizeChanged` converts DIP → physical pixels for `set_size`
   - `TabFactory` uses `panel.CompositionScaleX` as authoritative initial scale, wires the callback, seeds the context
   - removed the old `XamlRoot.Changed` system-DPI broadcast (per-leaf supersedes it)
   - `Detach` cancels the context; shared_ptr released after `ghostty_surface_free`

## Test plan
- [x] macOS Retina → RDP → Windows server: cell size matches Windows Terminal at the same `font-size`; background image fits; text sharp.
- [x] Local non-HiDPI Windows: matrix is identity at scale 1.0 — no visible change.
- [x] DPI live-change / resize: callback re-fires (font rebuild + `ResizeBuffers`), matrix re-installed.
- [x] Teardown: context cancelled, no use-after-free.
- [ ] CI build green.

## Depends on
- i999rri/ghostty#41 (merged) — submodule points at the windows-port merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)