### PR TITLE
Extract terminal content from TabView into a sibling AppContent grid

### DIFF
--- a/App/MainWindow.xaml
+++ b/App/MainWindow.xaml
@@ -10,39 +10,57 @@
     Title="Ghostty">
 
     <!-- Layout strategy:
-           Col 0  TabView (spans both columns) — fills the entire window so
-                  the SwapChainPanel content area keeps the full width.
-           Col 1  CaptionButtons (Auto = 138px) — anchored to the window's
-                  right edge in the OUTER grid so they don't shift around
-                  when the TabStripFooter width changes with tab count.
-                  Drawn on top of TabView's tab-strip area thanks to later-
-                  sibling Z-order.
-         The TabStripFooter still hosts a DragRegion border, but with
-         MinWidth=200 the OS gives it at least ~62px of empty space to the
-         left of where the buttons land (200 footer - 138 button cluster),
-         which is the only draggable strip area when many tabs are open. -->
+           Row 0  AppTitleBar (Auto height) — the entire chrome area:
+                  TabView's tab strip on the left, caption buttons pinned
+                  on the right. Hidden as a unit when chrome is turned off
+                  (planned follow-up for `window-decoration=false`).
+           Row 1  AppContent (Star) — terminal content area. Every Tab's
+                  SplitPanel is parented here (not in TabViewItem.Content)
+                  so the strip can live above without coupling its
+                  visibility to whether the terminal stays visible.
+                  Selection drives per-panel Visibility; tab switching
+                  toggles which child of AppContent is Visible.
+         Inside AppTitleBar:
+           Col 0  TabView (spans both columns) — strip-only, since the
+                  per-tab Content is hosted in AppContent. With null
+                  TabItem.Content the template's content row collapses to
+                  zero, so the Auto outer row sizes to just the strip.
+           Col 1  CaptionButtons (Auto ≈ 138px) — anchored right in the
+                  outer Grid so they don't shift when the TabStripFooter
+                  width changes; drawn on top of the strip via Z-order.
+         The TabStripFooter still hosts a DragRegion border (MinWidth=200
+         leaves ~62px of empty draggable area to the left of the caption
+         buttons). The window's title-bar drag region is the whole
+         AppTitleBar via SetTitleBar — DragRegion's only job is to give
+         the OS a visible-but-transparent surface inside the strip. -->
     <Grid>
-        <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="*" />
-            <ColumnDefinition Width="Auto" />
-        </Grid.ColumnDefinitions>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
 
-        <TabView x:Name="TabView" Grid.Column="0" Grid.ColumnSpan="2"
-                 IsAddTabButtonVisible="True"
-                 TabWidthMode="Equal"
-                 VerticalAlignment="Stretch"
-                 HorizontalAlignment="Stretch">
-            <TabView.TabStripFooter>
-                <Border x:Name="DragRegion"
-                        Background="Transparent"
-                        HorizontalAlignment="Stretch"
-                        MinWidth="200" />
-            </TabView.TabStripFooter>
-        </TabView>
+        <Grid x:Name="AppTitleBar" Grid.Row="0">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
 
-        <StackPanel x:Name="CaptionButtons" Grid.Column="1"
-                    Orientation="Horizontal"
-                    VerticalAlignment="Top">
+            <TabView x:Name="TabView" Grid.Column="0" Grid.ColumnSpan="2"
+                     IsAddTabButtonVisible="True"
+                     TabWidthMode="Equal"
+                     VerticalAlignment="Top"
+                     HorizontalAlignment="Stretch">
+                <TabView.TabStripFooter>
+                    <Border x:Name="DragRegion"
+                            Background="Transparent"
+                            HorizontalAlignment="Stretch"
+                            MinWidth="200" />
+                </TabView.TabStripFooter>
+            </TabView>
+
+            <StackPanel x:Name="CaptionButtons" Grid.Column="1"
+                        Orientation="Horizontal"
+                        VerticalAlignment="Top">
             <!-- Local Button.Resources overrides let the default
                  ControlTemplate paint flat caption-style backgrounds
                  without us retemplating the whole control.
@@ -102,5 +120,13 @@
                           Glyph="&#xE8BB;" FontSize="10" />
             </Button>
         </StackPanel>
+        </Grid>
+
+        <!-- AppContent: every Tab's SplitPanel is appended here as a
+             child (not as TabViewItem.Content). The currently-selected
+             tab's panel is the only one with Visibility=Visible; the
+             rest are Collapsed but stay parented so their swap chains
+             keep their DComp surface binding across tab switches. -->
+        <Grid x:Name="AppContent" Grid.Row="1" />
     </Grid>
 </Window>

--- a/App/MainWindow.xaml.cpp
+++ b/App/MainWindow.xaml.cpp
@@ -15,6 +15,7 @@
 #include <commctrl.h>
 #include <winrt/Microsoft.Windows.AppNotifications.h>
 #include <winrt/Microsoft.Windows.AppNotifications.Builder.h>
+#include <winrt/Windows.Graphics.h>
 #include <algorithm>
 #include <cmath>
 #include <filesystem>
@@ -220,14 +221,35 @@ namespace winrt::GhosttyWin32::implementation
             });
 
             auto tv = TabView();
-            // The OS-blessed drag region is the entire AppTitleBar grid
-            // (strip + caption-button column), not just the small Border
-            // we historically pointed it at. Anchoring it on the wrapping
-            // grid keeps the "chrome row" as one OS-recognised unit, which
-            // is what makes the planned `window-decoration=false` toggle a
-            // one-line `AppTitleBar.Visibility(Collapsed)` rather than a
-            // walk over multiple children.
-            SetTitleBar(AppTitleBar());
+            // Don't call Window.SetTitleBar(AppTitleBar()) — that would
+            // make the whole chrome row OS-title-bar input, including the
+            // tab headers. Double-clicking a tab header would then
+            // satisfy the OS's "double-click on title bar = maximize"
+            // gesture, so a quick second click on a tab maximises the
+            // window instead of just selecting the tab.
+            //
+            // Use AppWindowTitleBar.SetDragRectangles instead: explicit
+            // physical-pixel rectangles for the drag region. The tabs +
+            // caption-button columns are outside any drag rect, so the
+            // OS treats clicks on them as ordinary content clicks.
+            // UpdateDragRectangles() is the single source of truth and
+            // is re-called when DragRegion's bounds change (tab add /
+            // remove / TabStripFooter resize) so the rect tracks the
+            // strip's free space dynamically.
+            DragRegion().SizeChanged([weakSelf = get_weak()](auto&&, auto&&) {
+                if (auto self = weakSelf.get()) self->UpdateDragRectangles();
+            });
+            // Publish the initial rect once the strip has finished its
+            // first layout. DragRegion lives inside TabView's template,
+            // which only realises on TabView.Loaded — calling
+            // UpdateDragRectangles here would publish an empty rect that
+            // gets corrected immediately by the SizeChanged above, but
+            // the empty rect would leak through to OS until the next
+            // resize. Tying it to TabView.Loaded keeps the first
+            // published rect already correct.
+            tv.Loaded([weakSelf = get_weak()](auto&&, auto&&) {
+                if (auto self = weakSelf.get()) self->UpdateDragRectangles();
+            });
 
             // Title-bar click focus restore. Clicking the DragRegion
             // immediately knocks focus off the active TerminalControl
@@ -528,6 +550,50 @@ namespace winrt::GhosttyWin32::implementation
             if (auto* tc = tab->ActiveControl()) {
                 tc->ApplyFocusVisual(true);
             }
+        }
+    }
+
+    void MainWindow::UpdateDragRectangles()
+    {
+        // Convert DragRegion's current bounds to a single window-relative
+        // physical-pixel RectInt32 and hand it to AppWindowTitleBar. Only
+        // this rectangle responds to drag input; tabs and caption buttons
+        // sit outside it so OS title-bar gestures (double-click maximize,
+        // long-drag move) only fire from the strip's free space.
+        //
+        // Re-runs on DragRegion.SizeChanged: tab adds / removes change
+        // the strip layout and so the DragRegion's bounds. DPI changes
+        // also trigger a SizeChanged via the XAML relayout, so the
+        // physical-pixel conversion stays current without a separate
+        // DPI hook.
+        if (!m_hwnd) return;
+        auto dragRegion = DragRegion();
+        if (!dragRegion) return;
+        // Skip when the element hasn't been measured yet — TransformToVisual
+        // works but ActualWidth/Height are 0, which would publish an
+        // empty drag rect and let the OS treat the whole AppTitleBar as
+        // non-drag content until the next size change. Bailing keeps
+        // whatever rect was last published in effect.
+        if (dragRegion.ActualWidth() <= 0 || dragRegion.ActualHeight() <= 0) return;
+
+        auto content = Content();
+        if (!content) return;
+        auto transform = dragRegion.TransformToVisual(content);
+        auto origin = transform.TransformPoint(winrt::Windows::Foundation::Point{0.0f, 0.0f});
+
+        const double scale = static_cast<double>(GetDpiForWindow(m_hwnd)) / 96.0;
+        winrt::Windows::Graphics::RectInt32 rect{
+            static_cast<int32_t>(origin.X * scale),
+            static_cast<int32_t>(origin.Y * scale),
+            static_cast<int32_t>(dragRegion.ActualWidth() * scale),
+            static_cast<int32_t>(dragRegion.ActualHeight() * scale)
+        };
+        try {
+            AppWindow().TitleBar().SetDragRectangles({rect});
+        } catch (winrt::hresult_error const&) {
+            // AppWindow may not have a TitleBar yet during early init.
+            // The next SizeChanged after the window is realised will
+            // retry, so silently dropping the first attempt is fine.
         }
     }
 

--- a/App/MainWindow.xaml.cpp
+++ b/App/MainWindow.xaml.cpp
@@ -412,9 +412,28 @@ namespace winrt::GhosttyWin32::implementation
                     // parented; the swap chain handle keeps its DComp
                     // binding across the switch.
                     self->UpdateActivePanelVisibility();
-                    if (auto* tab = self->ActiveTab()) {
-                        tab->Focus();
-                    }
+                    // Defer Focus to the next dispatcher tick. The
+                    // synchronous Focus call races XAML's own focus
+                    // migration when the previously-active panel just
+                    // went Collapsed — observable as "click a tab once,
+                    // nothing happens; click again to actually switch"
+                    // because focus stays parked on the now-Collapsed
+                    // control and the next click is treated as a focus
+                    // recovery instead of a selection change. Same
+                    // pattern as the DragRegion PointerReleased handler
+                    // above, which had to bounce through the dispatcher
+                    // for the same reason.
+                    auto dq = self->DispatcherQueue();
+                    if (!dq) return;
+                    dq.TryEnqueue([weakSelf]() {
+                        auto self2 = weakSelf.get();
+                        if (!self2) return;
+                        try {
+                            if (auto* tab = self2->ActiveTab()) {
+                                tab->Focus();
+                            }
+                        } catch (winrt::hresult_error const&) {}
+                    });
                 } catch (winrt::hresult_error const&) {
                 }
             });

--- a/App/MainWindow.xaml.cpp
+++ b/App/MainWindow.xaml.cpp
@@ -512,6 +512,23 @@ namespace winrt::GhosttyWin32::implementation
                 ? winrt::Microsoft::UI::Xaml::Visibility::Visible
                 : winrt::Microsoft::UI::Xaml::Visibility::Collapsed);
         }
+        // Pre-apply the focused visual on the newly-active leaf
+        // synchronously, ahead of the dispatcher-deferred tab->Focus()
+        // call in SelectionChanged. Without this, the panel goes
+        // Visible while still in the "last LostFocus" state — its
+        // UnfocusedDim overlay is shown for the one dispatcher tick
+        // before XAML's GotFocus arrives and clears it — visible as a
+        // brief darken/brighten flash on every tab switch. The actual
+        // keyboard focus still goes through the deferred path (which
+        // is what fires m_onFocused → NotifySurfaceFocused and updates
+        // the active surface tracker); this only takes care of the
+        // overlay's visibility so the visual state matches the
+        // perceived selection immediately.
+        if (tab) {
+            if (auto* tc = tab->ActiveControl()) {
+                tc->ApplyFocusVisual(true);
+            }
+        }
     }
 
     void MainWindow::RemoveTabPanelFromAppContent(Tab const& tab)

--- a/App/MainWindow.xaml.cpp
+++ b/App/MainWindow.xaml.cpp
@@ -220,7 +220,14 @@ namespace winrt::GhosttyWin32::implementation
             });
 
             auto tv = TabView();
-            SetTitleBar(DragRegion());
+            // The OS-blessed drag region is the entire AppTitleBar grid
+            // (strip + caption-button column), not just the small Border
+            // we historically pointed it at. Anchoring it on the wrapping
+            // grid keeps the "chrome row" as one OS-recognised unit, which
+            // is what makes the planned `window-decoration=false` toggle a
+            // one-line `AppTitleBar.Visibility(Collapsed)` rather than a
+            // walk over multiple children.
+            SetTitleBar(AppTitleBar());
 
             // Title-bar click focus restore. Clicking the DragRegion
             // immediately knocks focus off the active TerminalControl
@@ -357,9 +364,19 @@ namespace winrt::GhosttyWin32::implementation
                     // teardown — same path as a normal title-bar X
                     // close, which works fine precisely because XAML
                     // finishes its own focus cleanup before our
-                    // destructors run.
+                    // destructors run. The orphan SplitPanel under
+                    // AppContent comes down with the window, no
+                    // explicit Remove needed.
                     this->Close();
                 } else {
+                    // Unparent the panel from AppContent before
+                    // destroying the Tab. ~Tab doesn't touch the
+                    // visual tree (Tab doesn't know about AppContent),
+                    // so without this the panel would leak as an
+                    // orphan child of AppContent.
+                    if (auto* t = m_tabs.FindByItem(item)) {
+                        RemoveTabPanelFromAppContent(*t);
+                    }
                     m_tabs.Remove(item);
                 }
             });
@@ -387,6 +404,14 @@ namespace winrt::GhosttyWin32::implementation
                 // window is mid-dispose, in which case TabView() throws
                 // RO_E_CLOSED. Swallow — focus restoration is moot then.
                 try {
+                    // Make the selected tab's SplitPanel the only Visible
+                    // child of AppContent. Must run before Focus() — XAML
+                    // refuses focus on a Collapsed element, so the new
+                    // active panel has to be Visible before tab->Focus()
+                    // fires. Old active panel goes Collapsed but stays
+                    // parented; the swap chain handle keeps its DComp
+                    // binding across the switch.
+                    self->UpdateActivePanelVisibility();
                     if (auto* tab = self->ActiveTab()) {
                         tab->Focus();
                     }
@@ -447,6 +472,43 @@ namespace winrt::GhosttyWin32::implementation
     {
         auto* tab = ActiveTab();
         return tab ? tab->ActiveControl() : nullptr;
+    }
+
+    void MainWindow::UpdateActivePanelVisibility()
+    {
+        // Walk AppContent.Children once: each child is a SplitPanel
+        // for one Tab. The one matching the currently-active tab's
+        // panel becomes Visible; everything else becomes Collapsed.
+        // Collapsed elements stay parented (no Unloaded fires) so the
+        // SwapChainPanel's DComp surface binding survives the switch.
+        auto* tab = ActiveTab();
+        winrt::GhosttyWin32::SplitPanel activePanel{ nullptr };
+        if (tab) activePanel = tab->Panel();
+        auto children = AppContent().Children();
+        for (uint32_t i = 0; i < children.Size(); ++i) {
+            auto child = children.GetAt(i).try_as<winrt::GhosttyWin32::SplitPanel>();
+            if (!child) continue;
+            bool isActive = activePanel && (child == activePanel);
+            child.Visibility(isActive
+                ? winrt::Microsoft::UI::Xaml::Visibility::Visible
+                : winrt::Microsoft::UI::Xaml::Visibility::Collapsed);
+        }
+    }
+
+    void MainWindow::RemoveTabPanelFromAppContent(Tab const& tab)
+    {
+        // Unparent the tab's SplitPanel from AppContent. Called by the
+        // close paths before the Tab object is destroyed — ~Tab doesn't
+        // know about AppContent (the factory deliberately keeps that
+        // knowledge in the host), so without this the panel would leak
+        // as an orphan child after Tab destruction.
+        auto panel = tab.Panel();
+        if (!panel) return;
+        auto children = AppContent().Children();
+        uint32_t idx = 0;
+        if (children.IndexOf(panel, idx)) {
+            children.RemoveAt(idx);
+        }
     }
 
     void MainWindow::NotifySurfaceFocused(ghostty_surface_t surface) noexcept
@@ -586,10 +648,11 @@ namespace winrt::GhosttyWin32::implementation
         static constexpr wchar_t kDefaultTabTitle[] = L" ";
         item.Header(box_value(kDefaultTabTitle));
         item.IsClosable(true);
-        // item.Content is set by TabFactory::Make (which wraps the
-        // control in a SplitPanel-backed Pane tree). Leaving it unset
-        // here keeps "the SplitPanel owns the pane tree" in a single
-        // place.
+        // item.Content stays unset: the SplitPanel is parented under
+        // AppContent (not under TabViewItem) so the tab strip can be
+        // hidden independently of the terminal content. See the layout
+        // comment in MainWindow.xaml. The append happens further down
+        // after TabFactory::Make returns the panel.
         // Same focus-retention story as the AddTabButton: TabViewItem is
         // a Control with IsTabStop=true by default, so clicking a tab
         // header lands focus on the header itself rather than the inner
@@ -625,19 +688,32 @@ namespace winrt::GhosttyWin32::implementation
             // race-free, while a direct Focus() call here is not.
         };
 
-        // Estimate the new panel's eventual size from the currently active
-        // tab. Both panels live in the same TabView content area, so the
-        // active tab's ActualWidth/Height is exactly what the new panel
-        // will lay out to once it becomes visible. Passing this lets
-        // ghostty create the swap chain at the right size from the start
-        // — without it, the new panel's ActualWidth is 0 (deferred
-        // SelectedItem) and ghostty falls back to the main window's full
-        // client rect, which is too tall by the tab strip height.
+        // Estimate the new panel's eventual size from the currently
+        // active tab — the new panel will lay out into the same
+        // AppContent row, so the active panel's size is the right
+        // target. Passing this lets ghostty create the swap chain at
+        // the right size from the start; without it the new panel's
+        // ActualWidth is 0 (Collapsed until the deferred activation
+        // fires) and ghostty falls back to the main window's full
+        // client rect, which causes a "stretch then resize" flash as
+        // soon as the panel becomes Visible.
+        //
+        // First-tab case: ActiveControl() is null and AppContent has
+        // already been measured (Activated fires after the first
+        // layout pass), so AppContent.ActualWidth/Height is the right
+        // fallback. Without this fallback the very first surface would
+        // be created at the bare window size — historically that
+        // produced a visible reflow on the first frame.
         uint32_t initialW = 0, initialH = 0;
         if (auto* prevControl = ActiveControl()) {
             auto prevPanel = prevControl->InnerPanel();
             initialW = static_cast<uint32_t>(prevPanel.ActualWidth());
             initialH = static_cast<uint32_t>(prevPanel.ActualHeight());
+        }
+        if (initialW == 0 || initialH == 0) {
+            auto content = AppContent();
+            if (initialW == 0) initialW = static_cast<uint32_t>(content.ActualWidth());
+            if (initialH == 0) initialH = static_cast<uint32_t>(content.ActualHeight());
         }
 
         // Wrap TabFactory::Make in SEH guard so a hardware exception in
@@ -694,6 +770,18 @@ namespace winrt::GhosttyWin32::implementation
             return;
         }
 
+        // Parent the SplitPanel under AppContent (NOT TabViewItem) with
+        // Visibility=Collapsed. The deferred onActivated callback flips
+        // SelectedItem on the TabView, which fires SelectionChanged →
+        // UpdateActivePanelVisibility, which is what actually makes
+        // this panel Visible — so the "panel becomes visible only with
+        // real content" invariant from issue #22 still holds. The panel
+        // ref is captured by value (cheap winrt handle, just AddRef)
+        // before the unique_ptr is moved into m_tabs so we don't reach
+        // through a moved-from pointer.
+        auto panel = tab->Panel();
+        panel.Visibility(winrt::Microsoft::UI::Xaml::Visibility::Collapsed);
+        AppContent().Children().Append(panel);
         // SelectedItem / SW_SHOW are deferred to the onActivated
         // callback fired from Tab once ghostty has presented its first
         // frame; focus + IME activation chain off SelectedItem via the
@@ -726,6 +814,10 @@ namespace winrt::GhosttyWin32::implementation
         if (tv.TabItems().Size() == 0) {
             RequestClose();
         } else {
+            // Mirror the TabCloseRequested handler: unparent the
+            // SplitPanel from AppContent before destroying the Tab so
+            // it doesn't leak as an orphan child.
+            RemoveTabPanelFromAppContent(*t);
             m_tabs.Remove(item);
         }
     }

--- a/App/MainWindow.xaml.h
+++ b/App/MainWindow.xaml.h
@@ -138,6 +138,19 @@ namespace winrt::GhosttyWin32::implementation
         // depending on the current OverlappedPresenter state.
         void UpdateMaximizeGlyph();
 
+        // Reconcile AppContent child Visibility with the currently
+        // active tab — selected tab's SplitPanel goes Visible, every
+        // other tab's panel goes Collapsed. Called from
+        // TabView.SelectionChanged on every selection flip (incl. the
+        // deferred first-tab activation that runs after ghostty presents
+        // its first frame).
+        void UpdateActivePanelVisibility();
+        // Unparent `tab`'s SplitPanel from AppContent. Called by the
+        // close paths just before the Tab object is destroyed so the
+        // panel doesn't leak as an orphan child. ~Tab can't do this
+        // itself because Tab is deliberately unaware of AppContent.
+        void RemoveTabPanelFromAppContent(Tab const& tab);
+
         // Tear down the pane carrying `id` and update the tree / tab
         // list. Dispatched from close_surface_cb. UI thread only.
         void CloseSurfaceByPaneId(PaneId id);

--- a/App/MainWindow.xaml.h
+++ b/App/MainWindow.xaml.h
@@ -150,6 +150,14 @@ namespace winrt::GhosttyWin32::implementation
         // panel doesn't leak as an orphan child. ~Tab can't do this
         // itself because Tab is deliberately unaware of AppContent.
         void RemoveTabPanelFromAppContent(Tab const& tab);
+        // Publish a single drag rectangle to AppWindowTitleBar covering
+        // the DragRegion's current bounds. Called from
+        // DragRegion.SizeChanged so the rect tracks the strip's free
+        // space as tabs are added / removed. Avoids using
+        // Window.SetTitleBar (which would mark the whole AppTitleBar —
+        // including tab headers — as OS title-bar input, triggering a
+        // double-click maximize when the user double-clicks a tab).
+        void UpdateDragRectangles();
 
         // Tear down the pane carrying `id` and update the tree / tab
         // list. Dispatched from close_surface_cb. UI thread only.

--- a/App/Tabs/Tab.h
+++ b/App/Tabs/Tab.h
@@ -14,13 +14,16 @@ namespace winrt::GhosttyWin32::implementation {
 // Each Tab references:
 //   * A SplitPanel (`m_panel`) that owns the Pane tree describing how
 //     this tab's content is partitioned across one or more terminal
-//     panes, and is the TabViewItem's Content. The Panel keeps its
-//     Children() collection in sync with the tree's leaf set so
-//     framework input routing, hit-testing, and measure / arrange work
-//     end-to-end. Today the tree is always a single leaf — NEW_SPLIT
-//     plumbing comes in the next phase — but the structure is in place
-//     so callers (Tabs::FindBySurface, action callbacks) walk the tree
-//     instead of assuming a single TerminalControl per tab.
+//     panes. The host (MainWindow) parents the panel under AppContent
+//     alongside every other tab's panel; selection drives per-panel
+//     Visibility, which is why TabViewItem.Content stays unset. The
+//     panel keeps its Children() collection in sync with the tree's
+//     leaf set so framework input routing, hit-testing, and measure /
+//     arrange work end-to-end. Today the tree is always a single leaf
+//     — NEW_SPLIT plumbing comes in the next phase — but the structure
+//     is in place so callers (Tabs::FindBySurface, action callbacks)
+//     walk the tree instead of assuming a single TerminalControl per
+//     tab.
 //   * A pointer to the currently active leaf (`m_activeLeaf`). All
 //     "focused terminal" operations (key events, IME, clipboard,
 //     action targets) flow through this. Today there is exactly one
@@ -163,8 +166,9 @@ private:
         DetachAllLeaves(node->Second());
     }
 
-    // SplitPanel owns the Pane tree (via its own m_root) and is set as
-    // the TabViewItem's Content by TabFactory.
+    // SplitPanel owns the Pane tree (via its own m_root). The host
+    // parents it under AppContent — Tab just borrows it via Panel()
+    // for tree walks and Detach plumbing.
     winrt::GhosttyWin32::SplitPanel m_panel{ nullptr };
     Microsoft::UI::Xaml::Controls::TabViewItem m_item{ nullptr };
     // Borrowed pointer into the SplitPanel's tree — never owning.

--- a/App/Tabs/TabFactory.h
+++ b/App/Tabs/TabFactory.h
@@ -51,11 +51,14 @@ public:
     TabFactory& operator=(TabFactory&&) = delete;
 
     // Build a fully-formed Tab. The caller created `item` and appended
-    // it to the TabView, but did NOT set `item.Content` — this factory
-    // creates the TerminalControl, wraps it in a single-leaf Pane
-    // tree, hosts it in a SplitPanel, and assigns the SplitPanel as
-    // the item's content. That keeps the pane-tree ownership invariant
-    // ("SplitPanel owns the tree, Tab borrows it") in one place.
+    // it to the TabView; this factory creates the TerminalControl,
+    // wraps it in a single-leaf Pane tree, and hosts it in a fresh
+    // SplitPanel. The SplitPanel is handed back via Tab.Panel() — the
+    // host is responsible for parenting it (today: under AppContent
+    // alongside the other tabs' panels, with Visibility driven by
+    // TabView selection). The factory deliberately doesn't touch
+    // item.Content or any other host-side layout: keeps the factory
+    // free of "where does the panel live" knowledge.
     //
     // Returns nullptr on failure (after cleaning up any partially-
     // acquired resources). Call on the UI thread; neither the inner
@@ -82,10 +85,11 @@ public:
         auto leaf = MakeLeaf(initialWidth, initialHeight, std::move(onActivated));
         if (!leaf) return nullptr;
 
-        // Wrap the leaf in a SplitPanel and assign as item.Content.
-        // With one leaf SplitPanel collapses to "arrange the single
-        // child at the full rect", matching the previous behaviour of
-        // placing the control directly under TabViewItem.
+        // Wrap the leaf in a SplitPanel. With one leaf the panel
+        // collapses to "arrange the single child at the full rect".
+        // The host parents the returned panel under AppContent — the
+        // factory deliberately doesn't, so it stays unaware of the
+        // host's chrome / content split.
         winrt::GhosttyWin32::SplitPanel splitPanel{};
         auto* splitPanelImpl = winrt::get_self<implementation::SplitPanel>(splitPanel);
         if (!splitPanelImpl) {
@@ -98,7 +102,6 @@ public:
         // with the correct brush.
         splitPanelImpl->SetDividerColor(m_dividerColor);
         splitPanelImpl->SetRoot(std::move(leaf));
-        item.Content(splitPanel);
 
         try {
             return std::make_unique<Tab>(std::move(splitPanel), std::move(item));


### PR DESCRIPTION
## Summary

- Restructure `MainWindow.xaml` so the chrome (tab strip + caption buttons) and the terminal content live in two sibling rows of the outer Grid — `AppTitleBar` and `AppContent` — instead of bundled inside TabView.
- Every Tab's `SplitPanel` is parented under `AppContent`; the selected tab's panel is the only one with `Visibility=Visible`, others stay parented but Collapsed so SwapChainPanel keeps its DComp surface binding across tab switches.
- `TabFactory::Make` no longer touches `item.Content` — the factory stays unaware of where the host parents the panel.

## Why

Anything that wants to hide the tab strip (e.g. `window-decoration=false` from #68) used to need to reach into TabView's internal control template, because TabView bundles the strip and per-tab content into one indivisible control with no public visibility property for the strip alone. Splitting chrome from content at the outer-Grid level makes the future toggle a one-line `AppTitleBar.Visibility(Collapsed)` and removes the dependency on WinUI template-part names.

## Behaviour preserved

- Deferred first-frame activation (issue #22): the panel still becomes Visible only after ghostty has presented its first frame — `SelectedItem(item)` fires from the activation callback, which triggers `SelectionChanged` → `UpdateActivePanelVisibility`.
- Close-path ordering (the `+0x1F8` AV from #26): `DetachAll` still runs before any RemoveAt; the new `RemoveTabPanelFromAppContent` unparent happens after `DwmFlush`, mirroring the previous timing.
- Initial swap-chain size hint: falls back to `AppContent.ActualWidth/Height` when there's no prior active tab (first-tab case) so the very first surface starts at the real terminal size instead of the bare window size.

## Follow-ups (not in this PR)

- PR #76 (`window-decoration=false`) will rebase on this and drop the `VisualTreeHelper` template-part walk in favour of `AppTitleBar.Visibility(Collapsed)`.
- DXGI ResizeBuffers debug-layer noise observed during testing — flag-mismatch warnings on swap chain creation. Needs separate investigation (looks like the flags differ each run, possibly uninitialised data on ghostty's renderer side; not blocking).

## Test plan

- [x] Build, single-tab launch — terminal occupies the full content row
- [x] `ctrl+shift+t` to create more tabs — strip shows them, each tab's panel renders correctly when selected
- [x] Click tab to switch — single click switches (Focus is deferred via DispatcherQueue to avoid the focus-migration race introduced by Collapsed/Visible flipping)
- [x] `ctrl+shift+w` / TabView close button — surviving tabs stay alive, closed panel unparents from AppContent
- [ ] Splits inside a tab still render
- [ ] Drag the AppTitleBar area to move the window

🤖 Generated with [Claude Code](https://claude.com/claude-code)