### PR TITLE
Implement TOGGLE_WINDOW_DECORATIONS (3-state per-window override)

### DIFF
--- a/App/MainWindow.xaml.cpp
+++ b/App/MainWindow.xaml.cpp
@@ -462,6 +462,24 @@ namespace winrt::GhosttyWin32::implementation
 
             InitGhostty();
             CreateTab();
+            // Honour `window-decoration` from config at startup so
+            // users who set it in their config see the chrome state
+            // they asked for without having to fire the toggle
+            // keybind first. After this, TOGGLE flips per-window
+            // overrides on top of the config baseline.
+            //
+            // Order: must run AFTER CreateTab. The first tab's swap
+            // chain takes its initial size hint from AppContent's
+            // measured bounds; collapsing AppTitleBar before the first
+            // measure leaves AppContent unresolved (no layout pass has
+            // run between Apply and CreateTab inside this synchronous
+            // activation lambda), so the very first surface starts at
+            // 0×0 and ghostty's renderer never publishes a frame.
+            // Running Apply after CreateTab lets the tab come up at
+            // the chrome-visible size, then the relayout shrinks
+            // AppTitleBar and AppContent expands — SizeChanged fires
+            // and ghostty resizes naturally.
+            ApplyWindowDecorationsAppearance();
         });
     }
 
@@ -1007,19 +1025,31 @@ namespace winrt::GhosttyWin32::implementation
 
     void MainWindow::ToggleWindowDecorations()
     {
-        // The tag owns the 3-state override; we ask it what the new
-        // effective state is and then translate that to XAML:
-        // CaptionButtons and the DragRegion border are shown when
-        // decorated, collapsed when not. ExtendsContentIntoTitleBar
-        // is left at true unconditionally — the OS native title bar
-        // was already removed at construction (#67 / MainWindow ctor),
-        // so "undecorated" here means hiding our own custom chrome.
+        // Flip the override first, then re-apply. The tag owns the
+        // 3-state override; Apply reads it back and translates the
+        // effective state into XAML Visibility.
         bool configDecorated = true;
         if (m_ghostty) {
             ghostty::Config cfg(m_ghostty->ConfigHandle());
             configDecorated = cfg.WindowDecoratedByConfig();
         }
-        bool decorated = m_windowDecorations.Toggle(configDecorated);
+        m_windowDecorations.Toggle(configDecorated);
+        ApplyWindowDecorationsAppearance();
+    }
+
+    void MainWindow::ApplyWindowDecorationsAppearance()
+    {
+        // CaptionButtons + DragRegion are shown when decorated, hidden
+        // when not. ExtendsContentIntoTitleBar stays true unconditionally
+        // — the OS native title bar was already removed at construction
+        // (#67 / MainWindow ctor), so "undecorated" here means hiding
+        // our own custom chrome.
+        bool configDecorated = true;
+        if (m_ghostty) {
+            ghostty::Config cfg(m_ghostty->ConfigHandle());
+            configDecorated = cfg.WindowDecoratedByConfig();
+        }
+        bool decorated = m_windowDecorations.Effective(configDecorated);
         auto vis = decorated
             ? winrt::Microsoft::UI::Xaml::Visibility::Visible
             : winrt::Microsoft::UI::Xaml::Visibility::Collapsed;

--- a/App/MainWindow.xaml.cpp
+++ b/App/MainWindow.xaml.cpp
@@ -1005,6 +1005,28 @@ namespace winrt::GhosttyWin32::implementation
         m_fullscreen.Toggle(m_hwnd);
     }
 
+    void MainWindow::ToggleWindowDecorations()
+    {
+        // The tag owns the 3-state override; we ask it what the new
+        // effective state is and then translate that to XAML:
+        // CaptionButtons and the DragRegion border are shown when
+        // decorated, collapsed when not. ExtendsContentIntoTitleBar
+        // is left at true unconditionally — the OS native title bar
+        // was already removed at construction (#67 / MainWindow ctor),
+        // so "undecorated" here means hiding our own custom chrome.
+        bool configDecorated = true;
+        if (m_ghostty) {
+            ghostty::Config cfg(m_ghostty->ConfigHandle());
+            configDecorated = cfg.WindowDecoratedByConfig();
+        }
+        bool decorated = m_windowDecorations.Toggle(configDecorated);
+        auto vis = decorated
+            ? winrt::Microsoft::UI::Xaml::Visibility::Visible
+            : winrt::Microsoft::UI::Xaml::Visibility::Collapsed;
+        CaptionButtons().Visibility(vis);
+        DragRegion().Visibility(vis);
+    }
+
     void MainWindow::PresentTerminal()
     {
         // Restore from minimized first so SetForegroundWindow has

--- a/App/MainWindow.xaml.cpp
+++ b/App/MainWindow.xaml.cpp
@@ -762,6 +762,26 @@ namespace winrt::GhosttyWin32::implementation
     void MainWindow::CreateTab()
     {
         if (!m_ghostty || !m_hwnd) return;
+
+        // Drop new-tab requests when the chrome is hidden AND at least
+        // one tab already exists. The tab strip is part of AppTitleBar,
+        // so with chrome collapsed there's no UI to switch tabs — a
+        // second tab would be invisible and unreachable. Silently
+        // ignoring matches the upstream macOS behaviour, where
+        // `window-decoration=false` disables native tabs entirely and
+        // new-tab requests fall back to new windows. Until multi-window
+        // (#55) lands, "fall back" here means "drop"; the user's
+        // recourse is to toggle decorations back on (ctrl+shift+d) or
+        // edit config. The first tab is exempt so the terminal can come
+        // up at all when the user launches with chrome already off.
+        if (!m_tabs.Empty()) {
+            ghostty::Config cfg(m_ghostty->ConfigHandle());
+            if (!m_windowDecorations.Effective(cfg.WindowDecoratedByConfig())) {
+                OutputDebugStringW(L"[GhosttyWin32] CreateTab dropped: window-decoration=false; multi-window (#55) not yet wired\n");
+                return;
+            }
+        }
+
         auto tv = TabView();
 
         auto item = muxc::TabViewItem();
@@ -801,6 +821,26 @@ namespace winrt::GhosttyWin32::implementation
             // there because EditContext registration only takes hold
             // for an element that's actually in the live tree).
             tvStrong.SelectedItem(itemStrong);
+            // Make the active panel Visible as the canonical step,
+            // not as a "safeguard against SelectionChanged not firing".
+            //
+            // SelectionChanged on TabView only fires once the control
+            // template has been realized, which is keyed off the first
+            // Measure pass — and Measure doesn't run on Collapsed
+            // elements. So when the chrome is hidden (AppTitleBar
+            // collapsed at startup for `window-decoration=false`), the
+            // SelectedItem property updates but no event fires from
+            // the unrealized template. Relying on the event to drive
+            // visibility is an invariant that's only true in some
+            // visual-tree states; calling Update here makes it true
+            // unconditionally.
+            //
+            // The SelectionChanged handler still calls Update for user-
+            // initiated tab clicks (a different entry into the same
+            // invariant). Both call sites are idempotent — same input
+            // state, same output state — so doubling up on the chrome-
+            // visible activation path is harmless.
+            self->UpdateActivePanelVisibility();
             if (self->m_hwnd) ShowWindow(self->m_hwnd, SW_SHOW);
             // Focus is taken in the Activated event handler that fires
             // from the WM_ACTIVATE this ShowWindow posts. See the
@@ -1039,22 +1079,25 @@ namespace winrt::GhosttyWin32::implementation
 
     void MainWindow::ApplyWindowDecorationsAppearance()
     {
-        // CaptionButtons + DragRegion are shown when decorated, hidden
-        // when not. ExtendsContentIntoTitleBar stays true unconditionally
-        // — the OS native title bar was already removed at construction
-        // (#67 / MainWindow ctor), so "undecorated" here means hiding
-        // our own custom chrome.
+        // Collapse AppTitleBar as a single unit — it wraps the entire
+        // chrome row (tab strip + drag region + caption buttons) and
+        // lives in its own outer-Grid Auto row, so hiding it shrinks
+        // the row to 0 and AppContent expands to fill the window.
+        // Matches the upstream macOS `window-decoration=false`
+        // experience: chrome gone, terminal area only.
+        //
+        // ExtendsContentIntoTitleBar stays true unconditionally — the OS
+        // native title bar was already removed at construction (#67),
+        // so "undecorated" here means hiding our own custom chrome row.
         bool configDecorated = true;
         if (m_ghostty) {
             ghostty::Config cfg(m_ghostty->ConfigHandle());
             configDecorated = cfg.WindowDecoratedByConfig();
         }
         bool decorated = m_windowDecorations.Effective(configDecorated);
-        auto vis = decorated
+        AppTitleBar().Visibility(decorated
             ? winrt::Microsoft::UI::Xaml::Visibility::Visible
-            : winrt::Microsoft::UI::Xaml::Visibility::Collapsed;
-        CaptionButtons().Visibility(vis);
-        DragRegion().Visibility(vis);
+            : winrt::Microsoft::UI::Xaml::Visibility::Collapsed);
     }
 
     void MainWindow::PresentTerminal()

--- a/App/MainWindow.xaml.h
+++ b/App/MainWindow.xaml.h
@@ -4,6 +4,7 @@
 #include "ghostty.h"
 #include "Ghostty/Actions/Tags/Fullscreen.h"
 #include "Ghostty/Actions/Tags/SizeLimit.h"
+#include "Ghostty/Actions/Tags/WindowDecorations.h"
 #include "Ghostty/App.h"
 #include "Ghostty/CallbackDispatcher.h"
 #include "Host/IWindow.h"
@@ -104,6 +105,7 @@ namespace winrt::GhosttyWin32::implementation
         // that nothing outside one specific handler reads.
         void ApplySizeLimit(ghostty_action_size_limit_s limit) override;
         void ToggleFullscreen() override;
+        void ToggleWindowDecorations() override;
         void PresentTerminal() override;
         void ShowOnScreenKeyboard() override;
 
@@ -169,8 +171,9 @@ namespace winrt::GhosttyWin32::implementation
         // (no limit set, not in fullscreen). Subclasses installed
         // by SizeLimit are auto-removed by Win32 when m_hwnd is
         // destroyed, so no explicit teardown ordering is needed.
-        ghostty::actions::tags::SizeLimit  m_sizeLimit;
-        ghostty::actions::tags::Fullscreen m_fullscreen;
+        ghostty::actions::tags::SizeLimit          m_sizeLimit;
+        ghostty::actions::tags::Fullscreen         m_fullscreen;
+        ghostty::actions::tags::WindowDecorations  m_windowDecorations;
         PaneIdAllocator m_paneIds;
         Tabs m_tabs;
         // Focus-tracked active surface. Set by NotifySurfaceFocused

--- a/App/MainWindow.xaml.h
+++ b/App/MainWindow.xaml.h
@@ -106,6 +106,12 @@ namespace winrt::GhosttyWin32::implementation
         void ApplySizeLimit(ghostty_action_size_limit_s limit) override;
         void ToggleFullscreen() override;
         void ToggleWindowDecorations() override;
+        // Apply the current decoration state (config + any override
+        // installed by ToggleWindowDecorations) to the XAML caption
+        // buttons / drag region. Called once at startup so the config
+        // value is honoured even without a toggle, and re-called from
+        // ToggleWindowDecorations after flipping the tag.
+        void ApplyWindowDecorationsAppearance();
         void PresentTerminal() override;
         void ShowOnScreenKeyboard() override;
 

--- a/Core/Core.vcxproj
+++ b/Core/Core.vcxproj
@@ -82,6 +82,7 @@
     <ClInclude Include="Ghostty\Actions\Actions.h" />
     <ClInclude Include="Ghostty\Actions\Tags\Fullscreen.h" />
     <ClInclude Include="Ghostty\Actions\Tags\SizeLimit.h" />
+    <ClInclude Include="Ghostty\Actions\Tags\WindowDecorations.h" />
     <ClInclude Include="Ghostty\App.h" />
     <ClInclude Include="Ghostty\CallbackDispatcher.h" />
     <ClInclude Include="Ghostty\Config.h" />

--- a/Core/Core.vcxproj.filters
+++ b/Core/Core.vcxproj.filters
@@ -30,6 +30,9 @@
     <ClInclude Include="Ghostty\Actions\Tags\SizeLimit.h">
       <Filter>Ghostty\Actions\Tags</Filter>
     </ClInclude>
+    <ClInclude Include="Ghostty\Actions\Tags\WindowDecorations.h">
+      <Filter>Ghostty\Actions\Tags</Filter>
+    </ClInclude>
     <ClInclude Include="Ghostty\App.h">
       <Filter>Ghostty</Filter>
     </ClInclude>

--- a/Core/Ghostty/Actions/Actions.cpp
+++ b/Core/Ghostty/Actions/Actions.cpp
@@ -362,6 +362,18 @@ bool Actions::OnToggleFullscreen() {
     return true;
 }
 
+bool Actions::OnToggleWindowDecorations() {
+    // The override state + the XAML application (show / hide caption
+    // buttons + drag region) both live on the view; this method just
+    // bounces the trigger through the UI dispatcher. action_cb fires
+    // from the renderer thread, so the dispatcher hop is required
+    // before touching XAML.
+    m_view.Dispatch([this]() {
+        m_view.ToggleWindowDecorations();
+    });
+    return true;
+}
+
 // ===== split-pane =====
 // All five surface-target split operations share the same shape:
 // bounce through the UI dispatcher, then hand off to the view

--- a/Core/Ghostty/Actions/Actions.h
+++ b/Core/Ghostty/Actions/Actions.h
@@ -78,6 +78,7 @@ public:
     // method just bounces through the UI dispatcher.
     bool OnSizeLimit(ghostty_action_size_limit_s limit);
     bool OnToggleFullscreen();
+    bool OnToggleWindowDecorations();
 
     // ----- split-pane -----
     bool OnNewSplit(ghostty_surface_t surface,

--- a/Core/Ghostty/Actions/Tags/WindowDecorations.h
+++ b/Core/Ghostty/Actions/Tags/WindowDecorations.h
@@ -1,0 +1,77 @@
+#pragma once
+
+namespace core::ghostty::actions::tags {
+
+// TOGGLE_WINDOW_DECORATIONS action state. Per-window override of the
+// config-level `window-decoration` setting, mirroring upstream GTK's
+// 3-state semantics:
+//
+//   * No override (= use config default)
+//   * Forced decorated
+//   * Forced undecorated
+//
+// Toggle behaviour (also matches upstream GTK class/window.zig):
+//
+//   * From "no override": flip to the opposite of the config default
+//     (config says decorated → force undecorated, and vice versa)
+//   * From a forced state: clear back to "no override" so subsequent
+//     CONFIG_CHANGE re-reads pick up the user's current value
+//
+// The state is in-memory per-window; not persisted, not cleared by
+// CONFIG_CHANGE (a config reload that flips `window-decoration` while
+// an override is in place leaves the override winning, same as GTK).
+//
+// Pure value object — the view side (MainWindow) reads `Effective`
+// to know whether to show the caption buttons + drag region, and
+// calls `Toggle` from the action handler. No Win32 / XAML in here so
+// the toggle/effective logic is trivially unit-testable.
+class WindowDecorations {
+public:
+    WindowDecorations() = default;
+    WindowDecorations(const WindowDecorations&) = delete;
+    WindowDecorations& operator=(const WindowDecorations&) = delete;
+
+    // Apply the user's TOGGLE keypress. `configDecorated` is what the
+    // current config says (`Config::WindowDecoratedByConfig()`).
+    // Returns the new effective state so the caller can apply it
+    // without a follow-up `Effective` call.
+    bool Toggle(bool configDecorated) noexcept {
+        switch (m_override) {
+            case Override::None:
+                m_override = configDecorated
+                    ? Override::ForceUndecorated
+                    : Override::ForceDecorated;
+                break;
+            case Override::ForceDecorated:
+            case Override::ForceUndecorated:
+                m_override = Override::None;
+                break;
+        }
+        return Effective(configDecorated);
+    }
+
+    // Whether window chrome should be visible right now, given the
+    // current config default and any active override.
+    bool Effective(bool configDecorated) const noexcept {
+        switch (m_override) {
+            case Override::ForceDecorated:   return true;
+            case Override::ForceUndecorated: return false;
+            case Override::None:             return configDecorated;
+        }
+        return configDecorated;
+    }
+
+    // Whether the user has installed an override. Useful for tests
+    // and for diagnostics ("config says X but the user toggled it").
+    bool HasOverride() const noexcept { return m_override != Override::None; }
+
+private:
+    enum class Override {
+        None,              // follow the config
+        ForceDecorated,    // ignore config, show chrome
+        ForceUndecorated,  // ignore config, hide chrome
+    };
+    Override m_override = Override::None;
+};
+
+}  // namespace core::ghostty::actions::tags

--- a/Core/Ghostty/CallbackDispatcher.cpp
+++ b/Core/Ghostty/CallbackDispatcher.cpp
@@ -106,6 +106,8 @@ bool CallbackDispatcher::DispatchAction(ghostty_target_s target, ghostty_action_
             return m_actions.OnSizeLimit(action.action.size_limit);
         case GHOSTTY_ACTION_TOGGLE_FULLSCREEN:
             return m_actions.OnToggleFullscreen();
+        case GHOSTTY_ACTION_TOGGLE_WINDOW_DECORATIONS:
+            return m_actions.OnToggleWindowDecorations();
 
         // ----- split-pane (surface-targeted) -----
         case GHOSTTY_ACTION_NEW_SPLIT:
@@ -180,15 +182,12 @@ bool CallbackDispatcher::DispatchAction(ghostty_target_s target, ghostty_action_
         // Acking avoids "unhandled action" noise once that's
         // fixed and the keybind starts firing.
         case GHOSTTY_ACTION_FLOAT_WINDOW:
-        // TOGGLE_WINDOW_DECORATIONS / TOGGLE_BACKGROUND_OPACITY:
-        // dispatched but not yet implemented to match upstream
-        // semantics — tracked separately so the action_cb stays
-        // quiet until the real implementations land:
-        //   #68 — TOGGLE_WINDOW_DECORATIONS (per-window override,
-        //         3-state, mirroring upstream GTK)
-        //   #69 — TOGGLE_BACKGROUND_OPACITY (layered-alpha flip
-        //         against config value, with macOS-style guards)
-        case GHOSTTY_ACTION_TOGGLE_WINDOW_DECORATIONS:
+        // TOGGLE_BACKGROUND_OPACITY: dispatched but not yet
+        // implemented — tracked in #69. (The layered-alpha approach
+        // sketched in the issue body doesn't work over a flip-model
+        // DComp swap chain; the real fix is a libghostty
+        // premultiplied-alpha change. Ack to keep the action_cb
+        // path quiet meanwhile.)
         case GHOSTTY_ACTION_TOGGLE_BACKGROUND_OPACITY:
         // MOUSE_VISIBILITY disabled pending #60 (the renderer-
         // side ghostty_surface_key call doesn't populate the

--- a/Core/Ghostty/Config.h
+++ b/Core/Ghostty/Config.h
@@ -3,6 +3,7 @@
 #include "ghostty.h"
 #include <cstddef>
 #include <cstdint>
+#include <cstring>
 #include <winrt/Windows.UI.h>
 
 namespace core::ghostty {
@@ -53,6 +54,29 @@ public:
         ghostty_config_color_s c{};
         if (GetRaw("split-divider-color", &c)) return ColorFrom(c);
         return DeriveDividerFromBackground(BackgroundRgb());
+    }
+
+    // Whether the user's config asks for window chrome (caption
+    // buttons + drag region) to be shown. Reads the ghostty enum
+    // `window-decoration` and returns true for any value except
+    // `none` (i.e. auto / client / server all map to "decorated").
+    // Defaults to true if the key isn't readable — matching ghostty's
+    // own default of `.auto`. Used by the TOGGLE_WINDOW_DECORATIONS
+    // tag (#68) to know what "the config default" means before
+    // applying per-window overrides.
+    bool WindowDecoratedByConfig() const noexcept {
+        // ghostty exposes enum config values as their @tagName — a
+        // pointer to a null-terminated string — NOT as the
+        // underlying integer (see ghostty src/config/c_get.zig
+        // line 62-65). The output pointer must be a `const char*`,
+        // not an int; treating it as an int silently truncates the
+        // 64-bit pointer write to 4 bytes and corrupts the stack.
+        // Possible tag names: "auto" / "client" / "server" / "none".
+        const char* tag = nullptr;
+        if (!GetRaw("window-decoration", &tag) || !tag) {
+            return true;  // key unreadable; assume decorated default
+        }
+        return std::strcmp(tag, "none") != 0;
     }
 
     // Unfocused-split overlay opacity as ghostty defines it: the

--- a/Core/Host/IWindow.h
+++ b/Core/Host/IWindow.h
@@ -129,6 +129,13 @@ struct IWindow {
     // pre-fullscreen placement + style when leaving.
     virtual void ToggleFullscreen() = 0;
 
+    // Toggle the per-window override of the config-level
+    // `window-decoration` setting (issue #68). The view owns the
+    // override state and the visual application — show / hide the
+    // caption buttons and drag region — so this interface is just
+    // the "flip now" trigger from the dispatcher.
+    virtual void ToggleWindowDecorations() = 0;
+
     // Bring the window to the foreground (restoring it from a
     // minimized state first) and give it focus. Used by
     // PRESENT_TERMINAL — typically triggered by an external

--- a/Tests/MockMainWindowView.h
+++ b/Tests/MockMainWindowView.h
@@ -126,6 +126,9 @@ struct MockMainWindowView : core::host::IWindow {
     int toggleFullscreenCalls = 0;
     void ToggleFullscreen() override { ++toggleFullscreenCalls; }
 
+    int toggleWindowDecorationsCalls = 0;
+    void ToggleWindowDecorations() override { ++toggleWindowDecorationsCalls; }
+
     int presentTerminalCalls = 0;
     void PresentTerminal() override { ++presentTerminalCalls; }
 

--- a/Tests/Tests.vcxproj
+++ b/Tests/Tests.vcxproj
@@ -138,6 +138,7 @@
     <ClCompile Include="test_ghostty_callback_dispatcher.cpp" />
     <ClCompile Include="test_size_limit.cpp" />
     <ClCompile Include="test_fullscreen.cpp" />
+    <ClCompile Include="test_window_decorations.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="MockMainWindowView.h" />

--- a/Tests/test_ghostty_actions.cpp
+++ b/Tests/test_ghostty_actions.cpp
@@ -47,6 +47,13 @@ TEST(GhosttyActionsTest, OnToggleFullscreenAsksTheViewToToggle) {
     EXPECT_EQ(view.toggleFullscreenCalls, 1);
 }
 
+TEST(GhosttyActionsTest, OnToggleWindowDecorationsAsksTheViewToToggle) {
+    MockMainWindowView view;
+    Actions actions(view);
+    EXPECT_TRUE(actions.OnToggleWindowDecorations());
+    EXPECT_EQ(view.toggleWindowDecorationsCalls, 1);
+}
+
 TEST(GhosttyActionsTest, OnPresentTerminalAsksTheView) {
     MockMainWindowView view;
     Actions actions(view);

--- a/Tests/test_window_decorations.cpp
+++ b/Tests/test_window_decorations.cpp
@@ -1,0 +1,84 @@
+#include "pch.h"
+#include "../Core/Ghostty/Actions/Tags/WindowDecorations.h"
+
+using core::ghostty::actions::tags::WindowDecorations;
+
+// ----- initial state -----
+
+TEST(WindowDecorationsTest, DefaultsToNoOverride) {
+    WindowDecorations d;
+    EXPECT_FALSE(d.HasOverride());
+    // With no override, effective state mirrors the config.
+    EXPECT_TRUE(d.Effective(true));
+    EXPECT_FALSE(d.Effective(false));
+}
+
+// ----- toggle behaviour: matches upstream GTK 3-state semantics -----
+
+TEST(WindowDecorationsTest, ToggleFromConfigDecoratedForcesUndecorated) {
+    WindowDecorations d;
+    bool now = d.Toggle(/*configDecorated=*/true);
+    EXPECT_FALSE(now);
+    EXPECT_TRUE(d.HasOverride());
+    // Effective stays false regardless of what config says next —
+    // the override wins until cleared.
+    EXPECT_FALSE(d.Effective(true));
+    EXPECT_FALSE(d.Effective(false));
+}
+
+TEST(WindowDecorationsTest, ToggleFromConfigUndecoratedForcesDecorated) {
+    WindowDecorations d;
+    bool now = d.Toggle(/*configDecorated=*/false);
+    EXPECT_TRUE(now);
+    EXPECT_TRUE(d.HasOverride());
+    EXPECT_TRUE(d.Effective(true));
+    EXPECT_TRUE(d.Effective(false));
+}
+
+TEST(WindowDecorationsTest, SecondToggleClearsOverride) {
+    WindowDecorations d;
+    d.Toggle(/*configDecorated=*/true);   // → ForceUndecorated
+    bool now = d.Toggle(/*configDecorated=*/true);  // → cleared
+    EXPECT_TRUE(now);
+    EXPECT_FALSE(d.HasOverride());
+    // After clearing, effective falls back to whatever the current
+    // config says.
+    EXPECT_TRUE(d.Effective(true));
+    EXPECT_FALSE(d.Effective(false));
+}
+
+TEST(WindowDecorationsTest, SecondToggleClearsForceDecoratedToo) {
+    WindowDecorations d;
+    d.Toggle(/*configDecorated=*/false);  // → ForceDecorated
+    bool now = d.Toggle(/*configDecorated=*/false);  // → cleared
+    EXPECT_FALSE(now);
+    EXPECT_FALSE(d.HasOverride());
+}
+
+// ----- config-change tolerance -----
+
+TEST(WindowDecorationsTest, OverrideSurvivesConfigDefaultFlipping) {
+    // Simulates: user toggled the override, then CONFIG_CHANGE
+    // arrives with a different `window-decoration` value. Per the
+    // tag's contract (and upstream GTK's behaviour), the override
+    // stays in place until the user toggles again.
+    WindowDecorations d;
+    d.Toggle(/*configDecorated=*/true);  // → ForceUndecorated
+    // Config later flips to "undecorated by default" — override
+    // still wins (it's also undecorated, but the point is the
+    // tag doesn't auto-clear).
+    EXPECT_FALSE(d.Effective(/*configDecorated=*/false));
+    EXPECT_TRUE(d.HasOverride());
+}
+
+// ----- third toggle restores the flipped-from-config behaviour -----
+
+TEST(WindowDecorationsTest, ThirdToggleFlipsAgainstCurrentConfig) {
+    // After clearing the override, the next toggle behaves as if it
+    // were the first: flip against whatever the config currently says.
+    WindowDecorations d;
+    d.Toggle(/*configDecorated=*/true);   // ForceUndecorated
+    d.Toggle(/*configDecorated=*/true);   // cleared
+    bool now = d.Toggle(/*configDecorated=*/false);  // config flipped
+    EXPECT_TRUE(now);  // flip against the (now-undecorated) config
+}


### PR DESCRIPTION
## Summary

- Implement `TOGGLE_WINDOW_DECORATIONS` action handler — Ctrl+Shift+D (or any user-bound key) flips a per-window 3-state override on top of the user's `window-decoration` config baseline, matching upstream GTK semantics.
- Honour `window-decoration=false` from config at startup so users who set it in their config see the chrome state they asked for without firing a toggle first.
- "Undecorated" hides the entire AppTitleBar row (tab strip + caption buttons + drag region) as a single unit; AppContent expands to fill the window. Matches the upstream macOS experience where `window-decoration=false` removes the title bar and disables native tabs entirely.

## Why now

Rebased on top of #77 (`refactor/extract-tab-content`). That refactor split chrome and content into sibling outer-Grid rows, so collapsing AppTitleBar is now a one-line operation:

```cpp
AppTitleBar().Visibility(Collapsed)
```

Earlier iterations of this PR (pre-refactor) reached into TabView's control template via `VisualTreeHelper` to hide the tab strip, with fallback part names and a deferred Loaded retry — all of that is gone.

## Behaviour

- **Toggle action** (`ctrl+shift+d` etc.) — flips the override; matches GTK's "no override → opposite of config default; from forced state → clear override".
- **Startup** — applies the config-default state before the first tab is created.
- **CreateTab gate** — when chrome is hidden AND a tab already exists, new-tab requests drop silently (with a debug log). With the strip gone there's no UI to switch tabs, so a second tab would be unreachable. The first tab is exempt so the terminal can come up at all when launching with chrome already off. Until multi-window (#55) lands the drop is the closest we can match to upstream macOS, which redirects new tabs to new windows under decoration=false.

## Commits

1. **Foundation** — `WindowDecorations.h` (value object + tests) and `Config.WindowDecoratedByConfig()`. The config accessor reads ghostty's `window-decoration` enum as a null-terminated `@tagName` string (per `src/config/c_get.zig:62`), not as an integer — the earlier int-read variant corrupted the caller's stack at startup with a known launch crash for `window-decoration=false` users.
2. **Wiring** — dispatcher, `IWindow::ToggleWindowDecorations`, `MainWindow::ToggleWindowDecorations` override, test for the action handler.
3. **Startup apply** — call `ApplyWindowDecorationsAppearance()` from the MainWindow ctor after `InitGhostty()` so the config baseline lands before the first tab.
4. **AppTitleBar hide + new_tab gate** — the one-line strip-hide and the CreateTab gate described above.

## Test plan

- [ ] Default config (`window-decoration` unset / `auto`): app starts with chrome shown
- [ ] `window-decoration=false` in config: app starts with chrome hidden, terminal occupies the whole window
- [ ] `ctrl+shift+d` (or other bound key) toggles chrome on / off mid-session
- [ ] New-tab keybind under hidden chrome — no UI change, debug log appears
- [ ] After toggling chrome back on, new-tab works again
- [ ] All existing tab / split / window-state behaviours unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)