### PR TITLE
Introduce core::ghostty::Surface wrapper

### DIFF
--- a/App/MainWindow.xaml.cpp
+++ b/App/MainWindow.xaml.cpp
@@ -704,7 +704,7 @@ namespace winrt::GhosttyWin32::implementation
             if (!tc || !tc->Surface()) return false;
             auto utf8 = interop::Encoding::toUtf8(win32::Clipboard::read(g_mainWindow->m_hwnd));
             if (utf8.empty()) return false;
-            ghostty_surface_complete_clipboard_request(tc->Surface(), utf8.c_str(), state, false);
+            tc->Surface().CompleteClipboardRequest(utf8.c_str(), state, false);
             return true;
         };
         rtConfig.confirm_read_clipboard_cb = [](void*, const char* content, void* state, ghostty_clipboard_request_e) {
@@ -712,7 +712,7 @@ namespace winrt::GhosttyWin32::implementation
             if (g_mainWindow) {
                 auto* tc = g_mainWindow->ActiveControl();
                 if (tc && tc->Surface()) {
-                    ghostty_surface_complete_clipboard_request(tc->Surface(), content, state, true);
+                    tc->Surface().CompleteClipboardRequest(content, state, true);
                 }
             }
         };
@@ -1328,7 +1328,7 @@ namespace winrt::GhosttyWin32::implementation
             if (!node) return nullptr;
             if (node->IsLeaf()) {
                 auto* tc = Tab::LeafToTerminalControl(*node);
-                return (tc && tc->Surface() == surface) ? node : nullptr;
+                return (tc && tc->Surface().Owns(surface)) ? node : nullptr;
             }
             if (auto* p = FindLeafForSurface(node->First(), surface)) return p;
             return FindLeafForSurface(node->Second(), surface);
@@ -1711,7 +1711,7 @@ namespace winrt::GhosttyWin32::implementation
             // outlive the underlying ghostty_surface_t. The next
             // TerminalControl::GotFocus on the retargeted sibling (or
             // a new tab) will refill the slot.
-            if (tc->Surface() == m_activeSurface) m_activeSurface = nullptr;
+            if (tc->Surface().Owns(m_activeSurface)) m_activeSurface = nullptr;
             tc->Detach();
         }
 

--- a/App/Tabs/Tabs.h
+++ b/App/Tabs/Tabs.h
@@ -135,7 +135,7 @@ private:
     static Pane* FindLeafBySurfaceRecursive(Pane* node, ghostty_surface_t surface) {
         if (!node) return nullptr;
         if (node->IsLeaf()) {
-            if (auto* c = Tab::LeafToTerminalControl(*node); c && c->Surface() == surface) {
+            if (auto* c = Tab::LeafToTerminalControl(*node); c && c->Surface().Owns(surface)) {
                 return node;
             }
             return nullptr;

--- a/App/TerminalControl.xaml.cpp
+++ b/App/TerminalControl.xaml.cpp
@@ -103,7 +103,7 @@ namespace winrt::GhosttyWin32::implementation
             // reaching into MainWindow globals from inside the
             // control.
             if (self->m_onFocused && self->m_surface) {
-                self->m_onFocused(self->m_surface);
+                self->m_onFocused(self->m_surface.Handle());
             }
         });
 
@@ -119,7 +119,7 @@ namespace winrt::GhosttyWin32::implementation
             if (!self || !self->m_surface) return;
             muix::PointerPoint point = args.GetCurrentPoint(self->Panel());
             auto pos = point.Position();
-            ghostty_surface_mouse_pos(self->m_surface, pos.X, pos.Y, host::currentMods());
+            self->m_surface.MousePos(pos.X, pos.Y, host::currentMods());
         });
 
         PointerPressed([weakSelf](auto&&, muxi::PointerRoutedEventArgs const& args) {
@@ -144,29 +144,29 @@ namespace winrt::GhosttyWin32::implementation
             } else if (props.IsRightButtonPressed()) {
                 // Right-click: copy selection if there is one,
                 // otherwise treat as a normal right button press.
-                if (ghostty_surface_has_selection(self->m_surface)) {
+                if (self->m_surface.HasSelection()) {
                     ghostty_text_s text = {};
-                    if (ghostty_surface_read_selection(self->m_surface, &text) && text.text && text.text_len > 0) {
+                    if (self->m_surface.ReadSelection(&text) && text.text && text.text_len > 0) {
                         win32::Clipboard::write(self->m_hostHwnd, interop::Encoding::toUtf16(text.text, static_cast<int>(text.text_len)));
-                        ghostty_surface_free_text(self->m_surface, &text);
+                        self->m_surface.FreeText(&text);
                     }
                     // Click-then-release without modifiers clears the
                     // selection in ghostty, matching the macOS gesture.
-                    ghostty_surface_mouse_button(self->m_surface, GHOSTTY_MOUSE_PRESS, GHOSTTY_MOUSE_LEFT, (ghostty_input_mods_e)0);
-                    ghostty_surface_mouse_button(self->m_surface, GHOSTTY_MOUSE_RELEASE, GHOSTTY_MOUSE_LEFT, (ghostty_input_mods_e)0);
+                    self->m_surface.MouseButton(GHOSTTY_MOUSE_PRESS, GHOSTTY_MOUSE_LEFT, (ghostty_input_mods_e)0);
+                    self->m_surface.MouseButton(GHOSTTY_MOUSE_RELEASE, GHOSTTY_MOUSE_LEFT, (ghostty_input_mods_e)0);
                     return;
                 }
                 btn = GHOSTTY_MOUSE_RIGHT;
             } else {
                 return;
             }
-            ghostty_surface_mouse_button(self->m_surface, GHOSTTY_MOUSE_PRESS, btn, host::currentMods());
+            self->m_surface.MouseButton(GHOSTTY_MOUSE_PRESS, btn, host::currentMods());
         });
 
         PointerReleased([weakSelf](auto&&, muxi::PointerRoutedEventArgs const& args) {
             auto self = weakSelf.get();
             if (!self || !self->m_surface) return;
-            ghostty_surface_mouse_button(self->m_surface, GHOSTTY_MOUSE_RELEASE, GHOSTTY_MOUSE_LEFT, host::currentMods());
+            self->m_surface.MouseButton(GHOSTTY_MOUSE_RELEASE, GHOSTTY_MOUSE_LEFT, host::currentMods());
             args.Handled(true);
         });
 
@@ -178,7 +178,7 @@ namespace winrt::GhosttyWin32::implementation
             int delta = props.MouseWheelDelta();
             double scrollY = (double)delta / 120.0;
             ghostty_input_scroll_mods_t smods = {};
-            ghostty_surface_mouse_scroll(self->m_surface, 0, scrollY, smods);
+            self->m_surface.MouseScroll(0, scrollY, smods);
             args.Handled(true);
         });
 
@@ -203,15 +203,15 @@ namespace winrt::GhosttyWin32::implementation
             // selection falls through to ghostty so the SIGINT path
             // runs.
             if (key.isCopyShortcut()
-                && ghostty_surface_has_selection(self->m_surface))
+                && self->m_surface.HasSelection())
             {
                 ghostty_text_s text = {};
-                if (ghostty_surface_read_selection(self->m_surface, &text) && text.text && text.text_len > 0) {
+                if (self->m_surface.ReadSelection(&text) && text.text && text.text_len > 0) {
                     win32::Clipboard::write(self->m_hostHwnd, interop::Encoding::toUtf16(text.text, static_cast<int>(text.text_len)));
-                    ghostty_surface_free_text(self->m_surface, &text);
+                    self->m_surface.FreeText(&text);
                 }
-                ghostty_surface_mouse_button(self->m_surface, GHOSTTY_MOUSE_PRESS, GHOSTTY_MOUSE_LEFT, (ghostty_input_mods_e)0);
-                ghostty_surface_mouse_button(self->m_surface, GHOSTTY_MOUSE_RELEASE, GHOSTTY_MOUSE_LEFT, (ghostty_input_mods_e)0);
+                self->m_surface.MouseButton(GHOSTTY_MOUSE_PRESS, GHOSTTY_MOUSE_LEFT, (ghostty_input_mods_e)0);
+                self->m_surface.MouseButton(GHOSTTY_MOUSE_RELEASE, GHOSTTY_MOUSE_LEFT, (ghostty_input_mods_e)0);
                 args.Handled(true);
                 return;
             }
@@ -222,10 +222,10 @@ namespace winrt::GhosttyWin32::implementation
             if (key.isPasteShortcut()) {
                 auto utf8 = interop::Encoding::toUtf8(win32::Clipboard::read(self->m_hostHwnd));
                 if (!utf8.empty()) {
-                    ghostty_surface_text(self->m_surface, utf8.c_str(), utf8.size());
+                    self->m_surface.Text(utf8.c_str(), utf8.size());
                 }
                 if (self->m_app) ghostty_app_tick(self->m_app);
-                ghostty_surface_refresh(self->m_surface);
+                self->m_surface.Refresh();
                 args.Handled(true);
                 return;
             }
@@ -236,10 +236,10 @@ namespace winrt::GhosttyWin32::implementation
             char textBuf[16] = {};
             auto raw = key.toRawKeyPress(textBuf, sizeof(textBuf));
             auto keyEvent = core::input::Translate(raw);
-            ghostty_surface_key(self->m_surface, keyEvent);
+            self->m_surface.Key(keyEvent);
 
             if (self->m_app) ghostty_app_tick(self->m_app);
-            ghostty_surface_refresh(self->m_surface);
+            self->m_surface.Refresh();
             args.Handled(true);
         });
 
@@ -249,7 +249,7 @@ namespace winrt::GhosttyWin32::implementation
             input::TerminalKeyUp key(args);
             auto raw = key.toRawKeyRelease();
             auto keyEvent = core::input::Translate(raw);
-            ghostty_surface_key(self->m_surface, keyEvent);
+            self->m_surface.Key(keyEvent);
         });
 
         // Terminals default to a text-input cursor; ghostty issues a
@@ -350,7 +350,7 @@ namespace winrt::GhosttyWin32::implementation
                                  std::shared_ptr<SwapChainChangedContext> swapChainChangedContext)
     {
         m_app = app;
-        m_surface = surface;
+        m_surface = core::ghostty::Surface(surface);
         m_compositionHandle = compositionHandle;
         m_hostHwnd = hostHwnd;
         m_attachRequest = std::move(attachRequest);
@@ -382,7 +382,7 @@ namespace winrt::GhosttyWin32::implementation
                 auto panel = sender.as<Microsoft::UI::Xaml::Controls::SwapChainPanel>();
                 auto px = display::ToPhysicalPixels(panel, sz.Width, sz.Height);
                 if (px.width > 0 && px.height > 0) {
-                    ghostty_surface_set_size(self->m_surface, px.width, px.height);
+                    self->m_surface.SetSize(px.width, px.height);
                 }
             });
 
@@ -412,7 +412,7 @@ namespace winrt::GhosttyWin32::implementation
                     self->m_swapChainChangedContext->compositionScale.store(
                         sx, std::memory_order_release);
                 }
-                ghostty_surface_set_content_scale(self->m_surface, sx, sy);
+                self->m_surface.SetContentScale(sx, sy);
                 // When the composition scale changes, the panel's DIP
                 // size hasn't necessarily changed (so XAML may not fire
                 // SizeChanged) but the physical-pixel footprint has.
@@ -422,7 +422,7 @@ namespace winrt::GhosttyWin32::implementation
                 // and read as oversized.
                 auto px = display::MeasuredPhysical(panel);
                 if (px.width > 0 && px.height > 0) {
-                    ghostty_surface_set_size(self->m_surface, px.width, px.height);
+                    self->m_surface.SetSize(px.width, px.height);
                 }
             });
     }
@@ -477,10 +477,12 @@ namespace winrt::GhosttyWin32::implementation
             // point with the kernel handle already invalid, which it
             // tolerates without faulting.
         }
-        if (m_surface) {
-            ghostty_surface_free(m_surface);
-            m_surface = nullptr;
-        }
+        // Wrapper dtor would free anyway, but the renderer-thread join
+        // happens inside ghostty_surface_free and must run BEFORE
+        // m_swapChainChangedContext goes out of scope below — so we
+        // drive the free explicitly here at the right point in the
+        // Detach sequence rather than waiting for the dtor.
+        m_surface.Reset();
         if (m_compositionHandle) {
             CloseHandle(m_compositionHandle);
             m_compositionHandle = nullptr;
@@ -533,15 +535,15 @@ namespace winrt::GhosttyWin32::implementation
                                         newText.c_str(), newText.size());
             if (self->m_ime.composing()) {
                 if (self->m_ime.text().empty()) {
-                    ghostty_surface_preedit(self->m_surface, nullptr, 0);
+                    self->m_surface.Preedit(nullptr, 0);
                 } else {
                     auto utf8 = interop::Encoding::toUtf8(self->m_ime.text());
                     if (!utf8.empty())
-                        ghostty_surface_preedit(self->m_surface, utf8.c_str(), utf8.size());
+                        self->m_surface.Preedit(utf8.c_str(), utf8.size());
                 }
             }
             if (self->m_app) ghostty_app_tick(self->m_app);
-            ghostty_surface_refresh(self->m_surface);
+            self->m_surface.Refresh();
         });
 
         m_editContext.CompositionStarted([weakSelf](
@@ -558,13 +560,13 @@ namespace winrt::GhosttyWin32::implementation
             auto self = weakSelf.get();
             if (!self) return;
             if (self->m_surface) {
-                ghostty_surface_preedit(self->m_surface, nullptr, 0);
+                self->m_surface.Preedit(nullptr, 0);
                 auto utf8 = interop::Encoding::toUtf8(self->m_ime.text());
                 if (!utf8.empty()) {
-                    ghostty_surface_text(self->m_surface, utf8.c_str(), utf8.size());
+                    self->m_surface.Text(utf8.c_str(), utf8.size());
                 }
                 if (self->m_app) ghostty_app_tick(self->m_app);
-                ghostty_surface_refresh(self->m_surface);
+                self->m_surface.Refresh();
             }
             self->m_ime.compositionCompleted();
         });
@@ -575,7 +577,7 @@ namespace winrt::GhosttyWin32::implementation
             auto self = weakSelf.get();
             if (!self || !self->m_surface || !self->m_hostHwnd) return;
             double x = 0, y = 0, w = 0, h = 0;
-            ghostty_surface_ime_point(self->m_surface, &x, &y, &w, &h);
+            self->m_surface.ImePoint(&x, &y, &w, &h);
             POINT screenPt = { (LONG)x, (LONG)y };
             ClientToScreen(self->m_hostHwnd, &screenPt);
             winrt::Windows::Foundation::Rect bounds{
@@ -591,7 +593,7 @@ namespace winrt::GhosttyWin32::implementation
             if (self->m_ime.composing()) {
                 self->m_ime.reset();
                 if (self->m_surface)
-                    ghostty_surface_preedit(self->m_surface, nullptr, 0);
+                    self->m_surface.Preedit(nullptr, 0);
             }
         });
     }

--- a/App/TerminalControl.xaml.h
+++ b/App/TerminalControl.xaml.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "TerminalControl.g.h"
+#include "Ghostty/Surface.h"
 #include "Host/ImeBuffer.h"
 #include "Interop/Encoding.h"
 #include "Win32/Clipboard.h"
@@ -141,7 +142,14 @@ namespace winrt::GhosttyWin32::implementation
         static void OnSwapChainChanged(void* swap_chain, void* userdata) noexcept;
 
         // Implementation-only accessors used by Tab.
-        ghostty_surface_t Surface() const noexcept { return m_surface; }
+        //
+        // Surface() returns the wrapper itself so call sites can issue
+        // typed operations (Refresh, Key, MouseButton, …) without
+        // touching raw ghostty C API. Identity-comparison call sites
+        // (action callbacks, FindLeafBySurface) compare via
+        // `tc->Surface().Handle()` against ghostty's raw handle.
+        core::ghostty::Surface const& Surface() const noexcept { return m_surface; }
+        core::ghostty::Surface& Surface() noexcept { return m_surface; }
         HANDLE CompositionHandle() const noexcept { return m_compositionHandle; }
 
         // Apply a ghostty-requested mouse cursor shape. Must be called on
@@ -189,7 +197,7 @@ namespace winrt::GhosttyWin32::implementation
         void SetupImeContext();
 
         ghostty_app_t m_app{ nullptr };
-        ghostty_surface_t m_surface{ nullptr };
+        core::ghostty::Surface m_surface{};
         HANDLE m_compositionHandle{ nullptr };
         // Host window HWND — used for Win32 APIs that need a window
         // owner (clipboard read/write, IME bounds in screen coords).

--- a/Core/Core.vcxproj
+++ b/Core/Core.vcxproj
@@ -86,6 +86,7 @@
     <ClInclude Include="Ghostty\App.h" />
     <ClInclude Include="Ghostty\CallbackDispatcher.h" />
     <ClInclude Include="Ghostty\Config.h" />
+    <ClInclude Include="Ghostty\Surface.h" />
     <ClInclude Include="Host\IWindow.h" />
     <ClInclude Include="Host\ImeBuffer.h" />
     <ClInclude Include="Host\KeyModifiers.h" />

--- a/Core/Core.vcxproj.filters
+++ b/Core/Core.vcxproj.filters
@@ -45,6 +45,9 @@
     <ClInclude Include="Ghostty\Config.h">
       <Filter>Ghostty</Filter>
     </ClInclude>
+    <ClInclude Include="Ghostty\Surface.h">
+      <Filter>Ghostty</Filter>
+    </ClInclude>
     <ClInclude Include="Host\IWindow.h">
       <Filter>Host</Filter>
     </ClInclude>

--- a/Core/Ghostty/Surface.h
+++ b/Core/Ghostty/Surface.h
@@ -1,0 +1,138 @@
+#pragma once
+
+#include "ghostty.h"
+
+#include <cstdint>
+#include <utility>
+
+namespace core::ghostty {
+
+// RAII wrapper around a single ghostty_surface_t.
+//
+// Owns the handle: dtor (and Reset) call ghostty_surface_free. The
+// destructor is the safety net — TerminalControl::Detach drives the
+// real teardown order (stop SizeChanged / swap-chain-changed callbacks
+// → call Reset() → release the shared_ptr the renderer thread watches),
+// because ghostty_surface_free joins the renderer thread and must
+// happen at exactly that point. The wrapper just makes "free the
+// handle" expressible as `m_surface.reset()` instead of a raw call.
+//
+// Every typed method is a no-op when the wrapper is empty, so call
+// sites don't need to null-check the handle themselves.
+class Surface {
+public:
+    Surface() noexcept = default;
+    explicit Surface(ghostty_surface_t handle) noexcept : m_handle(handle) {}
+
+    Surface(Surface const&) = delete;
+    Surface& operator=(Surface const&) = delete;
+
+    Surface(Surface&& other) noexcept
+        : m_handle(std::exchange(other.m_handle, nullptr)) {}
+
+    Surface& operator=(Surface&& other) noexcept {
+        if (this != &other) {
+            Reset();
+            m_handle = std::exchange(other.m_handle, nullptr);
+        }
+        return *this;
+    }
+
+    ~Surface() { Reset(); }
+
+    void Reset() noexcept {
+        if (m_handle) {
+            ghostty_surface_free(m_handle);
+            m_handle = nullptr;
+        }
+    }
+
+    // Raw handle escape hatch — for libghostty APIs we haven't wrapped
+    // yet, and for C action callbacks that receive the handle from
+    // ghostty itself and need to compare it against ours.
+    ghostty_surface_t Handle() const noexcept { return m_handle; }
+
+    explicit operator bool() const noexcept { return m_handle != nullptr; }
+
+    // True when this wrapper owns the given raw ghostty_surface_t.
+    // Identity is the underlying pointer — libghostty action callbacks
+    // hand the host a raw handle and the host walks its windows /
+    // tabs / leaves asking "which Surface owns this?" to route the
+    // action to the right TerminalControl. Spelled out as a method
+    // rather than operator== so the call site reads as ownership
+    // ("is this the surface that owns that handle?") instead of an
+    // unexplained pointer comparison.
+    bool Owns(ghostty_surface_t handle) const noexcept {
+        return m_handle == handle;
+    }
+
+    // ---- input ----
+    bool Key(ghostty_input_key_s ev) noexcept {
+        return m_handle && ghostty_surface_key(m_handle, ev);
+    }
+    void Text(char const* text, uintptr_t len) noexcept {
+        if (m_handle) ghostty_surface_text(m_handle, text, len);
+    }
+    void Preedit(char const* text, uintptr_t len) noexcept {
+        if (m_handle) ghostty_surface_preedit(m_handle, text, len);
+    }
+
+    // ---- mouse ----
+    bool MouseButton(ghostty_input_mouse_state_e state,
+                     ghostty_input_mouse_button_e button,
+                     ghostty_input_mods_e mods) noexcept {
+        return m_handle &&
+            ghostty_surface_mouse_button(m_handle, state, button, mods);
+    }
+    void MousePos(double x, double y, ghostty_input_mods_e mods) noexcept {
+        if (m_handle) ghostty_surface_mouse_pos(m_handle, x, y, mods);
+    }
+    void MouseScroll(double dx, double dy,
+                     ghostty_input_scroll_mods_t mods) noexcept {
+        if (m_handle) ghostty_surface_mouse_scroll(m_handle, dx, dy, mods);
+    }
+
+    // ---- render / lifecycle ----
+    void Refresh() noexcept {
+        if (m_handle) ghostty_surface_refresh(m_handle);
+    }
+    void SetSize(uint32_t w, uint32_t h) noexcept {
+        if (m_handle) ghostty_surface_set_size(m_handle, w, h);
+    }
+    void SetContentScale(double x, double y) noexcept {
+        if (m_handle) ghostty_surface_set_content_scale(m_handle, x, y);
+    }
+
+    // ---- selection ----
+    bool HasSelection() const noexcept {
+        return m_handle && ghostty_surface_has_selection(m_handle);
+    }
+    bool ReadSelection(ghostty_text_s* out) const noexcept {
+        return m_handle && ghostty_surface_read_selection(m_handle, out);
+    }
+    void FreeText(ghostty_text_s* text) noexcept {
+        if (m_handle) ghostty_surface_free_text(m_handle, text);
+    }
+
+    // ---- IME ----
+    void ImePoint(double* x, double* y, double* w, double* h) noexcept {
+        if (m_handle) ghostty_surface_ime_point(m_handle, x, y, w, h);
+    }
+
+    // ---- clipboard callback completion ----
+    // Called from the read-clipboard / confirm-read-clipboard runtime
+    // callbacks to hand the clipboard content back to ghostty for
+    // whichever surface requested it.
+    void CompleteClipboardRequest(char const* content, void* state,
+                                  bool confirmed) noexcept {
+        if (m_handle) {
+            ghostty_surface_complete_clipboard_request(
+                m_handle, content, state, confirmed);
+        }
+    }
+
+private:
+    ghostty_surface_t m_handle{ nullptr };
+};
+
+}  // namespace core::ghostty


### PR DESCRIPTION
## Summary

Wrap `ghostty_surface_t` in a small RAII type `core::ghostty::Surface` so the typed surface API (`Key`, `Text`, `Refresh`, `MouseButton`, `MousePos`, `HasSelection`, `Preedit`, `ImePoint`, …) becomes methods on a real object instead of a forest of free-function calls. Same handle, same lifecycle, just expressed at a higher altitude.

## Why this PR exists

Before this change, `ghostty_surface_*` is called inline at every input / IME / mouse / clipboard site that has `m_surface` in scope (~80 call sites across 6 files). Each call site repeats the same null-check and the same `ghostty_surface_xxx(m_surface, ...)` shape. The set of operations available on a surface is **not** discoverable from the type — it's the union of every site that happens to call into one of those C functions.

The wrapper makes the surface a proper domain object: what you can do to it is visible on the type, the null-check lives in one place, and the call sites read in domain language (`m_surface.Key(ev)`, `tc->Surface().HasSelection()`, `tc->Surface().Owns(handle)`).

## What changed

- **`Core/Ghostty/Surface.h` (new).** RAII wrapper.
  - Owns the handle. Dtor calls `ghostty_surface_free`; `Reset()` lets the caller drive the free at exactly the right point in a teardown sequence (TerminalControl::Detach has to free the surface in a specific order against the renderer-thread join and the swap-chain-changed callback shutdown).
  - One method per ghostty surface operation. Each one no-ops when the handle is null, so call sites stop repeating the guard.
  - **`Owns(ghostty_surface_t)`** rather than `operator==` for identity comparison — `c->Surface().Owns(s)` reads as ownership, while `c->Surface() == s` would look like an unexplained pointer comparison at the call site.
  - `Handle()` and `explicit operator bool` kept as escape hatches for the few sites that still need raw (focus-notification callback signature, mock interfaces in Tests).
- **`App/TerminalControl.xaml.{h,cpp}`.** `m_surface` is now the wrapper. `Surface()` returns it by reference. Detach's free path becomes `m_surface.Reset()` at the same point in the sequence.
- **`App/Tabs/Tabs.h`, `App/MainWindow.xaml.cpp`.** Identity-comparison sites (`FindLeafBySurface`, `FindLeafForSurface`, active-surface invalidation in close handlers) switch from `c->Surface() == s` (raw) to `c->Surface().Owns(s)`.

## What this is NOT

- Behaviour is preserved end-to-end. Renderer-thread join still happens inside `ghostty_surface_free`; Detach's call order is unchanged.
- The factory boundary (`TabFactory::MakeLeaf`) still calls `ghostty_surface_new` for the raw handle, which is then handed to `TerminalControl::Attach` and wrapped there. That's the only `ghostty_surface_*` C call left in `App/`.
- No multi-window scope. This is the foundation it builds on — `Surface` being a real type is what the future `core::host::Window` (#55) will hold and enumerate against when routing action callbacks by target — but #55 itself is a separate stack of PRs.

## Test plan

Pure refactor, behaviour-preserving:

- [ ] Type into a terminal, normal keys land in the pty
- [ ] IME composition (Japanese) — preedit shows, confirm types into pty
- [ ] Mouse click / drag selects text; right-click copies to clipboard
- [ ] Ctrl+C with selection → clipboard; Ctrl+C without → SIGINT
- [ ] Ctrl+V pastes
- [ ] Window resize re-sizes the swap chain (no shrunk-into-corner render)
- [ ] DPI change (RDP at 200%) — text stays correct size
- [ ] Close tab via Ctrl+Shift+W and via shell exit — both paths run Detach in the right order, no AV
- [ ] Action callbacks (toggle_fullscreen, reset_window_size, etc.) still route to the right TerminalControl

🤖 Generated with [Claude Code](https://claude.com/claude-code)