### PR TITLE
Drive UnfocusedDim from Tab.SetActiveLeaf instead of XAML focus

### DIFF
--- a/App/MainWindow.xaml.cpp
+++ b/App/MainWindow.xaml.cpp
@@ -522,6 +522,9 @@ namespace winrt::GhosttyWin32::implementation
         // panel becomes Visible; everything else becomes Collapsed.
         // Collapsed elements stay parented (no Unloaded fires) so the
         // SwapChainPanel's DComp surface binding survives the switch.
+        // No focus-visual pre-apply is needed — UnfocusedDim is owned
+        // by Tab.SetActiveLeaf and is independent of XAML focus, so
+        // tab switches don't disturb it.
         auto* tab = ActiveTab();
         winrt::GhosttyWin32::SplitPanel activePanel{ nullptr };
         if (tab) activePanel = tab->Panel();
@@ -533,23 +536,6 @@ namespace winrt::GhosttyWin32::implementation
             child.Visibility(isActive
                 ? winrt::Microsoft::UI::Xaml::Visibility::Visible
                 : winrt::Microsoft::UI::Xaml::Visibility::Collapsed);
-        }
-        // Pre-apply the focused visual on the newly-active leaf
-        // synchronously, ahead of the dispatcher-deferred tab->Focus()
-        // call in SelectionChanged. Without this, the panel goes
-        // Visible while still in the "last LostFocus" state — its
-        // UnfocusedDim overlay is shown for the one dispatcher tick
-        // before XAML's GotFocus arrives and clears it — visible as a
-        // brief darken/brighten flash on every tab switch. The actual
-        // keyboard focus still goes through the deferred path (which
-        // is what fires m_onFocused → NotifySurfaceFocused and updates
-        // the active surface tracker); this only takes care of the
-        // overlay's visibility so the visual state matches the
-        // perceived selection immediately.
-        if (tab) {
-            if (auto* tc = tab->ActiveControl()) {
-                tc->ApplyFocusVisual(true);
-            }
         }
     }
 
@@ -616,6 +602,25 @@ namespace winrt::GhosttyWin32::implementation
     void MainWindow::NotifySurfaceFocused(ghostty_surface_t surface) noexcept
     {
         m_activeSurface = surface;
+        // Route the focus event back into the owning Tab so it can
+        // update its per-tab dim invariant. SetActiveLeaf is idempotent
+        // when `leaf` is already the tab's active leaf, so the deferred
+        // Focus call we issue after tab switches (which re-focuses the
+        // same TerminalControl that was already active in the
+        // newly-selected tab) doesn't repaint anything. The case that
+        // matters is a pointer click on a non-active pane inside a
+        // split — GotFocus fires, we land here, SetActiveLeaf swaps
+        // the dim across the panes.
+        if (!surface) return;
+        try {
+            auto lookup = m_tabs.FindLeafBySurface(surface);
+            if (lookup.tab && lookup.leaf && lookup.tab->ActiveLeaf() != lookup.leaf) {
+                lookup.tab->SetActiveLeaf(lookup.leaf);
+            }
+        } catch (...) {
+            // Defensive: dim update is a UX nicety, never crash the
+            // focus path over it.
+        }
     }
 
     // ----- IMainWindowView -----

--- a/App/Tabs/Tab.h
+++ b/App/Tabs/Tab.h
@@ -56,11 +56,14 @@ public:
             throw winrt::hresult_error(E_INVALIDARG, L"Tab: SplitPanel has no root");
         }
         // Initial active leaf is the first (and currently only) leaf
-        // found via depth-first descent.
-        m_activeLeaf = FindFirstLeaf(panelImpl->Root());
-        if (!m_activeLeaf) {
+        // found via depth-first descent. Route through SetActiveLeaf so
+        // the per-tab dim state is applied consistently: active leaf
+        // bright, everything else dim.
+        auto* firstLeaf = FindFirstLeaf(panelImpl->Root());
+        if (!firstLeaf) {
             throw winrt::hresult_error(E_INVALIDARG, L"Tab: pane tree has no leaf");
         }
+        SetActiveLeaf(firstLeaf);
     }
 
     ~Tab() {
@@ -100,11 +103,27 @@ public:
 
     // Retarget the active leaf — used by NEW_SPLIT (focus shifts to
     // the freshly-created pane), GOTO_SPLIT (direction-based pane
-    // nav), and any future pointer-focus path. `leaf` must reach back
-    // to a leaf currently inside this tab's SplitPanel tree;
-    // callers are expected to verify with FindLeafByPaneId or by
-    // building the leaf themselves before the tree mutation.
-    void SetActiveLeaf(Pane* leaf) noexcept { m_activeLeaf = leaf; }
+    // nav), and the pointer-focus path (a click on a non-active pane).
+    // `leaf` must reach back to a leaf currently inside this tab's
+    // SplitPanel tree, or be nullptr to indicate "no active leaf yet"
+    // during a tree mutation. Callers verify with FindLeafByPaneId or
+    // build the leaf themselves before the tree mutation.
+    //
+    // Owns the per-tab dim invariant: the active leaf's UnfocusedDim
+    // is Collapsed (bright), every other leaf's is Visible (dim).
+    // Walking the tree on every SetActiveLeaf call is the canonical
+    // path — the dim state is a property of which leaf the tab thinks
+    // is active, not of XAML keyboard focus, so tab switches and
+    // alt-tabs don't disturb it (they don't change m_activeLeaf).
+    // Pointer clicks and keybind navigation come in through here too;
+    // the corresponding TerminalControl GotFocus / LostFocus hooks no
+    // longer touch the overlay.
+    void SetActiveLeaf(Pane* leaf) {
+        m_activeLeaf = leaf;
+        if (auto* panelImpl = winrt::get_self<implementation::SplitPanel>(m_panel)) {
+            ApplyDimRecursive(panelImpl->Root(), leaf);
+        }
+    }
 
     // Detach every TerminalControl in the tree (surface free, swap
     // chain release, composition handle close, SizeChanged unhook).
@@ -152,6 +171,23 @@ private:
         if (node->IsLeaf()) return node;
         if (auto* p = FindFirstLeaf(node->First())) return p;
         return FindFirstLeaf(node->Second());
+    }
+
+    // Walk the tree and apply the per-tab dim invariant: the leaf
+    // whose Pane* matches `active` gets its UnfocusedDim Collapsed
+    // (bright); every other leaf's gets Visible (dim). Static because
+    // it doesn't touch this instance's mutable state beyond the
+    // leaves it visits.
+    static void ApplyDimRecursive(Pane* node, Pane const* active) {
+        if (!node) return;
+        if (node->IsLeaf()) {
+            if (auto* tc = LeafToTerminalControl(*node)) {
+                tc->ApplyFocusVisual(node == active);
+            }
+            return;
+        }
+        ApplyDimRecursive(node->First(), active);
+        ApplyDimRecursive(node->Second(), active);
     }
 
     static void DetachAllLeaves(Pane* node) {

--- a/App/TerminalControl.xaml.cpp
+++ b/App/TerminalControl.xaml.cpp
@@ -80,7 +80,19 @@ namespace winrt::GhosttyWin32::implementation
             auto self = weakSelf.get();
             if (!self) return;
             if (self->m_editContext) self->m_editContext.NotifyFocusEnter();
-            self->ApplyFocusVisual(true);
+            // The UnfocusedDim overlay is driven by Tab.SetActiveLeaf,
+            // not by XAML focus events. Reason: the dim represents
+            // "this leaf is the active split in its tab", which has
+            // nothing to do with XAML keyboard focus. Hooking it on
+            // GotFocus / LostFocus produces a dim flash whenever
+            // focus migrates briefly (tab switch, new-tab creation,
+            // alt-tab away), even though the active leaf hasn't
+            // changed. The surface-focused notification still fires
+            // here — the host's NotifySurfaceFocused routes through
+            // Tab.SetActiveLeaf, so a real focus shift (pointer
+            // click on a non-active pane) still updates the dim by
+            // going through the tab.
+            //
             // Surface-level focus event for the host. Mirrors the
             // upstream getActiveSurface pattern (#62): the host uses
             // this to track "currently focused surface" without us
@@ -95,7 +107,7 @@ namespace winrt::GhosttyWin32::implementation
             auto self = weakSelf.get();
             if (!self) return;
             if (self->m_editContext) self->m_editContext.NotifyFocusLeave();
-            self->ApplyFocusVisual(false);
+            // No dim change here — see the GotFocus comment above.
         });
 
         PointerMoved([weakSelf](auto&&, muxi::PointerRoutedEventArgs const& args) {


### PR DESCRIPTION
## Summary

- Move the UnfocusedDim overlay from XAML focus events (GotFocus / LostFocus on each TerminalControl) to Tab.SetActiveLeaf.
- Tab.SetActiveLeaf walks the tree and applies the invariant: active leaf bright, all other leaves dim. Pure on a single-leaf tab.
- MainWindow.NotifySurfaceFocused routes back into Tab.SetActiveLeaf so a pointer click on a non-active pane (the case that actually changes which leaf the tab considers active) still moves the dim.

## Why

The dim is conceptually "this leaf is the active split inside its tab", and that's owned by `Tab.m_activeLeaf` — not by XAML keyboard focus. Hooking it on the focus events fires the overlay during any focus migration that doesn't correspond to a real active-leaf change:

- **Tab switch** — old tab's active TerminalControl LostFocus while the new tab takes over; overlay briefly turns Visible on the old leaf, visible as a darken/brighten flash for one dispatcher tick.
- **New-tab creation** — TabItems.Append / AppContent.Children.Append triggers an XAML focus walk that drops focus off the currently-active TerminalControl. The overlay turns Visible and stays that way for the 100ms+ it takes ghostty to produce its first frame, so the user's current terminal visibly darkens.
- **Alt-tab away** — same shape; the leaf is still the active split, but XAML LostFocus dims it.

Moving the trigger to `Tab.SetActiveLeaf` makes the dim track the actual semantic state ("which split is active in this tab") rather than the incidental XAML state.

## Test plan

- [ ] Splits within a tab: clicking a non-active pane darkens the other panes, brightens the clicked one
- [ ] Splits + keybind navigation (`ctrl+shift+[` / `]`): dim follows the keybind
- [ ] Tab switch (click strip / `ctrl+page_up/down`): no darken / brighten flash on either tab's active pane
- [ ] New tab via `ctrl+shift+t` or `+` button: current terminal stays bright while waiting for the new tab to come up
- [ ] Alt-tab away and back: the active pane stays bright across the cycle
- [ ] Close the active pane in a split: dim transfers to whichever pane becomes the new active leaf

🤖 Generated with [Claude Code](https://claude.com/claude-code)