### PR TITLE
Introduce TerminalKeyDown / TerminalKeyUp domain objects

### DIFF
--- a/App/App.vcxproj
+++ b/App/App.vcxproj
@@ -164,6 +164,8 @@
     <ClInclude Include="Tabs\TabFactory.h" />
     <ClInclude Include="Tabs\Tabs.h" />
     <ClInclude Include="Display\PhysicalPixels.h" />
+    <ClInclude Include="Input\TerminalKeyDown.h" />
+    <ClInclude Include="Input\TerminalKeyUp.h" />
     <ClInclude Include="TerminalControl.xaml.h">
       <DependentUpon>TerminalControl.xaml</DependentUpon>
     </ClInclude>

--- a/App/App.vcxproj.filters
+++ b/App/App.vcxproj.filters
@@ -29,6 +29,9 @@
     <Filter Include="Display">
       <UniqueIdentifier>{B3E9F5A2-7C8D-4E6A-9F1B-2D5E8C3A6F4D}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Input">
+      <UniqueIdentifier>{A6D4F1B8-3C5E-4978-8B2A-1F7C6E9D5B3A}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Tabs\Tab.h">
@@ -51,6 +54,12 @@
     </ClInclude>
     <ClInclude Include="Display\PhysicalPixels.h">
       <Filter>Display</Filter>
+    </ClInclude>
+    <ClInclude Include="Input\TerminalKeyDown.h">
+      <Filter>Input</Filter>
+    </ClInclude>
+    <ClInclude Include="Input\TerminalKeyUp.h">
+      <Filter>Input</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/App/Input/TerminalKeyDown.h
+++ b/App/Input/TerminalKeyDown.h
@@ -1,0 +1,161 @@
+#pragma once
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <winrt/Microsoft.UI.Xaml.Input.h>
+
+#include "Input/KeyEventTranslator.h"
+
+namespace winrt::GhosttyWin32::implementation::input {
+
+// Domain model for a KeyDown event arriving at TerminalControl.
+//
+// The class answers two kinds of questions:
+//
+//   1. "What did the user mean by this keystroke?" — isImeKeystroke,
+//      isCopyShortcut, isPasteShortcut. The caller reads its own
+//      logic as prose ("if it's a copy shortcut and there's a
+//      selection, copy the selection") instead of bit-fiddling
+//      ctrl/shift/vk at every use site.
+//
+//   2. "What does ghostty need from it?" — toRawKeyPress. The
+//      OS-specific assembly (ToUnicode dance, scan-code + extended
+//      bit, modifier cache) lives here so the translator stays a
+//      pure (RawKeyPress -> ghostty_input_key_s) function with no
+//      Win32 / WinUI dependencies of its own.
+//
+// Construction reads the side-effecting OS state (GetKeyState
+// modifier mask, ImeBuffer.composing()) once and caches it. Every
+// accessor afterwards is a pure read of the snapshot, so the
+// shortcut tests and the toRawKeyPress assembly see the same
+// modifier state the isImeKeystroke check was tested against.
+class TerminalKeyDown {
+public:
+    TerminalKeyDown(
+        winrt::Microsoft::UI::Xaml::Input::KeyRoutedEventArgs const& args,
+        bool ime_composing) noexcept
+        : m_args(args)
+        , m_imeComposing(ime_composing)
+        , m_ctrl((GetKeyState(VK_CONTROL) & 0x8000) != 0)
+        , m_shift((GetKeyState(VK_SHIFT)   & 0x8000) != 0)
+        , m_alt((GetKeyState(VK_MENU)      & 0x8000) != 0)
+    {}
+
+    // ----- domain queries -----
+    //
+    // isImeKeystroke: the IME owns the lifecycle (composing in
+    //   flight, or VK_PROCESSKEY signalling "the IME is about to
+    //   eat this"). The EditContext handlers will react; the
+    //   terminal must not double-encode.
+    // isCopyShortcut: Ctrl+C with no extra modifiers. The host
+    //   intercepts to copy the selection to the OS clipboard, but
+    //   only if a selection actually exists — the call site has to
+    //   check ghostty_surface_has_selection itself. Ctrl+C with no
+    //   selection falls through to ghostty so the SIGINT path runs.
+    // isPasteShortcut: Ctrl+V with no extra modifiers. The host
+    //   reads the clipboard and feeds it via the paste API
+    //   (ghostty_surface_text), bypassing the key-event pipeline.
+    bool isImeKeystroke() const noexcept {
+        return vk() == VK_PROCESSKEY || m_imeComposing;
+    }
+    bool isCopyShortcut() const noexcept {
+        return m_ctrl && !m_shift && vk() == 'C';
+    }
+    bool isPasteShortcut() const noexcept {
+        return m_ctrl && !m_shift && vk() == 'V';
+    }
+
+    // ----- convert to translator input -----
+    //
+    // text_buf owns the OS-translated UTF-8 the resulting
+    // RawKeyPress points at, so it must outlive the returned struct.
+    // The buffer should be at least a few bytes — 16 is comfortable
+    // for any single codepoint plus its UTF-8 expansion.
+    //
+    // Two ToUnicode calls run inside:
+    //
+    //   * One with an empty keyboard state -> unshifted codepoint
+    //     for ghostty's unicode-keyed bindings (`ctrl+shift+t = new_tab`
+    //     matches 't', not the physical-key enum).
+    //   * One with the live keyboard state -> the printable UTF-8
+    //     the keystroke actually produced, populated into `text`
+    //     only for codepoints >= 0x20 (control characters get
+    //     re-encoded by ghostty itself from the scan code).
+    //
+    // Each call drains its dead-key state with VK_SPACE afterwards
+    // so a real keystroke that lands next isn't affected.
+    core::input::RawKeyPress toRawKeyPress(
+        char* text_buf, std::size_t text_buf_size) const noexcept;
+
+    // ----- raw accessors -----
+    int vk() const noexcept { return static_cast<int>(m_args.Key()); }
+    bool ctrl() const noexcept { return m_ctrl; }
+    bool shift() const noexcept { return m_shift; }
+    bool alt() const noexcept { return m_alt; }
+
+private:
+    winrt::Microsoft::UI::Xaml::Input::KeyRoutedEventArgs m_args;
+    bool m_imeComposing;
+    bool m_ctrl;
+    bool m_shift;
+    bool m_alt;
+};
+
+inline core::input::RawKeyPress TerminalKeyDown::toRawKeyPress(
+    char* text_buf, std::size_t text_buf_size) const noexcept
+{
+    auto vk_code   = static_cast<uint32_t>(vk());
+    auto scan_code = static_cast<uint32_t>(m_args.KeyStatus().ScanCode);
+
+    BYTE plain_state[256] = {};
+    wchar_t unshifted_chars[4] = {};
+    int unshifted_count = ToUnicode(
+        vk_code, scan_code, plain_state, unshifted_chars, 4, 0);
+    wchar_t drain1[4] = {};
+    ToUnicode(VK_SPACE, 0x39, plain_state, drain1, 4, 0);
+
+    BYTE live_state[256] = {};
+    GetKeyboardState(live_state);
+    wchar_t live_chars[4] = {};
+    int live_count = ToUnicode(
+        vk_code, scan_code, live_state, live_chars, 4, 0);
+    wchar_t drain2[4] = {};
+    ToUnicode(VK_SPACE, 0x39, live_state, drain2, 4, 0);
+
+    const char* text_ptr = nullptr;
+    if (live_count > 0
+        && live_chars[0] >= 0x20
+        && text_buf
+        && text_buf_size > 1)
+    {
+        int len = WideCharToMultiByte(
+            CP_UTF8, 0, live_chars, live_count,
+            text_buf, static_cast<int>(text_buf_size - 1),
+            nullptr, nullptr);
+        if (len > 0) {
+            text_buf[len] = '\0';
+            text_ptr = text_buf;
+        }
+    }
+
+    return core::input::RawKeyPress{
+        .vk_code     = vk_code,
+        .scan_code   = scan_code,
+        .is_extended = m_args.KeyStatus().IsExtendedKey,
+        .shift       = m_shift,
+        .ctrl        = m_ctrl,
+        .alt         = m_alt,
+        .composing   = false,  // isImeKeystroke already short-circuited the caller
+        .text        = text_ptr,
+        .unshifted_codepoint =
+            (unshifted_count > 0 && unshifted_chars[0] >= 0x20)
+                ? static_cast<uint32_t>(unshifted_chars[0]) : 0u,
+    };
+}
+
+}  // namespace winrt::GhosttyWin32::implementation::input

--- a/App/Input/TerminalKeyUp.h
+++ b/App/Input/TerminalKeyUp.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
+
+#include <cstdint>
+#include <winrt/Microsoft.UI.Xaml.Input.h>
+
+#include "Input/KeyEventTranslator.h"
+
+namespace winrt::GhosttyWin32::implementation::input {
+
+// Domain model for a KeyUp event arriving at TerminalControl.
+// Symmetric with TerminalKeyDown.
+//
+// Release events don't currently drive any host-side shortcut or
+// IME logic of their own — the keystroke is forwarded straight to
+// ghostty so binding triggers that fire on release can resolve.
+// The class exists so the host can talk about "the key the user
+// just released" instead of poking args.Key() directly, and so the
+// translator pipeline keeps a uniform shape
+// (TerminalKey* -> toRaw -> Translate -> ghostty_surface_key) for
+// the press and release sides.
+class TerminalKeyUp {
+public:
+    explicit TerminalKeyUp(
+        winrt::Microsoft::UI::Xaml::Input::KeyRoutedEventArgs const& args) noexcept
+        : m_args(args)
+        , m_ctrl((GetKeyState(VK_CONTROL) & 0x8000) != 0)
+        , m_shift((GetKeyState(VK_SHIFT)   & 0x8000) != 0)
+        , m_alt((GetKeyState(VK_MENU)      & 0x8000) != 0)
+    {}
+
+    core::input::RawKeyRelease toRawKeyRelease() const noexcept {
+        return core::input::RawKeyRelease{
+            .vk_code     = static_cast<uint32_t>(vk()),
+            .scan_code   = static_cast<uint32_t>(m_args.KeyStatus().ScanCode),
+            .is_extended = m_args.KeyStatus().IsExtendedKey,
+            .shift       = m_shift,
+            .ctrl        = m_ctrl,
+            .alt         = m_alt,
+        };
+    }
+
+    int vk() const noexcept { return static_cast<int>(m_args.Key()); }
+    bool ctrl() const noexcept { return m_ctrl; }
+    bool shift() const noexcept { return m_shift; }
+    bool alt() const noexcept { return m_alt; }
+
+private:
+    winrt::Microsoft::UI::Xaml::Input::KeyRoutedEventArgs m_args;
+    bool m_ctrl;
+    bool m_shift;
+    bool m_alt;
+};
+
+}  // namespace winrt::GhosttyWin32::implementation::input

--- a/App/TerminalControl.xaml.cpp
+++ b/App/TerminalControl.xaml.cpp
@@ -3,6 +3,8 @@
 #include "Interop/Encoding.h"
 #include "Host/KeyModifiers.h"
 #include "Input/KeyEventTranslator.h"
+#include "Input/TerminalKeyDown.h"
+#include "Input/TerminalKeyUp.h"
 #include "Display/PhysicalPixels.h"
 #include "Win32/Clipboard.h"
 #include <dxgi1_3.h>
@@ -190,34 +192,34 @@ namespace winrt::GhosttyWin32::implementation
             auto self = weakSelf.get();
             if (!self || !self->m_surface) return;
 
-            int vk = static_cast<int>(args.Key());
-            UINT scanCode = args.KeyStatus().ScanCode;
-            bool ctrl = GetKeyState(VK_CONTROL) & 0x8000;
-            bool shift = GetKeyState(VK_SHIFT) & 0x8000;
+            input::TerminalKeyDown key(args, self->m_ime.composing());
 
-            // IME is processing this key — let the EditContext handlers
-            // own the composition lifecycle, and don't double-encode
+            // IME owns the composition lifecycle; don't double-encode
             // into the pty.
-            if (vk == VK_PROCESSKEY || self->m_ime.composing()) return;
+            if (key.isImeKeystroke()) return;
 
-            // Ctrl+C: copy selection if any, otherwise fall through to
-            // ghostty_surface_key so the SIGINT path runs.
-            if (ctrl && !shift && vk == 'C') {
-                if (ghostty_surface_has_selection(self->m_surface)) {
-                    ghostty_text_s text = {};
-                    if (ghostty_surface_read_selection(self->m_surface, &text) && text.text && text.text_len > 0) {
-                        win32::Clipboard::write(self->m_hostHwnd, interop::Encoding::toUtf16(text.text, static_cast<int>(text.text_len)));
-                        ghostty_surface_free_text(self->m_surface, &text);
-                    }
-                    ghostty_surface_mouse_button(self->m_surface, GHOSTTY_MOUSE_PRESS, GHOSTTY_MOUSE_LEFT, (ghostty_input_mods_e)0);
-                    ghostty_surface_mouse_button(self->m_surface, GHOSTTY_MOUSE_RELEASE, GHOSTTY_MOUSE_LEFT, (ghostty_input_mods_e)0);
-                    args.Handled(true);
-                    return;
+            // Copy shortcut with a live selection: write to the OS
+            // clipboard and clear the selection. Ctrl+C with no
+            // selection falls through to ghostty so the SIGINT path
+            // runs.
+            if (key.isCopyShortcut()
+                && ghostty_surface_has_selection(self->m_surface))
+            {
+                ghostty_text_s text = {};
+                if (ghostty_surface_read_selection(self->m_surface, &text) && text.text && text.text_len > 0) {
+                    win32::Clipboard::write(self->m_hostHwnd, interop::Encoding::toUtf16(text.text, static_cast<int>(text.text_len)));
+                    ghostty_surface_free_text(self->m_surface, &text);
                 }
+                ghostty_surface_mouse_button(self->m_surface, GHOSTTY_MOUSE_PRESS, GHOSTTY_MOUSE_LEFT, (ghostty_input_mods_e)0);
+                ghostty_surface_mouse_button(self->m_surface, GHOSTTY_MOUSE_RELEASE, GHOSTTY_MOUSE_LEFT, (ghostty_input_mods_e)0);
+                args.Handled(true);
+                return;
             }
 
-            // Ctrl+V: paste from clipboard.
-            if (ctrl && !shift && vk == 'V') {
+            // Paste shortcut: read the OS clipboard and feed it as
+            // text. The paste API (ghostty_surface_text) is the
+            // bracketed-paste path on ghostty's side.
+            if (key.isPasteShortcut()) {
                 auto utf8 = interop::Encoding::toUtf8(win32::Clipboard::read(self->m_hostHwnd));
                 if (!utf8.empty()) {
                     ghostty_surface_text(self->m_surface, utf8.c_str(), utf8.size());
@@ -228,64 +230,11 @@ namespace winrt::GhosttyWin32::implementation
                 return;
             }
 
-            // Two ToUnicode calls feed two separate ghostty fields:
-            //
-            //   * `unshifted_codepoint` — keystroke with no modifiers
-            //     held, used by ghostty to match unicode-keyed
-            //     bindings (`keybind = ctrl+shift+t = new_tab`
-            //     matches against 't', not against the physical-key
-            //     enum). Computed via an empty key-state buffer.
-            //
-            //   * `text` — the OS-translated UTF-8 the keystroke
-            //     actually produces with live modifiers held. ghostty's
-            //     encoder writes this to the pty via the legacy
-            //     fallback when no binding matches, so this is how
-            //     printable input reaches the terminal. Restricted to
-            //     codepoints >= 0x20 — control characters get encoded
-            //     by ghostty's ctrlSeq / pcStyleFunctionKey paths from
-            //     the scan code, and passing them through `text` would
-            //     double-write.
-            //
-            // Each ToUnicode call can leave dead-key state in the
-            // local buffer; drain with VK_SPACE so the next real
-            // keystroke isn't affected.
-            BYTE plainState[256] = {};
-            wchar_t unshiftedChars[4] = {};
-            int unshiftedCount = ToUnicode(vk, scanCode, plainState, unshiftedChars, 4, 0);
-            wchar_t drain1[4] = {};
-            ToUnicode(VK_SPACE, 0x39, plainState, drain1, 4, 0);
-
+            // Forward as ordinary terminal input. textBuf owns the
+            // OS-translated UTF-8 the RawKeyPress.text pointer
+            // references, so it has to outlive `raw`.
             char textBuf[16] = {};
-            const char* textPtr = nullptr;
-            BYTE liveState[256] = {};
-            GetKeyboardState(liveState);
-            wchar_t liveChars[4] = {};
-            int liveCount = ToUnicode(vk, scanCode, liveState, liveChars, 4, 0);
-            wchar_t drain2[4] = {};
-            ToUnicode(VK_SPACE, 0x39, liveState, drain2, 4, 0);
-            if (liveCount > 0 && liveChars[0] >= 0x20) {
-                int len = WideCharToMultiByte(
-                    CP_UTF8, 0, liveChars, liveCount,
-                    textBuf, sizeof(textBuf) - 1, nullptr, nullptr);
-                if (len > 0) {
-                    textBuf[len] = '\0';
-                    textPtr = textBuf;
-                }
-            }
-
-            core::input::RawKeyPress raw{
-                .vk_code     = static_cast<uint32_t>(vk),
-                .scan_code   = scanCode,
-                .is_extended = args.KeyStatus().IsExtendedKey,
-                .shift       = shift,
-                .ctrl        = ctrl,
-                .alt         = (GetKeyState(VK_MENU) & 0x8000) != 0,
-                .composing   = false,  // IME path already short-circuited above
-                .text        = textPtr,
-                .unshifted_codepoint =
-                    (unshiftedCount > 0 && unshiftedChars[0] >= 0x20)
-                        ? static_cast<uint32_t>(unshiftedChars[0]) : 0u,
-            };
+            auto raw = key.toRawKeyPress(textBuf, sizeof(textBuf));
             auto keyEvent = core::input::Translate(raw);
             ghostty_surface_key(self->m_surface, keyEvent);
 
@@ -297,14 +246,8 @@ namespace winrt::GhosttyWin32::implementation
         KeyUp([weakSelf](auto&&, muxi::KeyRoutedEventArgs const& args) {
             auto self = weakSelf.get();
             if (!self || !self->m_surface) return;
-            core::input::RawKeyRelease raw{
-                .vk_code     = static_cast<uint32_t>(args.Key()),
-                .scan_code   = args.KeyStatus().ScanCode,
-                .is_extended = args.KeyStatus().IsExtendedKey,
-                .shift       = (GetKeyState(VK_SHIFT) & 0x8000) != 0,
-                .ctrl        = (GetKeyState(VK_CONTROL) & 0x8000) != 0,
-                .alt         = (GetKeyState(VK_MENU) & 0x8000) != 0,
-            };
+            input::TerminalKeyUp key(args);
+            auto raw = key.toRawKeyRelease();
             auto keyEvent = core::input::Translate(raw);
             ghostty_surface_key(self->m_surface, keyEvent);
         });

--- a/Tests/test_key_event_translator.cpp
+++ b/Tests/test_key_event_translator.cpp
@@ -56,8 +56,8 @@ TEST(KeyEventTranslatorTest, ReleaseOverloadProducesActionRelease) {
 
 TEST(KeyEventTranslatorTest, ModsBitmaskFromIndividualFlags) {
     RawKeyPress raw{
-        .ctrl  = true,
         .shift = true,
+        .ctrl  = true,
     };
 
     auto out = Translate(raw);


### PR DESCRIPTION
## Summary

Wrap the WinUI 3 key-event extraction in a pair of host-side domain objects so the TerminalControl handlers read as prose instead of bit fiddling.

- `App/Input/TerminalKeyDown.h` — wraps `KeyRoutedEventArgs` + the IME composing flag + the live Win32 modifier state. Answers domain questions (`isImeKeystroke`, `isCopyShortcut`, `isPasteShortcut`) and exposes `toRawKeyPress(text_buf, size)` for handing off to the translator. Construction reads `GetKeyState` once and caches it — the shortcut tests and the toRawKeyPress assembly share the same snapshot the IME guard was tested against.
- `App/Input/TerminalKeyUp.h` — symmetric for the release side. No domain queries today (release events don't drive any host-side shortcut or IME logic), but the class exists so the host can talk about "the key the user released" instead of poking `args.Key()` directly, and so the translator pipeline keeps a uniform shape on both sides.

## What the call site reads like

```cpp
KeyDown([weakSelf](auto&&, args) {
    auto self = weakSelf.get();
    if (!self || !self->m_surface) return;

    input::TerminalKeyDown key(args, self->m_ime.composing());

    if (key.isImeKeystroke()) return;

    if (key.isCopyShortcut() && ghostty_surface_has_selection(self->m_surface)) {
        // copy selection to clipboard, return
    }
    if (key.isPasteShortcut()) {
        // paste clipboard into terminal, return
    }

    char textBuf[16] = {};
    auto raw = key.toRawKeyPress(textBuf, sizeof(textBuf));
    auto event = core::input::Translate(raw);
    ghostty_surface_key(self->m_surface, event);
});
```

The handler reads in domain language ("if it's a copy shortcut and there's a selection, copy") instead of `ctrl && !shift && vk == 'C'` repeated at every branch.

## Layering

| Layer | Lives in | Depends on | Owns |
|---|---|---|---|
| `core::input::Translate` (closes #60) | `Core/Input/KeyEventTranslator.h` | `ghostty.h` only | `RawKeyPress` / `RawKeyRelease` to `ghostty_input_key_s` |
| `input::TerminalKey{Down,Up}` (new) | `App/Input/` | WinUI 3 + Win32 + KeyEventTranslator | WinUI args + IME state + modifier cache; ToUnicode assembly; domain queries |
| `TerminalControl::KeyDown/KeyUp` | App | both | side-effecting branches (clipboard, ghostty_surface_key) |

The translator stays a pure function with no Win32 or WinUI dependencies. The domain objects sit between WinUI's raw args and the translator's primitive snapshot, and bundle the OS-state assembly that the previous inline code spread across the handler and a flat helper file.

## What this replaces

The previous draft of this PR introduced `App/Input/XamlKeyEvent.h` with free functions `FromKeyDown` / `FromKeyUp`. Those have been folded into `TerminalKeyDown::toRawKeyPress` / `TerminalKeyUp::toRawKeyRelease` — same OS-state assembly, but expressed as methods on the domain object that already holds the cached modifier state, so the helper file goes away.

## Base branch

Stacked on top of [#81](https://github.com/i999rri/GhosttyWin32/pull/81) (`refactor/key-event-translator`). Once #81 merges, this PR retargets to `dev` cleanly.

## Test plan

Same matrix as #81 — refactor is behaviour-preserving:

- [x] F11 fires `toggle_fullscreen` (function-key physical route)
- [x] F9 fires `reset_window_size` (function-key physical route, secondary check)
- [x] Unicode digit bindings (`ctrl+shift+one`, `two`, `nine`) fire `reset_window_size` (unicode route)
- [x] Physical digit binding (`ctrl+shift+physical:two`) fires `reset_window_size` (digit-physical route)
- [x] Printable input types into the pty
- [x] Backspace / Delete work
- [x] Ctrl+C with selection → clipboard copy
- [x] Ctrl+C with no selection → SIGINT
- [x] Ctrl+V paste works
- [x] IME composition works

### Known limitation (out of scope)

`Ctrl+Shift+0` does not fire on Japanese-IME systems because the keystroke is consumed by TSF / IME before WinUI 3 raises `KeyDown` — see #83. Not a regression; same behaviour in any app on the affected system. Other digits (1..9, both unicode and physical routes) are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)