### PR TITLE
Route MOUSE_SHAPE to the pane under the pointer, not the active pane

### DIFF
--- a/App/MainWindow.xaml.cpp
+++ b/App/MainWindow.xaml.cpp
@@ -859,14 +859,17 @@ namespace winrt::GhosttyWin32::implementation
     void MainWindow::SetCursorShapeForSurface(ghostty_surface_t surface,
                                               ghostty_action_mouse_shape_e shape)
     {
-        // Known: routes to the tab's active leaf rather than the
-        // pane owning `surface` — tracked in #65 because split
-        // panes get the wrong cursor. Behaviour preserved on this
-        // refactor; the fix is a separate PR.
-        if (auto* t = m_tabs.FindBySurface(surface)) {
-            if (auto* tc = t->ActiveControl()) {
-                tc->SetCursorShape(shape);
-            }
+        // Route the shape to the leaf that actually owns `surface`, not
+        // the tab's active leaf. MOUSE_SHAPE carries the originating
+        // surface, and with split panes the pointer can be over a
+        // non-active pane — using ActiveControl() landed the shape on
+        // the wrong pane (#65). FindLeafBySurface walks the pane tree
+        // and returns the owning leaf; in the single-pane case it
+        // resolves to the same control ActiveControl() would.
+        auto lookup = m_tabs.FindLeafBySurface(surface);
+        if (!lookup.leaf) return;
+        if (auto* tc = Tab::LeafToTerminalControl(*lookup.leaf)) {
+            tc->SetCursorShape(shape);
         }
     }
 


### PR DESCRIPTION
Fixes #65

## Summary
With split panes, moving the pointer over a non-active pane changed the cursor shape on the **active** pane instead of the one under the pointer; the hovered pane kept its old shape (I-beam over cells, resize arrow over splitters, hand on Ctrl-hover links).

`MOUSE_SHAPE` carries the originating `ghostty_surface_t`, but `SetCursorShapeForSurface` resolved it only as far as the owning `Tab` and then applied the shape to `Tab::ActiveControl()`, dropping the per-leaf resolution. In the single-pane case `ActiveControl()` was the right leaf, so this only surfaced after split panes shipped (#18).

## Fix
Use `Tabs::FindLeafBySurface` — which already walks the pane tree and is used by the notification-routing path — to get the specific leaf, then `Tab::LeafToTerminalControl` to reach its control. One-function change; single-pane behaviour unchanged.

## Audit (per the issue's "check other GHOSTTY_TARGET_SURFACE handlers" note)
The other surface-targeted handlers in `MainWindow` operate at tab / panel-root granularity, so they don't have the wrong-leaf problem:
- Split / Equalize / GotoSplit / ResizeSplit → act on the tab's `SplitPanel` root
- SetTabTitle / CopyTabTitle / CloseSurface → tab-level

Only `MOUSE_SHAPE` is per-leaf.

## Test plan
- [x] Split a tab into 2 panes. Hover the **non-active** pane → that pane shows I-beam (previously the active pane changed instead).
- [x] Hover a splitter → resize arrow on the correct pane.
- [x] Ctrl+hover a URL in a non-active pane → hand cursor on that pane.
- [x] Single pane: unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)