### PR TITLE
Centralise DIPs-to-physical-pixels conversion (fixes split sizing on HiDPI)

### DIFF
--- a/App/App.vcxproj
+++ b/App/App.vcxproj
@@ -163,6 +163,7 @@
     <ClInclude Include="Tabs\Tab.h" />
     <ClInclude Include="Tabs\TabFactory.h" />
     <ClInclude Include="Tabs\Tabs.h" />
+    <ClInclude Include="Display\PhysicalPixels.h" />
     <ClInclude Include="TerminalControl.xaml.h">
       <DependentUpon>TerminalControl.xaml</DependentUpon>
     </ClInclude>

--- a/App/App.vcxproj.filters
+++ b/App/App.vcxproj.filters
@@ -26,6 +26,9 @@
     <Filter Include="Tabs\Panes">
       <UniqueIdentifier>{8A5D7C1F-3B6E-49C4-A0F2-D7E9B4F8C2A1}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Display">
+      <UniqueIdentifier>{B3E9F5A2-7C8D-4E6A-9F1B-2D5E8C3A6F4D}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Tabs\Tab.h">
@@ -45,6 +48,9 @@
     </ClInclude>
     <ClInclude Include="Tabs\Panes\PaneIdAllocator.h">
       <Filter>Tabs\Panes</Filter>
+    </ClInclude>
+    <ClInclude Include="Display\PhysicalPixels.h">
+      <Filter>Display</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/App/Display/PhysicalPixels.h
+++ b/App/Display/PhysicalPixels.h
@@ -1,0 +1,116 @@
+#pragma once
+
+#include <cstdint>
+#include <utility>
+#include <winrt/Microsoft.UI.Xaml.h>
+#include <winrt/Microsoft.UI.Xaml.Controls.h>
+
+namespace winrt::GhosttyWin32::implementation::display {
+
+// ghostty exposes its swap-chain size as raw physical pixels — both
+// the initial-size config and `ghostty_surface_set_size`. XAML reports
+// element bounds in DIPs; multiplying by the active DPI scale gets the
+// buffer resolution ghostty wants.
+//
+// Centralising the conversion catches two recurring mistakes:
+//
+//   1. Forgetting the multiplication entirely. Passing DIPs straight
+//      through halves the swap-chain resolution on a 200 % display,
+//      so the rendered content lands in a buffer half the panel's
+//      physical footprint and shows up shrunk into the corner with a
+//      black margin.
+//
+//   2. Treating a transient 0 scale as the real value. Both
+//      `SwapChainPanel.CompositionScale*` and
+//      `XamlRoot.RasterizationScale` can report 0 before composition
+//      has picked up the element (first frame on RDP, before the
+//      `CompositionScaleChanged` hook fires). Multiplying width by 0
+//      yields a 0-pixel swap chain, which crashes some DXGI paths.
+//      The fallback to 1.0 here matches what every existing call site
+//      already did ad-hoc; the eventual scale-change event re-publishes
+//      the correct value via `ghostty_surface_set_size`.
+//
+// Type dispatch:
+//
+//   - `EffectiveScales(SwapChainPanel)` uses the panel's per-panel
+//     `CompositionScaleX/Y`. Granular and matches what gets passed to
+//     `ghostty_surface_set_content_scale` from the panel's own
+//     `CompositionScaleChanged` event, so we stay consistent with that
+//     code path.
+//
+//   - `EffectiveScales(FrameworkElement)` (the generic overload) uses
+//     `XamlRoot.RasterizationScale`. Same value as composition scale
+//     in normal monitor-DPI scenarios; works for any element that's
+//     attached to a XamlRoot.
+//
+//   - `ToPhysicalPixels` / `MeasuredPhysical` are templates that
+//     instantiate over whatever the caller passes — the right
+//     `EffectiveScales` overload is picked at compile time based on
+//     the argument's static type. No runtime `try_as` cost.
+struct PhysicalSize {
+    uint32_t width;
+    uint32_t height;
+};
+
+// Specialised resolver: `SwapChainPanel` has its own per-panel
+// composition scale, which can transiently differ from the root
+// rasterization scale (e.g. during the first frame on RDP before
+// composition settles). Use it directly when the caller knows the
+// element is a SwapChainPanel.
+inline std::pair<double, double> EffectiveScales(
+    winrt::Microsoft::UI::Xaml::Controls::SwapChainPanel const& panel)
+{
+    double sx = panel.CompositionScaleX();
+    double sy = panel.CompositionScaleY();
+    if (sx > 0.0 && sy > 0.0) return { sx, sy };
+    if (auto root = panel.XamlRoot()) {
+        double s = root.RasterizationScale();
+        if (s > 0.0) return { s, s };
+    }
+    return { 1.0, 1.0 };
+}
+
+// Generic resolver: any other `FrameworkElement` (Grid, ContentPresenter,
+// etc.) doesn't expose composition scale; the root's rasterization
+// scale is the correct equivalent.
+inline std::pair<double, double> EffectiveScales(
+    winrt::Microsoft::UI::Xaml::FrameworkElement const& element)
+{
+    if (auto root = element.XamlRoot()) {
+        double s = root.RasterizationScale();
+        if (s > 0.0) return { s, s };
+    }
+    return { 1.0, 1.0 };
+}
+
+// Convert an explicit (width, height) DIP pair to physical pixels
+// using `element`'s scale. Useful when the caller has a DIP
+// measurement from a different source (e.g. SizeChanged's NewSize, or
+// a halved source-pane width) than the element's own ActualWidth.
+//
+// Templated so the right `EffectiveScales` overload is selected at
+// compile time from the argument's static type.
+template <typename TElement>
+inline PhysicalSize ToPhysicalPixels(
+    TElement const& element,
+    double widthDips,
+    double heightDips)
+{
+    auto [sx, sy] = EffectiveScales(element);
+    return {
+        static_cast<uint32_t>(widthDips  * sx),
+        static_cast<uint32_t>(heightDips * sy),
+    };
+}
+
+// `element`'s own measured size (ActualWidth/Height) converted to
+// physical pixels. The common case for "size this swap chain at the
+// pane's current bounds". 0 when the element hasn't been measured
+// yet.
+template <typename TElement>
+inline PhysicalSize MeasuredPhysical(TElement const& element)
+{
+    return ToPhysicalPixels(element, element.ActualWidth(), element.ActualHeight());
+}
+
+}  // namespace winrt::GhosttyWin32::implementation::display

--- a/App/MainWindow.xaml.cpp
+++ b/App/MainWindow.xaml.cpp
@@ -3,6 +3,7 @@
 #include "Ghostty/CallbackDispatcher.h"
 #include "Host/KeyModifiers.h"
 #include "Interop/Encoding.h"
+#include "Display/PhysicalPixels.h"
 #include "Win32/Clipboard.h"
 #include "Win32/SEHGuard.h"
 #if __has_include("MainWindow.g.cpp")
@@ -800,22 +801,21 @@ namespace winrt::GhosttyWin32::implementation
         // client rect, which causes a "stretch then resize" flash as
         // soon as the panel becomes Visible.
         //
-        // First-tab case: ActiveControl() is null and AppContent has
-        // already been measured (Activated fires after the first
-        // layout pass), so AppContent.ActualWidth/Height is the right
-        // fallback. Without this fallback the very first surface would
-        // be created at the bare window size — historically that
-        // produced a visible reflow on the first frame.
+        // Values are PHYSICAL pixels (see display::MeasuredPhysical for
+        // why the conversion matters). First-tab case: ActiveControl()
+        // is null and AppContent has already been measured (Activated
+        // fires after the first layout pass), so the AppContent
+        // fallback gives a non-zero hint.
         uint32_t initialW = 0, initialH = 0;
         if (auto* prevControl = ActiveControl()) {
-            auto prevPanel = prevControl->InnerPanel();
-            initialW = static_cast<uint32_t>(prevPanel.ActualWidth());
-            initialH = static_cast<uint32_t>(prevPanel.ActualHeight());
+            auto sz = display::MeasuredPhysical(prevControl->InnerPanel());
+            initialW = sz.width;
+            initialH = sz.height;
         }
         if (initialW == 0 || initialH == 0) {
-            auto content = AppContent();
-            if (initialW == 0) initialW = static_cast<uint32_t>(content.ActualWidth());
-            if (initialH == 0) initialH = static_cast<uint32_t>(content.ActualHeight());
+            auto sz = display::MeasuredPhysical(AppContent());
+            if (initialW == 0) initialW = sz.width;
+            if (initialH == 0) initialH = sz.height;
         }
 
         // Wrap TabFactory::Make in SEH guard so a hardware exception in
@@ -1367,17 +1367,14 @@ namespace winrt::GhosttyWin32::implementation
         }
 
         // Size hint for the new ghostty surface: the source pane's
-        // current SwapChainPanel size halved on the split axis. The
-        // SplitPanel's first arrange pass after ReplaceLeaf will
-        // re-size both leaves to their actual half-extent and trigger
-        // SizeChanged → ghostty resize anyway; this just keeps the
-        // initial swap chain close to the eventual size so the first
-        // frame doesn't have to stretch.
+        // current SwapChainPanel size halved on the split axis,
+        // expressed in PHYSICAL pixels (see display::MeasuredPhysical
+        // for why the conversion matters).
         uint32_t srcW = 0, srcH = 0;
         if (auto* srcTc = Tab::LeafToTerminalControl(*sourceLeaf)) {
-            auto p = srcTc->InnerPanel();
-            srcW = static_cast<uint32_t>(p.ActualWidth());
-            srcH = static_cast<uint32_t>(p.ActualHeight());
+            auto sz = display::MeasuredPhysical(srcTc->InnerPanel());
+            srcW = sz.width;
+            srcH = sz.height;
         }
         uint32_t newW = (orient == SplitOrientation::Horizontal) ? srcW / 2 : srcW;
         uint32_t newH = (orient == SplitOrientation::Vertical)   ? srcH / 2 : srcH;

--- a/App/TerminalControl.xaml.cpp
+++ b/App/TerminalControl.xaml.cpp
@@ -2,6 +2,7 @@
 #include "TerminalControl.xaml.h"
 #include "Interop/Encoding.h"
 #include "Host/KeyModifiers.h"
+#include "Display/PhysicalPixels.h"
 #include "Win32/Clipboard.h"
 #include <dxgi1_3.h>
 #if __has_include("TerminalControl.g.cpp")
@@ -401,30 +402,16 @@ namespace winrt::GhosttyWin32::implementation
                        Microsoft::UI::Xaml::SizeChangedEventArgs const& args) {
                 auto self = weakSelf.get();
                 if (!self || !self->m_surface) return;
+                // SizeChangedEventArgs.NewSize is in DIPs; ghostty's
+                // surface_set_size needs the swap-chain buffer
+                // resolution in physical pixels. display::ToPhysicalPixels
+                // does the multiplication and the CompositionScale=0
+                // fallback.
                 auto sz = args.NewSize();
-                // ghostty_surface_set_size takes physical pixels (the
-                // renderer creates swap-chain buffers at exactly this
-                // resolution), but SizeChangedEventArgs.NewSize is in
-                // DIPs. On 200% DPI a 1067 DIP panel needs a 2134 px
-                // swap chain; passing the DIP value through directly
-                // makes the renderer create a half-resolution buffer
-                // and the (DPI-scaled) glyphs land on it at too few
-                // pixels per cell, so text reads as ~2x oversized.
-                // Multiply by CompositionScale so the swap chain
-                // resolution matches the panel's physical pixel
-                // footprint. CompositionScale == 0 means the panel
-                // hasn't been picked up by composition yet — leave
-                // it at 1.0 and rely on the next SizeChanged once
-                // composition settles.
                 auto panel = sender.as<Microsoft::UI::Xaml::Controls::SwapChainPanel>();
-                double scaleX = panel.CompositionScaleX();
-                double scaleY = panel.CompositionScaleY();
-                if (scaleX <= 0.0) scaleX = 1.0;
-                if (scaleY <= 0.0) scaleY = 1.0;
-                uint32_t w = static_cast<uint32_t>(sz.Width * scaleX);
-                uint32_t h = static_cast<uint32_t>(sz.Height * scaleY);
-                if (w > 0 && h > 0) {
-                    ghostty_surface_set_size(self->m_surface, w, h);
+                auto px = display::ToPhysicalPixels(panel, sz.Width, sz.Height);
+                if (px.width > 0 && px.height > 0) {
+                    ghostty_surface_set_size(self->m_surface, px.width, px.height);
                 }
             });
 
@@ -455,20 +442,16 @@ namespace winrt::GhosttyWin32::implementation
                         sx, std::memory_order_release);
                 }
                 ghostty_surface_set_content_scale(self->m_surface, sx, sy);
-                // ghostty_surface_set_size takes physical pixels — when
-                // the composition scale changes, the panel's logical
-                // size in DIPs hasn't necessarily changed (so XAML may
-                // not fire SizeChanged) but the physical-pixel footprint
-                // has. Re-push it so the swap-chain resolution matches
-                // the new composition scale; otherwise the glyphs end up
-                // at the new font size on the old (lower-resolution)
-                // swap chain and read as oversized.
-                double dipW = panel.ActualWidth();
-                double dipH = panel.ActualHeight();
-                uint32_t pw = static_cast<uint32_t>(dipW * sx);
-                uint32_t ph = static_cast<uint32_t>(dipH * sy);
-                if (pw > 0 && ph > 0) {
-                    ghostty_surface_set_size(self->m_surface, pw, ph);
+                // When the composition scale changes, the panel's DIP
+                // size hasn't necessarily changed (so XAML may not fire
+                // SizeChanged) but the physical-pixel footprint has.
+                // Re-push the size so the swap-chain resolution matches
+                // the new scale; otherwise glyphs end up at the new
+                // font size on the old (lower-resolution) swap chain
+                // and read as oversized.
+                auto px = display::MeasuredPhysical(panel);
+                if (px.width > 0 && px.height > 0) {
+                    ghostty_surface_set_size(self->m_surface, px.width, px.height);
                 }
             });
     }


### PR DESCRIPTION
## Summary

Centralise the four-line DIPs-to-physical-pixels conversion that every swap-chain-size hand-off to ghostty was repeating, and pick up three call sites that had the conversion missing entirely — which is what caused the visible bug at HiDPI.

- New `App/Display/PhysicalPixels.h`.
- Overload + template dispatch: `EffectiveScales(SwapChainPanel)` reads the panel's per-panel `CompositionScaleX/Y`; `EffectiveScales(FrameworkElement)` falls back to `XamlRoot.RasterizationScale`. `ToPhysicalPixels` / `MeasuredPhysical` are templated so the right overload is selected at compile time from the argument's static type — no runtime `try_as` cost.
- Both paths share the `scale = 0 → fall back to 1.0` guard, so a call site can no longer skip it accidentally.
- Replace all five existing call sites: `MainWindow.CreateTab` (×2), `MainWindow.SplitActivePane`, `TerminalControl` `SizeChanged`, `TerminalControl` `CompositionScaleChanged`.

## Why this fixes the split-on-HiDPI bug

`cfg.platform.windows.initial_width` / `initial_height` are the swap-chain buffer **physical-pixel** resolution. Three sites in `MainWindow.xaml.cpp` were passing `ActualWidth()` straight through — DIPs — without multiplying by the active DPI scale. On a 200 % display:

- A 400-DIP half-pane (the pane area after a horizontal split) reached ghostty as a 400-pixel hint.
- The panel actually composites at 800 physical pixels.
- The swap chain came up at half the panel's resolution, so the host's `SetMatrixTransform` inverse-scale left the rendered content shrunk into the corner of the pane with a black margin until the user resized the window.

Routing everything through `display::MeasuredPhysical` does the multiplication uniformly. Same physical-pixel value lands at ghostty whether the trigger was a tab creation, a split, a layout-time `SizeChanged`, or a DPI change.

## Why overload + template (not runtime dispatch)

`SwapChainPanel.CompositionScaleX/Y` exposes a per-panel composition scale that the existing `CompositionScaleChanged` event hook depends on — losing that path would lose the granular event-driven update on RDP. `FrameworkElement` (Grid, ContentPresenter, …) doesn't expose composition scale at all; `XamlRoot.RasterizationScale` is the right substitute. Two distinct scale sources, picked by the argument's static type via overload resolution. The template above stays a single API surface — `display::MeasuredPhysical(anyElement)` — but compiles down to the right scale call with no runtime `try_as` cost.

## Test plan

- [ ] RDP 200 %: `ctrl+shift+enter` to split, new pane fills the full half-area (no black margin)
- [ ] RDP 200 %: new tab opens at the full content area
- [ ] Local 100 %: split + new tab still work (no regression)
- [ ] Resize the window: text reflows correctly (`SizeChanged` path)
- [ ] Drag the window to a different-DPI monitor: text size adjusts (`CompositionScaleChanged` path)

## Supersedes #79

Closes [#79](https://github.com/i999rri/GhosttyWin32/pull/79) — that PR caught three sites and added the scale conversion inline; centralising it here both fixes the same three sites AND removes the duplication, so they roll into one PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)