### PR TITLE
Consolidate App on v145 toolset (drop v143 / VS 2022 path)

### DIFF
--- a/.github/actions/build-signed-msix/action.yml
+++ b/.github/actions/build-signed-msix/action.yml
@@ -184,7 +184,7 @@ runs:
           "Package/Package.wapproj",
           "/p:Configuration=Release",
           "/p:Platform=x64",
-          "/p:PlatformToolset=v143",
+          "/p:PlatformToolset=v145",
           "/p:GenerateAppxPackageOnBuild=true",
           "/p:UapAppxPackageBuildMode=SideloadOnly",
           "/p:AppxBundle=Never"

--- a/App/App.vcxproj
+++ b/App/App.vcxproj
@@ -69,8 +69,7 @@
   </ItemGroup>
   <PropertyGroup Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset Condition="'$(VisualStudioVersion)' &gt;= '18.0'">v145</PlatformToolset>
-    <PlatformToolset Condition="'$(VisualStudioVersion)' &lt; '18.0'">v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <DesktopCompatible>true</DesktopCompatible>
   </PropertyGroup>


### PR DESCRIPTION
## Summary

CI started failing on PR builds 2026-06-14 with:

\`\`\`
error MSB8020: The build tools for 'v143' application Type UWP
(Platform Toolset = 'Visual Studio 2022') cannot be found.
\`\`\`

Same configuration passed every run up to 2026-06-12. The GitHub Actions \`windows-latest\` image was refreshed between then and 2026-06-14 and no longer ships the v143 UWP workload — VS 18 is installed (Core.vcxproj uses v145 in the same log and succeeds), but v143 is the wrong toolset to ask for on this runner.

## Where v143 was being requested

Two places had to be unpinned:

1. **\`App/App.vcxproj\`** had a conditional pair:
   \`\`\`xml
   <PlatformToolset Condition=\"'\$(VisualStudioVersion)' &gt;= '18.0'\">v145</PlatformToolset>
   <PlatformToolset Condition=\"'\$(VisualStudioVersion)' &lt; '18.0'\">v143</PlatformToolset>
   \`\`\`
   This was added so VS 2022 developers could build locally without installing v145. MSBuild on the CI runner doesn't set \`VisualStudioVersion\`; Package.wapproj's standard fallback then pins it to \`15.0\`, the condition fell through to v143, and the project asked for a toolset the runner couldn't fulfil.

2. **\`.github/actions/build-signed-msix/action.yml\`** passed \`/p:PlatformToolset=v143\` on the wapproj build, which won over App.vcxproj's setting regardless. So fixing only the project file had no visible effect — that's why the first iteration of this PR still failed.

## What this changes

- \`App/App.vcxproj\`: drop the condition, pin \`<PlatformToolset>v145</PlatformToolset>\` unconditionally — matches \`Core/Core.vcxproj\`.
- \`.github/actions/build-signed-msix/action.yml\`: change \`/p:PlatformToolset=v143\` to \`/p:PlatformToolset=v145\`.

The toolset is now consistent across the tree (Core, App, CI), and the runner workload mismatch goes away.

## VS 2022 support dropped

WinUI 3 1.8 (what this project targets) is v145-only on Microsoft's side now. Straddling v143 + v145 was carrying complexity for a path that wasn't being maintained anyway. VS 2022 developers who want to keep building have to install the v145 toolset alongside their v143 — the same step VS 18 users already take in the other direction.

## Why this PR is separate

Originally surfaced via PR #85 (App-scope ghostty lift) failing CI on the same error. Cause is unrelated to that PR's code, so this fix is split out and targets \`dev\` directly.

## Test plan

- [ ] CI green on this PR — a passing build is the proof.
- [ ] User confirms local VS 18 build still passes after pulling this change.