### PR TITLE
Lift crash flag and SEH handler to App scope

### DIFF
--- a/App/App.xaml.cpp
+++ b/App/App.xaml.cpp
@@ -14,7 +14,12 @@ using namespace winrt;
 using namespace Microsoft::UI::Xaml;
 
 namespace {
-    std::filesystem::path crashFlagPathApp() {
+    // Flag file used to detect that the previous process didn't exit
+    // cleanly. Created in OnLaunched, removed in ~App on clean
+    // shutdown — if it's still there at next launch, the previous
+    // run crashed and OnLaunched waits briefly so the NVIDIA driver
+    // has time to recover its internal state.
+    std::filesystem::path crashFlagPath() {
         wchar_t buf[MAX_PATH];
         DWORD len = GetTempPathW(MAX_PATH, buf);
         if (len == 0) return L"GhosttyWin32_running.flag";
@@ -56,7 +61,54 @@ namespace winrt::GhosttyWin32::implementation
     // above) is in scope where the unique_ptr destructor is
     // instantiated. The body itself is empty — destruction runs
     // member-by-member per the App.xaml.h declaration order.
-    App::~App() = default;
+    App::~App()
+    {
+        // Clean shutdown reached — remove the crash flag so the next
+        // launch doesn't sit through the 2-second driver recovery pause.
+        // Best-effort: if the filesystem call fails we lose nothing
+        // beyond the extra pause on the next start.
+        std::error_code ec;
+        std::filesystem::remove(crashFlagPath(), ec);
+    }
+
+    long __stdcall App::OnUnhandledException(struct _EXCEPTION_POINTERS* /*info*/) noexcept
+    {
+        // Fatal crash inside the process. Best-effort cleanup: hide
+        // every registered window and release each active
+        // TerminalControl's composition handle before letting
+        // WER / debugger take over. We deliberately don't touch XAML
+        // objects (releasing the surfaces via DComp is enough) or
+        // ghostty structures that might be wrecked. If any of them
+        // does crash anyway, the unhandled-exception filter "fails"
+        // recursively and WER takes over with its standard dialog —
+        // same end result, just less polished. That's an acceptable
+        // trade for keeping this code readable.
+        OutputDebugStringA("GhosttyWin32: unhandled exception, attempting cleanup\n");
+        if (g_app) {
+            // Walk every registered window; the SEH handler is
+            // process-wide, and once multi-window lands a fatal
+            // crash still wants every window's composition handles
+            // released before we hand control back.
+            for (auto* w : g_app->Windows()) {
+                if (!w) continue;
+                if (w->m_hwnd) ShowWindow(w->m_hwnd, SW_HIDE);
+                for (auto& tab : w->m_tabs) {
+                    if (!tab) continue;
+                    if (auto* tc = tab->ActiveControl()) {
+                        HANDLE h = tc->CompositionHandle();
+                        if (h) CloseHandle(h);
+                    }
+                }
+            }
+        }
+        MessageBoxW(nullptr,
+            L"GhosttyWin32 hit a fatal error and must exit.\n\n"
+            L"Restarting the app usually recovers.",
+            L"GhosttyWin32",
+            MB_OK | MB_ICONERROR | MB_TASKMODAL);
+        // Don't swallow the exception — let WER / debugger see it as usual.
+        return EXCEPTION_CONTINUE_SEARCH;
+    }
 
     void App::OnInstanceActivated(
         winrt::Windows::Foundation::IInspectable const&,
@@ -177,13 +229,21 @@ namespace winrt::GhosttyWin32::implementation
         // Activated handler — by then the window is already mapped.
         {
             std::error_code ec;
-            auto flag = crashFlagPathApp();
+            auto flag = crashFlagPath();
             if (std::filesystem::exists(flag, ec)) {
                 OutputDebugStringA("GhosttyWin32: previous run crashed; pausing 2s for driver recovery\n");
                 Sleep(2000);
             }
             std::ofstream(flag).close();
         }
+
+        // Register the process-wide SEH handler now that the crash
+        // flag is in place. Historically this lived in MainWindow's
+        // Activated handler; moving it here makes it independent of
+        // window count — a fatal exception with two windows open
+        // still walks every window's composition handles before we
+        // let WER take over.
+        SetUnhandledExceptionFilter(&App::OnUnhandledException);
 
         // AppNotificationManager::Default().Register() and the
         // NotificationInvoked subscription both already happened in

--- a/App/App.xaml.h
+++ b/App/App.xaml.h
@@ -50,6 +50,15 @@ namespace winrt::GhosttyWin32::implementation
         // decode failure.
         static uint64_t ParseSurfaceIdFromArguments(std::wstring const& arguments);
 
+        // Best-effort cleanup invoked from SetUnhandledExceptionFilter
+        // when a SEH exception unwinds past the top of the call stack.
+        // Process-wide by definition — walks every registered MainWindow
+        // via the App-scope aggregate to release composition handles
+        // before the process dies. Registered once in OnLaunched;
+        // returns EXCEPTION_CONTINUE_SEARCH so the debugger / WER sees
+        // the exception normally.
+        static long __stdcall OnUnhandledException(struct _EXCEPTION_POINTERS* info) noexcept;
+
         // Borrowed accessor for the process-wide ghostty::App.
         // OnLaunched creates it before make<MainWindow>() and aborts
         // if creation fails, so any code path that can see a live

--- a/App/MainWindow.xaml.cpp
+++ b/App/MainWindow.xaml.cpp
@@ -28,19 +28,6 @@
 #pragma comment(lib, "shell32.lib")
 #pragma comment(lib, "comctl32.lib")
 
-namespace {
-    // Flag file used to detect that the previous process didn't exit cleanly.
-    // Created at startup, deleted on clean shutdown — if it's still there at
-    // launch time, the previous run crashed and we wait briefly so the
-    // NVIDIA driver has time to recover its internal state.
-    std::filesystem::path crashFlagPath() {
-        wchar_t buf[MAX_PATH];
-        DWORD len = GetTempPathW(MAX_PATH, buf);
-        if (len == 0) return L"GhosttyWin32_running.flag";
-        return std::filesystem::path(buf) / L"GhosttyWin32_running.flag";
-    }
-}
-
 using namespace winrt;
 using namespace Microsoft::UI::Xaml;
 namespace muxc = Microsoft::UI::Xaml::Controls;
@@ -74,13 +61,6 @@ namespace winrt::GhosttyWin32::implementation
             static bool initialized = false;
             if (initialized) return;
             initialized = true;
-
-            // Best-effort cleanup if we crash later — tells DComp to release
-            // surfaces so the next launch starts cleaner. The crash flag
-            // itself is set / checked / cleared in App::OnLaunched so the
-            // recovery delay happens before any window is mapped (avoids a
-            // visible white flash).
-            SetUnhandledExceptionFilter(&MainWindow::OnUnhandledException);
 
             // Enter the App-scope aggregate. Every caller —
             // runtime callbacks, target-based routing, the SEH
@@ -517,47 +497,10 @@ namespace winrt::GhosttyWin32::implementation
         // ghostty::App ownership lives on App scope now (#55 prep).
         // App's destructor frees ghostty AFTER its `window` member
         // (this MainWindow) has gone, so the surface/IO-thread join
-        // inside ghostty_app_free finds nothing left to wait on.
-        // Clean shutdown reached — clear the crash flag so the next launch
-        // doesn't pause unnecessarily.
-        std::error_code ec;
-        std::filesystem::remove(crashFlagPath(), ec);
-    }
-
-    long __stdcall MainWindow::OnUnhandledException(struct _EXCEPTION_POINTERS* /*info*/) noexcept
-    {
-        // Best-effort cleanup before the OS kills the process. Each call here
-        // is a Win32 / kernel API that's safe even with a corrupted heap;
-        // ShowWindow / CloseHandle / MessageBoxW don't touch user-mode
-        // structures that might be wrecked. If any of them does crash anyway,
-        // the unhandled-exception filter "fails" recursively and WER takes
-        // over with its standard dialog — same end result, just less polished.
-        // That's an acceptable trade for keeping this code readable.
-        OutputDebugStringA("GhosttyWin32: unhandled exception, attempting cleanup\n");
-        if (App::g_app) {
-            // Walk every registered window; the SEH handler is
-            // process-wide, and once multi-window lands a fatal
-            // crash still wants every window's composition handles
-            // released before we hand control back.
-            for (auto* w : App::g_app->Windows()) {
-                if (!w) continue;
-                if (w->m_hwnd) ShowWindow(w->m_hwnd, SW_HIDE);
-                for (auto& tab : w->m_tabs) {
-                    if (!tab) continue;
-                    if (auto* tc = tab->ActiveControl()) {
-                        HANDLE h = tc->CompositionHandle();
-                        if (h) CloseHandle(h);
-                    }
-                }
-            }
-        }
-        MessageBoxW(nullptr,
-            L"GhosttyWin32 hit a fatal error and must exit.\n\n"
-            L"Restarting the app usually recovers.",
-            L"GhosttyWin32",
-            MB_OK | MB_ICONERROR | MB_TASKMODAL);
-        // Don't swallow the exception — let WER / debugger see it as usual.
-        return EXCEPTION_CONTINUE_SEARCH;
+        // inside ghostty_app_free finds nothing left to wait on. The
+        // crash flag is also App's concern: App::~App clears it once
+        // per clean process shutdown, which is the granularity the
+        // "did the previous run crash?" check actually wants.
     }
 
     Tab* MainWindow::ActiveTab()

--- a/App/MainWindow.xaml.h
+++ b/App/MainWindow.xaml.h
@@ -30,13 +30,6 @@ namespace winrt::GhosttyWin32::implementation
         MainWindow();
         ~MainWindow();
 
-        // Best-effort cleanup invoked from SetUnhandledExceptionFilter.
-        // Walks live tabs and closes their composition surface handles so
-        // DComp drops its driver-side references before the OS kills the
-        // process — reduces the chance the next launch inherits corrupted
-        // NVIDIA state.
-        static long __stdcall OnUnhandledException(struct _EXCEPTION_POINTERS* info) noexcept;
-
         // Caption button click handlers, referenced from MainWindow.xaml.
         // Routed through Win32 messages (WM_SYSCOMMAND / WM_CLOSE / ShowWindow)
         // rather than OverlappedPresenter state changes, which have
@@ -149,6 +142,13 @@ namespace winrt::GhosttyWin32::implementation
         // Friending the runtime keeps those members private to
         // everyone else while documenting the tight coupling.
         friend class MainWindowRuntime;
+        // The process-wide SEH handler on App walks every window's
+        // tabs to release composition handles before a fatal crash
+        // reaches WER. Same pattern as MainWindowRuntime: a specific
+        // outside actor that has an intrinsic reason to reach into
+        // this window's guts, granted access by name rather than by
+        // widening the public surface.
+        friend struct App;
 
 
         void InitGhostty();


### PR DESCRIPTION
## Summary

Fold crash-recovery infrastructure onto \`App\`. Adding a second MainWindow no longer breaks it.

Previously split: \`App::OnLaunched\` wrote the flag, \`MainWindow\`'s Activated handler registered \`SetUnhandledExceptionFilter\`, \`MainWindow\`'s destructor cleared the flag, \`MainWindow::OnUnhandledException\` was the SEH handler body. That composed fine for one window but not two — the flag would clear when the first window closes even though the process is still live, and re-registering the SEH filter per window is a no-op racy against teardown.

## Stacked on

Sits on top of [#88](https://github.com/i999rri/GhosttyWin32/pull/88) (window registry). Uses the \`MainWindows\` aggregate the SEH handler needs to walk, so the sensible base is #88's HEAD; on merge, GitHub auto-retargets to \`dev\`.

## What moves where

| Piece | Was on | Now on |
|---|---|---|
| \`crashFlagPath()\` helper | MainWindow.xaml.cpp anonymous namespace + duplicate on App | Single copy on App.xaml.cpp |
| Flag write | App::OnLaunched (unchanged) | App::OnLaunched |
| Flag clear | MainWindow::~MainWindow | App::~App |
| \`SetUnhandledExceptionFilter\` registration | MainWindow ctor Activated handler | App::OnLaunched, right after the flag write |
| SEH handler body | \`MainWindow::OnUnhandledException\` | \`App::OnUnhandledException\` |

## Notes worth flagging

### \`friend struct App;\` on MainWindow

The SEH handler walks \`w->m_hwnd\` / \`w->m_tabs\` to release composition handles before WER takes over. Those are private on MainWindow, and the reader is now \`App::OnUnhandledException\` rather than a MainWindow member — so \`App\` needs the same friend access \`MainWindowRuntime\` already had. Documented next to the existing friend line.

### \`App::~App\` no longer \`= default\`

#85 declared \`~App()\` out-of-line to satisfy \`unique_ptr<MainWindowRuntime>\`'s incomplete-type destructor requirement. That out-of-line body was \`= default\`; it now has a two-line implementation that clears the crash flag. Same rationale for the declaration; the body just gained content.

### Behaviour unchanged today

Single-window: OnLaunched still paces the driver recovery, the SEH handler still walks the sole registered window on crash, clean shutdown still clears the flag. The only observable change is which class owns each piece — and with only one window in the aggregate, that owner change has no functional effect.

## Test plan

- [ ] Startup, verify \`GhosttyWin32_running.flag\` appears in %TEMP%
- [ ] Clean exit (X button), verify flag removed
- [ ] Kill process externally, restart — verify the 2-second driver recovery pause hits and the debug output logs it
- [ ] Normal terminal use unchanged (no regression from the file moves)
- [ ] Tab close / clipboard / shell exit still function