### PR TITLE
Introduce App-scope window registry (MainWindows aggregate)

### DIFF
--- a/App/App.vcxproj
+++ b/App/App.vcxproj
@@ -155,6 +155,7 @@
     <ClInclude Include="MainWindow.xaml.h">
       <DependentUpon>MainWindow.xaml</DependentUpon>
     </ClInclude>
+    <ClInclude Include="MainWindows.h" />
     <ClInclude Include="SplitPanel.h" />
     <ClInclude Include="Tabs\Panes\Pane.h" />
     <ClInclude Include="Tabs\Panes\PaneId.h" />
@@ -186,6 +187,7 @@
     <ClCompile Include="MainWindow.xaml.cpp">
       <DependentUpon>MainWindow.xaml</DependentUpon>
     </ClCompile>
+    <ClCompile Include="MainWindows.cpp" />
     <ClCompile Include="Ghostty\MainWindowRuntime.cpp" />
     <ClCompile Include="SplitPanel.cpp" />
     <ClCompile Include="TerminalControl.xaml.cpp">

--- a/App/App.xaml.cpp
+++ b/App/App.xaml.cpp
@@ -204,18 +204,26 @@ namespace winrt::GhosttyWin32::implementation
         // (window → m_ghostty → m_runtime), keeping the userdata
         // pointer alive across ghostty_app_free's surface-thread
         // join.
-        // The runtime consults these callables at the top of every
-        // callback. Keeping App-scope knowledge here — which statics
-        // have to be alive, how to reach the ghostty wrapper — means
-        // MainWindowRuntime doesn't hard-code its own definition of
-        // readiness and doesn't reach out of its window domain.
-        m_runtime = std::make_unique<MainWindowRuntime>(
-            []() {
-                return g_mainWindow != nullptr
-                    && App::g_app != nullptr
+        // The runtime consults these callables through its Host
+        // bundle. Keeping App-scope knowledge here — which state has
+        // to be alive, how to reach the ghostty wrapper, how to look
+        // up windows — means MainWindowRuntime doesn't hard-code any
+        // of it. designated-initialiser field names double as
+        // documentation for what each closure does.
+        m_runtime = std::make_unique<MainWindowRuntime>(MainWindowRuntime::Host{
+            .isReady = []() {
+                return App::g_app != nullptr
+                    && !App::g_app->Windows().Empty()
                     && App::g_app->Ghostty() != nullptr;
             },
-            []() { App::g_app->Ghostty()->Tick(); });
+            .wakeupTick = []() { App::g_app->Ghostty()->Tick(); },
+            .findWindowBySurface = [](ghostty_surface_t s) -> MainWindow* {
+                return App::g_app->Windows().FindForSurface(s);
+            },
+            .anyWindow = []() -> MainWindow* {
+                return App::g_app->Windows().Any();
+            },
+        });
         m_ghostty = core::ghostty::App::Create(
             core::ghostty::RuntimeConfigFactory::Build(m_runtime.get()));
         if (!m_ghostty) {

--- a/App/App.xaml.cpp
+++ b/App/App.xaml.cpp
@@ -197,8 +197,9 @@ namespace winrt::GhosttyWin32::implementation
         // the rtConfig userdata — every C callback ghostty fires
         // unwraps that pointer back to our IGhosttyRuntime impl. The
         // first callback won't fire until a surface is created, by
-        // which point Activate has run and `g_mainWindow` is set, so
-        // MainWindowRuntime can reach back into the window.
+        // which point Activate has run and the Activated handler has
+        // registered the new MainWindow with the aggregate, so
+        // MainWindowRuntime's lookups return non-null.
         //
         // Member ordering in App.xaml.h enforces destruction order
         // (window → m_ghostty → m_runtime), keeping the userdata

--- a/App/App.xaml.h
+++ b/App/App.xaml.h
@@ -2,6 +2,7 @@
 
 #include "App.xaml.g.h"
 #include "Ghostty/App.h"
+#include "MainWindows.h"
 #include <winrt/Microsoft.Windows.AppLifecycle.h>
 #include <winrt/Microsoft.Windows.AppNotifications.h>
 #include <memory>
@@ -58,6 +59,16 @@ namespace winrt::GhosttyWin32::implementation
         // and the surfaces they held.
         core::ghostty::App* Ghostty() const noexcept { return m_ghostty.get(); }
 
+        // Aggregate for the set of live MainWindows. Sibling to
+        // `Tabs` in shape: a borrow-only collection that MainWindow
+        // registers itself into during its Activated handler and
+        // unregisters from in its destructor. Runtime callbacks and
+        // target-based routing consult this to reach the right
+        // window; the accessor replaces the file-scope `g_mainWindow`
+        // static.
+        MainWindows&       Windows()       noexcept { return m_windows; }
+        MainWindows const& Windows() const noexcept { return m_windows; }
+
     private:
         // Subsequent-activation handler. The first activation runs through
         // OnLaunched; later activations (a second click of a notification,
@@ -92,6 +103,14 @@ namespace winrt::GhosttyWin32::implementation
         //      and no more callbacks can fire — safe to release the
         //      IGhosttyRuntime the factory's userdata pointer was
         //      aimed at.
+        //
+        // `m_windows` is a borrow-only aggregate; its own destruction
+        // order relative to the members below doesn't matter (the
+        // pointers don't own the MainWindows, `window` does), but
+        // every MainWindow unregisters itself in its destructor which
+        // runs during step 1, so by the time we reach step 2 the
+        // aggregate is already empty.
+        MainWindows                        m_windows;
         std::unique_ptr<MainWindowRuntime> m_runtime;
         std::unique_ptr<core::ghostty::App> m_ghostty;
 

--- a/App/App.xaml.h
+++ b/App/App.xaml.h
@@ -64,8 +64,7 @@ namespace winrt::GhosttyWin32::implementation
         // registers itself into during its Activated handler and
         // unregisters from in its destructor. Runtime callbacks and
         // target-based routing consult this to reach the right
-        // window; the accessor replaces the file-scope `g_mainWindow`
-        // static.
+        // window.
         MainWindows&       Windows()       noexcept { return m_windows; }
         MainWindows const& Windows() const noexcept { return m_windows; }
 

--- a/App/Ghostty/MainWindowRuntime.cpp
+++ b/App/Ghostty/MainWindowRuntime.cpp
@@ -12,10 +12,8 @@ namespace winrt::GhosttyWin32::implementation {
 namespace interop = core::interop;
 namespace win32   = core::win32;
 
-MainWindowRuntime::MainWindowRuntime(ReadinessCheck isHostReady,
-                                     WakeupTick     wakeupTick)
-    : m_isHostReady(std::move(isHostReady))
-    , m_wakeupTick(std::move(wakeupTick))
+MainWindowRuntime::MainWindowRuntime(Host host)
+    : m_host(std::move(host))
 {
 }
 
@@ -27,9 +25,11 @@ void MainWindowRuntime::OnWakeup()
     // the dispatcher pulling the item. `[this]` captures the runtime
     // pointer; runtime lifetime outlasts ghostty per App's member
     // ordering, so the capture stays valid.
-    if (!m_isHostReady()) return;
-    g_mainWindow->DispatcherQueue().TryEnqueue([this]() {
-        if (m_isHostReady()) m_wakeupTick();
+    if (!m_host.isReady()) return;
+    auto* window = m_host.anyWindow();
+    if (!window) return;
+    window->DispatcherQueue().TryEnqueue([this]() {
+        if (m_host.isReady()) m_host.wakeupTick();
     });
 }
 
@@ -38,17 +38,23 @@ bool MainWindowRuntime::OnAction(ghostty_target_s target,
 {
     // Thin forwarder. All dispatch + handler bodies live in
     // GhosttyCallbackDispatcher / GhosttyActions.
-    if (!m_isHostReady() || !g_mainWindow->m_ghosttyDispatcher) return false;
-    return g_mainWindow->m_ghosttyDispatcher->DispatchAction(target, action);
+    if (!m_host.isReady()) return false;
+    auto* window = (target.tag == GHOSTTY_TARGET_SURFACE)
+        ? m_host.findWindowBySurface(target.target.surface)
+        : m_host.anyWindow();
+    if (!window || !window->m_ghosttyDispatcher) return false;
+    return window->m_ghosttyDispatcher->DispatchAction(target, action);
 }
 
 bool MainWindowRuntime::OnReadClipboard(void* state)
 {
-    if (!m_isHostReady()) return false;
-    auto* tc = g_mainWindow->ActiveControl();
+    if (!m_host.isReady()) return false;
+    auto* window = m_host.anyWindow();
+    if (!window) return false;
+    auto* tc = window->ActiveControl();
     if (!tc || !tc->Surface()) return false;
     auto utf8 = interop::Encoding::toUtf8(
-        win32::Clipboard::read(g_mainWindow->m_hwnd));
+        win32::Clipboard::read(window->m_hwnd));
     if (utf8.empty()) return false;
     tc->Surface().CompleteClipboardRequest(utf8.c_str(), state, false);
     return true;
@@ -57,8 +63,10 @@ bool MainWindowRuntime::OnReadClipboard(void* state)
 void MainWindowRuntime::OnConfirmReadClipboard(char const* content, void* state)
 {
     // Auto-confirm clipboard reads.
-    if (!m_isHostReady()) return;
-    auto* tc = g_mainWindow->ActiveControl();
+    if (!m_host.isReady()) return;
+    auto* window = m_host.anyWindow();
+    if (!window) return;
+    auto* tc = window->ActiveControl();
     if (tc && tc->Surface()) {
         tc->Surface().CompleteClipboardRequest(content, state, true);
     }
@@ -66,9 +74,11 @@ void MainWindowRuntime::OnConfirmReadClipboard(char const* content, void* state)
 
 void MainWindowRuntime::OnWriteClipboard(char const* utf8)
 {
-    if (!m_isHostReady()) return;
+    if (!m_host.isReady()) return;
+    auto* window = m_host.anyWindow();
+    if (!window) return;
     win32::Clipboard::write(
-        g_mainWindow->m_hwnd, interop::Encoding::toUtf16(utf8));
+        window->m_hwnd, interop::Encoding::toUtf16(utf8));
 }
 
 void MainWindowRuntime::OnCloseSurface(void* paneIdUserdata)
@@ -77,11 +87,17 @@ void MainWindowRuntime::OnCloseSurface(void* paneIdUserdata)
     // to close the surface. The userdata is the PaneId we set in
     // TabFactory::MakeLeaf. Dispatch the UI mutation to the next UI
     // tick so it happens off the renderer thread.
-    if (!m_isHostReady()) return;
+    //
+    // PaneIds are per-window today (each MainWindow has its own
+    // allocator), so with multiple windows we'd need target routing
+    // here. Single-window makes `anyWindow` sufficient; #55's
+    // NEW_WINDOW work will revisit.
+    if (!m_host.isReady()) return;
+    auto* window = m_host.anyWindow();
+    if (!window) return;
     PaneId id = PaneId::FromUserdata(paneIdUserdata);
-    auto* mw = g_mainWindow;
-    mw->DispatcherQueue().TryEnqueue([mw, id]() {
-        mw->CloseSurfaceByPaneId(id);
+    window->DispatcherQueue().TryEnqueue([window, id]() {
+        window->CloseSurfaceByPaneId(id);
     });
 }
 

--- a/App/Ghostty/MainWindowRuntime.h
+++ b/App/Ghostty/MainWindowRuntime.h
@@ -6,38 +6,63 @@
 
 namespace winrt::GhosttyWin32::implementation {
 
+class MainWindow;
+
 // App-side implementation of the runtime hooks ghostty calls back
 // into. The factory in Core does the C↔C++ translation; this class
-// holds all the bridge logic — clipboard via Win32, action dispatch
-// through CallbackDispatcher, surface close via PaneId — and is the
-// only thing that knows about MainWindow / App::g_app statics in
-// this layer.
+// holds the bridge logic — clipboard via Win32, action dispatch
+// through CallbackDispatcher, surface close via PaneId. Everything
+// outside its own window domain (readiness state, ghostty ticking,
+// window lookup) is passed in through the `Host` bundle so the class
+// stays focused and testable.
 //
 // Owned by `winrt::App` as a `std::unique_ptr` member declared
-// *before* the ghostty wrapper, so that destruction order survives
+// *before* the ghostty wrapper, so destruction order survives
 // `ghostty_app_free`'s surface-thread join — any in-flight callback
 // still sees a live runtime.
 class MainWindowRuntime : public core::ghostty::IGhosttyRuntime {
 public:
     // Predicate consulted at the top of every callback before host
-    // state gets touched. Whether "ready" means "g_mainWindow set +
-    // App::g_app live + ghostty wrapper alive," some subset, or a
-    // completely different condition (e.g. under test) is App's
-    // choice — this class only knows there's a function to ask.
+    // state gets touched. App decides what "ready" means (which
+    // statics have to be alive, whether a window is registered, …);
+    // this class only knows there's a function to ask.
     using ReadinessCheck = std::function<bool()>;
 
     // Drives ghostty's event loop forward. OnWakeup dispatches this
-    // to the UI thread. Injected instead of calling the App-scope
+    // to the UI thread. Injected instead of reaching for
     // `App::g_app->Ghostty()->Tick()` directly so this class doesn't
-    // reach out of its window domain — `App` and the ghostty wrapper
-    // are somebody else's concerns.
+    // touch App scope.
     using WakeupTick = std::function<void()>;
 
-    // `isHostReady` and `wakeupTick` must remain callable for the
-    // runtime's lifetime — App owns both this runtime and the state
-    // the closures capture, so their lifetimes are naturally tied.
-    MainWindowRuntime(ReadinessCheck isHostReady,
-                      WakeupTick     wakeupTick);
+    // Returns the window whose tab tree owns `surface`, or null when
+    // none does. Called for SURFACE-target actions and for
+    // clipboard / close routing that comes with a surface handle.
+    using FindWindowBySurface = std::function<MainWindow*(ghostty_surface_t)>;
+
+    // Returns any live window (currently: the first registered) or
+    // null when the aggregate is empty. Called for callbacks that
+    // have no per-surface handle — wakeup, clipboard read/write with
+    // no explicit target, APP-target actions.
+    using AnyWindow = std::function<MainWindow*()>;
+
+    // Bundle of callables the runtime consults. `App` fills each
+    // slot at construction time. Reads at the call sites are
+    // `m_host.xxx(...)`, so the runtime touches its dependencies
+    // through method-like syntax while every dependency stays
+    // visible on the type — adding a new slot doesn't break existing
+    // callers, only requires filling one more field.
+    //
+    // Each closure must remain callable for the runtime's lifetime.
+    // App owns both this runtime and the state the closures capture,
+    // so their lifetimes are naturally tied.
+    struct Host {
+        ReadinessCheck      isReady;
+        WakeupTick          wakeupTick;
+        FindWindowBySurface findWindowBySurface;
+        AnyWindow           anyWindow;
+    };
+
+    explicit MainWindowRuntime(Host host);
     ~MainWindowRuntime() override = default;
 
     MainWindowRuntime(MainWindowRuntime const&)            = delete;
@@ -52,8 +77,7 @@ public:
     void OnCloseSurface(void* paneIdUserdata) override;
 
 private:
-    ReadinessCheck m_isHostReady;
-    WakeupTick     m_wakeupTick;
+    Host m_host;
 };
 
 }  // namespace winrt::GhosttyWin32::implementation

--- a/App/MainWindow.xaml.cpp
+++ b/App/MainWindow.xaml.cpp
@@ -542,13 +542,20 @@ namespace winrt::GhosttyWin32::implementation
         // over with its standard dialog — same end result, just less polished.
         // That's an acceptable trade for keeping this code readable.
         OutputDebugStringA("GhosttyWin32: unhandled exception, attempting cleanup\n");
-        if (g_mainWindow) {
-            if (g_mainWindow->m_hwnd) ShowWindow(g_mainWindow->m_hwnd, SW_HIDE);
-            for (auto& tab : g_mainWindow->m_tabs) {
-                if (!tab) continue;
-                if (auto* tc = tab->ActiveControl()) {
-                    HANDLE h = tc->CompositionHandle();
-                    if (h) CloseHandle(h);
+        if (App::g_app) {
+            // Walk every registered window; the SEH handler is
+            // process-wide, and once multi-window lands a fatal
+            // crash still wants every window's composition handles
+            // released before we hand control back.
+            for (auto* w : App::g_app->Windows()) {
+                if (!w) continue;
+                if (w->m_hwnd) ShowWindow(w->m_hwnd, SW_HIDE);
+                for (auto& tab : w->m_tabs) {
+                    if (!tab) continue;
+                    if (auto* tc = tab->ActiveControl()) {
+                        HANDLE h = tc->CompositionHandle();
+                        if (h) CloseHandle(h);
+                    }
                 }
             }
         }

--- a/App/MainWindow.xaml.cpp
+++ b/App/MainWindow.xaml.cpp
@@ -645,6 +645,11 @@ namespace winrt::GhosttyWin32::implementation
         }
     }
 
+    bool MainWindow::OwnsSurface(ghostty_surface_t surface) const noexcept
+    {
+        return surface != nullptr && m_tabs.FindBySurface(surface) != nullptr;
+    }
+
     void MainWindow::NotifySurfaceFocused(ghostty_surface_t surface) noexcept
     {
         m_activeSurface = surface;

--- a/App/MainWindow.xaml.cpp
+++ b/App/MainWindow.xaml.cpp
@@ -89,6 +89,12 @@ namespace winrt::GhosttyWin32::implementation
             SetUnhandledExceptionFilter(&MainWindow::OnUnhandledException);
 
             g_mainWindow = this;
+            // Also register with the App-scope aggregate — the
+            // registry is what the runtime callbacks and any future
+            // target-based routing consult. g_mainWindow stays wired
+            // in parallel for now; it goes away in a later commit
+            // once every reader has been migrated to the aggregate.
+            if (App::g_app) App::g_app->Windows().Register(this);
             auto windowNative = this->try_as<::IWindowNative>();
             if (windowNative) windowNative->get_WindowHandle(&m_hwnd);
             if (m_hwnd) ShowWindow(m_hwnd, SW_HIDE);
@@ -510,6 +516,11 @@ namespace winrt::GhosttyWin32::implementation
 
     MainWindow::~MainWindow()
     {
+        // Take ourselves off the App-scope aggregate before anything
+        // else — subsequent runtime callbacks that fire during
+        // ghostty_app_free's join land in the FindForSurface / Any
+        // paths and must not find a half-torn-down window.
+        if (App::g_app) App::g_app->Windows().Unregister(this);
         m_tabs.Clear();   // Tab destructors handle cleanup
         // ghostty::App ownership lives on App scope now (#55 prep).
         // App's destructor frees ghostty AFTER its `window` member

--- a/App/MainWindow.xaml.cpp
+++ b/App/MainWindow.xaml.cpp
@@ -47,12 +47,6 @@ namespace muxc = Microsoft::UI::Xaml::Controls;
 
 namespace winrt::GhosttyWin32::implementation
 {
-    // Definition for the extern declaration in MainWindow.xaml.h. The
-    // runtime callbacks built by RuntimeConfigFactory live in a
-    // separate TU and need to see this symbol; the Activated handler
-    // sets it on first window construction.
-    MainWindow* g_mainWindow = nullptr;
-
     MainWindow::MainWindow()
     {
         // Adopt the App-scope ghostty wrapper as a class invariant.
@@ -88,12 +82,10 @@ namespace winrt::GhosttyWin32::implementation
             // visible white flash).
             SetUnhandledExceptionFilter(&MainWindow::OnUnhandledException);
 
-            g_mainWindow = this;
-            // Also register with the App-scope aggregate — the
-            // registry is what the runtime callbacks and any future
-            // target-based routing consult. g_mainWindow stays wired
-            // in parallel for now; it goes away in a later commit
-            // once every reader has been migrated to the aggregate.
+            // Enter the App-scope aggregate. Every caller —
+            // runtime callbacks, target-based routing, the SEH
+            // handler — consults this collection to reach a live
+            // MainWindow; no file-scope static shortcut remains.
             if (App::g_app) App::g_app->Windows().Register(this);
             auto windowNative = this->try_as<::IWindowNative>();
             if (windowNative) windowNative->get_WindowHandle(&m_hwnd);

--- a/App/MainWindow.xaml.h
+++ b/App/MainWindow.xaml.h
@@ -64,6 +64,12 @@ namespace winrt::GhosttyWin32::implementation
         // surface itself is torn down.
         ghostty_surface_t GetActiveSurface() const noexcept { return m_activeSurface; }
 
+        // True when any leaf in this window's tab tree owns `surface`.
+        // App::FindWindowForSurface iterates its window list and asks
+        // each in turn — the linear cost is fine at the scale a
+        // multi-window session will reach in practice.
+        bool OwnsSurface(ghostty_surface_t surface) const noexcept;
+
         // ----- IMainWindowView -----
         // Narrow surface the callback dispatcher / GhosttyActions
         // consume; see IMainWindowView.h for why these live behind

--- a/App/MainWindow.xaml.h
+++ b/App/MainWindow.xaml.h
@@ -227,15 +227,6 @@ namespace winrt::GhosttyWin32::implementation
         // half-torn-down ghostty handle from any of its handlers.
         std::unique_ptr<ghostty::CallbackDispatcher> m_ghosttyDispatcher;
     };
-
-    // Process-wide pointer to the live MainWindow. Set in the
-    // Activated handler on first construction. Exposed at namespace
-    // scope so RuntimeConfigFactory's static callbacks — defined in a
-    // separate TU — can route ghostty's runtime hooks back into the
-    // window. Goes away in PR2 of #55, replaced by an App-scope
-    // registry that lets callbacks address a specific window by
-    // target.
-    extern MainWindow* g_mainWindow;
 }
 
 namespace winrt::GhosttyWin32::factory_implementation

--- a/App/MainWindows.cpp
+++ b/App/MainWindows.cpp
@@ -1,0 +1,17 @@
+#include "pch.h"
+#include "MainWindows.h"
+
+#include "MainWindow.xaml.h"
+
+namespace winrt::GhosttyWin32::implementation {
+
+MainWindow* MainWindows::FindForSurface(ghostty_surface_t surface) const noexcept
+{
+    if (!surface) return nullptr;
+    for (auto* w : m_windows) {
+        if (w && w->OwnsSurface(surface)) return w;
+    }
+    return nullptr;
+}
+
+}  // namespace winrt::GhosttyWin32::implementation

--- a/App/MainWindows.h
+++ b/App/MainWindows.h
@@ -1,0 +1,70 @@
+#pragma once
+
+#include "ghostty.h"
+
+#include <algorithm>
+#include <vector>
+
+namespace winrt::GhosttyWin32::implementation {
+
+class MainWindow;
+
+// Aggregate for the set of MainWindows live in the process. MainWindow
+// adds and removes itself as part of its own lifecycle; runtime
+// callbacks and target-based routing consult this collection to reach
+// the right window for a given surface (or any window when the
+// callback has no per-surface handle).
+//
+// Sibling to `Tabs` (which manages the `Tab*` collection inside a
+// MainWindow): both are borrowing collections built out of raw
+// pointers into objects whose ownership lives elsewhere. Ownership of
+// each MainWindow stays with `winrt::App::window`; ownership of the
+// aggregate itself stays with `winrt::App::m_windows`.
+//
+// Not thread-safe. Registration/lookup all happen on the UI thread —
+// MainWindow's ctor/dtor and the runtime callbacks that reach here go
+// through the DispatcherQueue hop before touching state.
+class MainWindows {
+public:
+    MainWindows() = default;
+
+    MainWindows(MainWindows const&)            = delete;
+    MainWindows& operator=(MainWindows const&) = delete;
+    MainWindows(MainWindows&&)                 = delete;
+    MainWindows& operator=(MainWindows&&)      = delete;
+
+    void Register(MainWindow* w)
+    {
+        if (!w) return;
+        m_windows.push_back(w);
+    }
+
+    void Unregister(MainWindow* w) noexcept
+    {
+        auto it = std::find(m_windows.begin(), m_windows.end(), w);
+        if (it != m_windows.end()) m_windows.erase(it);
+    }
+
+    // Any registered window (currently: the first). For callbacks
+    // that have no per-surface target — wakeup, clipboard read/write,
+    // APP-target actions. Null before any window registers or after
+    // all have unregistered.
+    MainWindow* Any() const noexcept
+    {
+        return m_windows.empty() ? nullptr : m_windows.front();
+    }
+
+    // Window whose tab tree owns `surface`, or null. Linear scan; the
+    // window count in practice is single digits, so no index needed.
+    // Definition lives in MainWindows.cpp to break the header include
+    // cycle (MainWindow needs to be complete for `OwnsSurface`).
+    MainWindow* FindForSurface(ghostty_surface_t surface) const noexcept;
+
+    bool   Empty() const noexcept { return m_windows.empty(); }
+    size_t Count() const noexcept { return m_windows.size(); }
+
+private:
+    std::vector<MainWindow*> m_windows;
+};
+
+}  // namespace winrt::GhosttyWin32::implementation

--- a/App/MainWindows.h
+++ b/App/MainWindows.h
@@ -63,6 +63,12 @@ public:
     bool   Empty() const noexcept { return m_windows.empty(); }
     size_t Count() const noexcept { return m_windows.size(); }
 
+    // range-for support. Iteration is over live borrowed pointers in
+    // registration order; users of the range must not modify the
+    // aggregate through Register / Unregister mid-loop.
+    auto begin() const noexcept { return m_windows.begin(); }
+    auto end()   const noexcept { return m_windows.end(); }
+
 private:
     std::vector<MainWindow*> m_windows;
 };


### PR DESCRIPTION
## Summary

Foundation for #55 multi-window support: replace the file-scope \`g_mainWindow\` static with an App-scope aggregate that MainWindow registers itself into. Every runtime callback and target-based routing consults the aggregate rather than reaching for a single-window shortcut.

Behaviour is unchanged. Only one MainWindow ever registers today; the code shape is the one #55's NEW_WINDOW work drops a second window into without touching this layer.

## Stacked on

Sits on top of [#85](https://github.com/i999rri/GhosttyWin32/pull/85) (App-scope ghostty lift). #85 introduced the runtime interface (IGhosttyRuntime) and moved the config factory to Core; this PR is what \`g_mainWindow\` gets replaced with. Once #85 lands, GitHub auto-retargets this to \`dev\`.

## Commit-by-commit

| | Commit | What it does |
|---|---|---|
| 1 | \`Add App-scope window registry as a MainWindows aggregate\` | Introduce \`MainWindows\` — a small aggregate class sibling to \`Tabs\` — plus \`App::Windows()\` accessor. Empty, nothing calls it yet. Also adds \`MainWindow::OwnsSurface\`. |
| 2 | \`Register MainWindow with the App-scope aggregate on ctor / dtor\` | MainWindow's Activated handler registers, destructor unregisters (before \`m_tabs.Clear()\` so callbacks fired during ghostty_app_free's join can't walk into half-torn-down state). \`g_mainWindow\` still wired in parallel. |
| 3 | \`Route MainWindowRuntime through the App-scope aggregate\` | Widens \`MainWindowRuntime\`'s injection from two closures to a \`Host\` bundle of four (readiness, wakeupTick, findWindowBySurface, anyWindow). Every callback resolves its target window through the bundle; SURFACE-target actions use surface lookup, everything else uses \`anyWindow\`. |
| 4 | \`Route MainWindow's SEH handler through the aggregate\` | \`MainWindow::OnUnhandledException\` used \`g_mainWindow\` to walk one window's tabs before letting the crash propagate. Add \`begin\` / \`end\` to \`MainWindows\` and range-for over the aggregate so a future multi-window crash releases every composition handle, not just one. |
| 5 | \`Remove the g_mainWindow static\` | Nothing reads it anymore. Drop the definition, the \`extern\`, the assignment in the Activated handler, and stale comments. |

## Design notes worth flagging

### \`MainWindows\` as an aggregate class, not a raw \`std::vector\` on App

Sibling to \`Tabs\` inside a MainWindow — same shape: borrow-only collection, ownership lives elsewhere, aggregate exposes named operations (\`Register\` / \`Unregister\` / \`Any\` / \`FindForSurface\`). Keeps \`App\` from accreting registry methods and gives the concept its own testable seam.

### \`MainWindowRuntime::Host\` — struct-of-callables instead of many ctor params

Following the readiness-check / wakeup-tick pattern introduced in #85's later commits: rather than expand the constructor to four positional \`std::function\` parameters, bundle them into a single \`Host\` struct filled by designated initialiser. Adding a fifth callable (e.g. for multi-window window-creation) becomes an additive field change rather than a signature break.

### Callback routing shape

- \`OnAction\` — \`findWindowBySurface\` on SURFACE targets, \`anyWindow\` on APP targets.
- \`OnWakeup\`, \`OnReadClipboard\`, \`OnConfirmReadClipboard\`, \`OnWriteClipboard\` — no per-surface handle, use \`anyWindow\`.
- \`OnCloseSurface\` — \`anyWindow\` today. Its userdata is a per-window PaneId (each MainWindow allocates independently), so genuine multi-window routing needs #55's NEW_WINDOW work to encode window identity in the userdata. A comment in the callback flags this.

### Destruction order

App's member layout is now (declaration → destruction order):

\`\`\`
m_windows      (aggregate, declared 1st  → destructed last)
m_runtime      (unique_ptr,               → destructed 3rd)
m_ghostty      (unique_ptr,               → destructed 2nd)
window         (declared last,            → destructed 1st)
\`\`\`

\`window\` tearing down invokes MainWindow's destructor, which \`Unregister\`s before \`m_tabs.Clear()\` runs. By the time \`m_ghostty\` calls \`ghostty_app_free\`, the aggregate is empty; callbacks that fire during the join land in the runtime's \`isReady()\` check and return early, then flow through \`Any()\` returning null.

## Known issue

While testing this PR, a WinRT \`RO_E_CLOSED\` exception was observed after certain complex operation sequences followed by a tab close. Not reproducible on simple cases, and the callback path shape is unchanged from pre-PR2 — likely a pre-existing latent race that specific state combinations expose. Filed as #87 for follow-up; not blocking here.

## Test plan

- [ ] Startup + basic terminal use
- [ ] Ctrl+Shift+T new tab
- [ ] Tab close via UI
- [ ] Ctrl+C / Ctrl+V clipboard
- [ ] Shell \`exit\` triggers surface close callback
- [ ] Ctrl+Shift+D and other keybound actions still route
- [ ] Window close via X button → clean exit