### PR TITLE
Implement NEW_WINDOW: spawn a second top-level MainWindow

### DIFF
--- a/App/App.xaml.cpp
+++ b/App/App.xaml.cpp
@@ -116,15 +116,17 @@ namespace winrt::GhosttyWin32::implementation
         winrt::Microsoft::Windows::AppLifecycle::AppActivationArguments const& args)
     {
         // Activated fires on a worker — bounce to the UI thread before
-        // touching the window. If the redirect happened before OnLaunched
-        // wired up `window`, just drop it; OnLaunched will run normally
-        // and present the terminal as a first-launch effect.
-        if (!window) return;
-        window.DispatcherQueue().TryEnqueue([weak = get_weak(), args]() {
-            if (auto self = weak.get()) {
-                self->HandleActivation(args);
-            }
-        });
+        // touching any Xaml state. If the redirect happened before
+        // OnLaunched added the first window, just drop it; OnLaunched
+        // will run normally and present the terminal as a first-launch
+        // effect.
+        if (m_topLevelWindows.empty()) return;
+        m_topLevelWindows.front().DispatcherQueue().TryEnqueue(
+            [weak = get_weak(), args]() {
+                if (auto self = weak.get()) {
+                    self->HandleActivation(args);
+                }
+            });
     }
 
     void App::HandleActivation(
@@ -138,10 +140,8 @@ namespace winrt::GhosttyWin32::implementation
         // forward; the surface-targeted route (clicks on toasts we
         // raised ourselves) is handled by OnNotificationInvoked, where
         // the args are in-process and safe to read.
-        if (auto mwProj = window.try_as<winrt::GhosttyWin32::MainWindow>()) {
-            if (auto* mw = winrt::get_self<implementation::MainWindow>(mwProj)) {
-                mw->PresentNotification(implementation::PaneId{ 0 });
-            }
+        if (auto* mw = m_windows.Any()) {
+            mw->PresentNotification(implementation::PaneId{ 0 });
         }
     }
 
@@ -149,19 +149,26 @@ namespace winrt::GhosttyWin32::implementation
     {
         // Called from the wWinMain-side NotificationInvoked subscriber
         // on a worker thread. Bounce to the UI thread before touching
-        // the window. If the click arrives before OnLaunched has
-        // wired `window`, drop it — the user just gets the regular
-        // foreground from AppInstance::Activated.
-        if (!window) return;
-        window.DispatcherQueue().TryEnqueue(
+        // any Xaml state. If the click arrives before OnLaunched has
+        // added the first window, drop it — the user just gets the
+        // regular foreground from AppInstance::Activated.
+        if (m_topLevelWindows.empty()) return;
+        m_topLevelWindows.front().DispatcherQueue().TryEnqueue(
             [weak = get_weak(), paneIdValue]()
             {
                 auto self = weak.get();
                 if (!self) return;
-                if (auto mwProj = self->window.try_as<winrt::GhosttyWin32::MainWindow>()) {
-                    if (auto* mw = winrt::get_self<implementation::MainWindow>(mwProj)) {
-                        mw->PresentNotification(implementation::PaneId{ paneIdValue });
-                    }
+                // Route the click to the specific window that owns
+                // the targeted pane; fall back to any live window if
+                // the id is the "no target" sentinel or the owning
+                // window has since closed.
+                PaneId target{ paneIdValue };
+                MainWindow* mw = target
+                    ? self->m_windows.FindForPaneId(target)
+                    : nullptr;
+                if (!mw) mw = self->m_windows.Any();
+                if (mw) {
+                    mw->PresentNotification(target);
                 }
             });
     }

--- a/App/App.xaml.cpp
+++ b/App/App.xaml.cpp
@@ -3,6 +3,7 @@
 #include "MainWindow.xaml.h"
 #include "Ghostty/MainWindowRuntime.h"
 #include "Ghostty/RuntimeConfigFactory.h"
+#include <algorithm>
 #include <filesystem>
 #include <fstream>
 #include <string>
@@ -295,7 +296,29 @@ namespace winrt::GhosttyWin32::implementation
             return;
         }
 
-        window = make<MainWindow>();
-        window.Activate();
+        CreateNewWindow();
+    }
+
+    void App::CreateNewWindow()
+    {
+        auto w = make<MainWindow>();
+        m_topLevelWindows.push_back(w);
+        // Auto-erase the vector entry when the user closes the
+        // window. Capture only `this`; the sender comes in through
+        // the event args, so no strong Window reference is trapped
+        // inside the lambda — closing really is the last thing that
+        // keeps the Window alive.
+        w.Closed([this](winrt::Windows::Foundation::IInspectable const& sender,
+                        winrt::Microsoft::UI::Xaml::WindowEventArgs const&) {
+            auto closing = sender.try_as<winrt::Microsoft::UI::Xaml::Window>();
+            if (!closing) return;
+            auto it = std::find(m_topLevelWindows.begin(),
+                                m_topLevelWindows.end(),
+                                closing);
+            if (it != m_topLevelWindows.end()) {
+                m_topLevelWindows.erase(it);
+            }
+        });
+        w.Activate();
     }
 }

--- a/App/App.xaml.cpp
+++ b/App/App.xaml.cpp
@@ -284,6 +284,9 @@ namespace winrt::GhosttyWin32::implementation
             .anyWindow = []() -> MainWindow* {
                 return App::g_app->Windows().Any();
             },
+            .findWindowByPaneId = [](PaneId id) -> MainWindow* {
+                return App::g_app->Windows().FindForPaneId(id);
+            },
         });
         m_ghostty = core::ghostty::App::Create(
             core::ghostty::RuntimeConfigFactory::Build(m_runtime.get()));

--- a/App/App.xaml.h
+++ b/App/App.xaml.h
@@ -3,6 +3,7 @@
 #include "App.xaml.g.h"
 #include "Ghostty/App.h"
 #include "MainWindows.h"
+#include "Tabs/Panes/PaneIdAllocator.h"
 #include <winrt/Microsoft.Windows.AppLifecycle.h>
 #include <winrt/Microsoft.Windows.AppNotifications.h>
 #include <memory>
@@ -77,6 +78,16 @@ namespace winrt::GhosttyWin32::implementation
         MainWindows&       Windows()       noexcept { return m_windows; }
         MainWindows const& Windows() const noexcept { return m_windows; }
 
+        // Process-wide PaneId allocator. Every leaf across every
+        // MainWindow draws its id from here so PaneIds are globally
+        // unique — that's what lets close_surface_cb route a
+        // ghostty-side close request to the exact pane by id alone,
+        // even when a second (or Nth) MainWindow enters the picture.
+        // Also what `AppNotification`'s `surfaceId=` argument encodes
+        // when a background notification click needs to focus a
+        // specific pane regardless of which window owns it.
+        PaneIdAllocator& PaneIds() noexcept { return m_paneIds; }
+
     private:
         // Subsequent-activation handler. The first activation runs through
         // OnLaunched; later activations (a second click of a notification,
@@ -112,6 +123,11 @@ namespace winrt::GhosttyWin32::implementation
         //      IGhosttyRuntime the factory's userdata pointer was
         //      aimed at.
         //
+        // Process-wide PaneId issuer. Held by App because MainWindow
+        // ctor / tab creation both need it before their own state is
+        // fully assembled; sharing the counter across windows keeps
+        // ids collision-free for close_surface_cb routing.
+        PaneIdAllocator                    m_paneIds;
         // `m_windows` is a borrow-only aggregate; its own destruction
         // order relative to the members below doesn't matter (the
         // pointers don't own the MainWindows, `window` does), but

--- a/App/App.xaml.h
+++ b/App/App.xaml.h
@@ -88,6 +88,15 @@ namespace winrt::GhosttyWin32::implementation
         // specific pane regardless of which window owns it.
         PaneIdAllocator& PaneIds() noexcept { return m_paneIds; }
 
+        // Spawns a fresh top-level MainWindow, plugs it into the
+        // aggregate (via its Activated handler) and shows it. Both
+        // `OnLaunched`'s initial window and future `NEW_WINDOW`
+        // action handlers go through here — one path, one lifetime
+        // story. A Closed subscription drops the strong reference
+        // when the user closes the window; the vector doesn't hold
+        // stale entries for windows that outlive their HWND.
+        void CreateNewWindow();
+
     private:
         // Subsequent-activation handler. The first activation runs through
         // OnLaunched; later activations (a second click of a notification,
@@ -111,9 +120,10 @@ namespace winrt::GhosttyWin32::implementation
         // declaration semantics. The members below MUST stay in this
         // order:
         //
-        //   1. `window` destructs first (last-declared) → every
-        //      MainWindow is released → every TerminalControl
-        //      detaches → every surface is freed.
+        //   1. `m_topLevelWindows` destructs first (last-declared) →
+        //      every Window handle releases → every MainWindow
+        //      destructor runs → every TerminalControl detaches →
+        //      every surface is freed.
         //   2. `m_ghostty` destructs → `ghostty_app_free` joins the
         //      surface / IO worker threads. In-flight callbacks fired
         //      from a thread that hasn't observed the join yet can
@@ -130,15 +140,24 @@ namespace winrt::GhosttyWin32::implementation
         PaneIdAllocator                    m_paneIds;
         // `m_windows` is a borrow-only aggregate; its own destruction
         // order relative to the members below doesn't matter (the
-        // pointers don't own the MainWindows, `window` does), but
-        // every MainWindow unregisters itself in its destructor which
-        // runs during step 1, so by the time we reach step 2 the
-        // aggregate is already empty.
+        // pointers don't own the MainWindows, `m_topLevelWindows`
+        // does), but every MainWindow unregisters itself in its
+        // destructor which runs during step 1, so by the time we
+        // reach step 2 the aggregate is already empty.
         MainWindows                        m_windows;
         std::unique_ptr<MainWindowRuntime> m_runtime;
         std::unique_ptr<core::ghostty::App> m_ghostty;
 
-        winrt::Microsoft::UI::Xaml::Window window{ nullptr };
+        // Strong references to every top-level window we've spawned.
+        // The vector owns each `Window` handle (the WinRT smart
+        // pointer form) until the user closes that window; a
+        // per-window Closed subscription installed by CreateNewWindow
+        // erases the matching entry so we don't stack up dangling
+        // handles across a long session. On App teardown, whatever's
+        // still here destructs during m_topLevelWindows' own
+        // destruction and each MainWindow unregisters itself from
+        // the aggregate above as part of the same unwind.
+        std::vector<winrt::Microsoft::UI::Xaml::Window> m_topLevelWindows;
         // Token for the primary AppInstance's Activated event; the
         // subscription lives for the lifetime of the App.
         winrt::event_token m_activatedToken{};

--- a/App/Ghostty/MainWindowRuntime.cpp
+++ b/App/Ghostty/MainWindowRuntime.cpp
@@ -85,17 +85,14 @@ void MainWindowRuntime::OnCloseSurface(void* paneIdUserdata)
 {
     // Shell exited (e.g. user typed `exit`) or ghostty otherwise asked
     // to close the surface. The userdata is the PaneId we set in
-    // TabFactory::MakeLeaf. Dispatch the UI mutation to the next UI
-    // tick so it happens off the renderer thread.
-    //
-    // PaneIds are per-window today (each MainWindow has its own
-    // allocator), so with multiple windows we'd need target routing
-    // here. Single-window makes `anyWindow` sufficient; #55's
-    // NEW_WINDOW work will revisit.
+    // TabFactory::MakeLeaf — a globally unique id, so resolving to
+    // the owning window is a lookup rather than "assume the only
+    // window." Dispatch the UI mutation to the next UI tick so it
+    // happens off the renderer thread.
     if (!m_host.isReady()) return;
-    auto* window = m_host.anyWindow();
-    if (!window) return;
     PaneId id = PaneId::FromUserdata(paneIdUserdata);
+    auto* window = m_host.findWindowByPaneId(id);
+    if (!window) return;
     window->DispatcherQueue().TryEnqueue([window, id]() {
         window->CloseSurfaceByPaneId(id);
     });

--- a/App/Ghostty/MainWindowRuntime.h
+++ b/App/Ghostty/MainWindowRuntime.h
@@ -7,7 +7,7 @@
 
 namespace winrt::GhosttyWin32::implementation {
 
-class MainWindow;
+struct MainWindow;
 
 // App-side implementation of the runtime hooks ghostty calls back
 // into. The factory in Core does the C↔C++ translation; this class

--- a/App/Ghostty/MainWindowRuntime.h
+++ b/App/Ghostty/MainWindowRuntime.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "Ghostty/IGhosttyRuntime.h"
+#include "Tabs/Panes/PaneId.h"
 
 #include <functional>
 
@@ -45,6 +46,12 @@ public:
     // no explicit target, APP-target actions.
     using AnyWindow = std::function<MainWindow*()>;
 
+    // Returns the window whose tab tree owns the given `PaneId`, or
+    // null. `close_surface_cb` gives us a userdata that's a globally
+    // unique PaneId (issued from the App-scope allocator), so this
+    // resolves to exactly one window even with several open.
+    using FindWindowByPaneId = std::function<MainWindow*(PaneId)>;
+
     // Bundle of callables the runtime consults. `App` fills each
     // slot at construction time. Reads at the call sites are
     // `m_host.xxx(...)`, so the runtime touches its dependencies
@@ -60,6 +67,7 @@ public:
         WakeupTick          wakeupTick;
         FindWindowBySurface findWindowBySurface;
         AnyWindow           anyWindow;
+        FindWindowByPaneId  findWindowByPaneId;
     };
 
     explicit MainWindowRuntime(Host host);

--- a/App/MainWindow.xaml.cpp
+++ b/App/MainWindow.xaml.cpp
@@ -53,7 +53,13 @@ namespace winrt::GhosttyWin32::implementation
         // dispatcher here (rather than waiting for Activated) keeps
         // the action_cb forwarder safe even if it fires through any
         // pre-Activated edge case.
-        m_ghosttyDispatcher = ghostty::CallbackDispatcher::Create(*this);
+        // NEW_WINDOW is App-scope: the "add another top-level window"
+        // operation doesn't belong on IWindow, so the factory takes
+        // it as a callable the App fills in. Same shape as
+        // MainWindowRuntime's Host bundle for other cross-scope hooks.
+        m_ghosttyDispatcher = ghostty::CallbackDispatcher::Create(
+            *this,
+            []() { if (App::g_app) App::g_app->CreateNewWindow(); });
 
         ExtendsContentIntoTitleBar(true);
 

--- a/App/MainWindow.xaml.cpp
+++ b/App/MainWindow.xaml.cpp
@@ -603,6 +603,11 @@ namespace winrt::GhosttyWin32::implementation
         return surface != nullptr && m_tabs.FindBySurface(surface) != nullptr;
     }
 
+    bool MainWindow::OwnsPane(PaneId id) const noexcept
+    {
+        return static_cast<bool>(id) && m_tabs.FindByPaneId(id).tab != nullptr;
+    }
+
     void MainWindow::NotifySurfaceFocused(ghostty_surface_t surface) noexcept
     {
         m_activeSurface = surface;
@@ -682,7 +687,7 @@ namespace winrt::GhosttyWin32::implementation
                 m_ghosttyApp->Handle(),
                 cfg,
                 m_hwnd,
-                m_paneIds,
+                App::g_app->PaneIds(),
                 std::move(onLeafFocused));
         }
     }

--- a/App/MainWindow.xaml.cpp
+++ b/App/MainWindow.xaml.cpp
@@ -64,9 +64,8 @@ namespace winrt::GhosttyWin32::implementation
         ExtendsContentIntoTitleBar(true);
 
         Activated([this](auto&&, auto&&) {
-            static bool initialized = false;
-            if (initialized) return;
-            initialized = true;
+            if (m_activatedOnce) return;
+            m_activatedOnce = true;
 
             // Enter the App-scope aggregate. Every caller —
             // runtime callbacks, target-based routing, the SEH

--- a/App/MainWindow.xaml.h
+++ b/App/MainWindow.xaml.h
@@ -209,6 +209,14 @@ namespace winrt::GhosttyWin32::implementation
         core::ghostty::App* m_ghosttyApp{ nullptr };
 
         HWND m_hwnd = nullptr;
+        // Activated fires whenever the window gains focus, but the
+        // one-shot setup below (HWND grab, tab-factory construction,
+        // first-tab spawn, etc.) is only meaningful on the first
+        // activation. Per-instance rather than a function-static
+        // bool because that shape leaked across MainWindow instances
+        // and left every window after the first stuck in the
+        // "already set up" branch with no HWND, no tabs, no terminal.
+        bool m_activatedOnce = false;
         // SIZE_LIMIT / TOGGLE_FULLSCREEN state. Default constructed
         // (no limit set, not in fullscreen). Subclasses installed
         // by SizeLimit are auto-removed by Win32 when m_hwnd is

--- a/App/MainWindow.xaml.h
+++ b/App/MainWindow.xaml.h
@@ -10,7 +10,7 @@
 #include "Host/IWindow.h"
 #include "Interop/Encoding.h"
 #include "Win32/Clipboard.h"
-#include "Tabs/Panes/PaneIdAllocator.h"
+#include "Tabs/Panes/PaneId.h"
 #include "Tabs/Tab.h"
 #include "Tabs/TabFactory.h"
 #include "Tabs/Tabs.h"
@@ -62,6 +62,12 @@ namespace winrt::GhosttyWin32::implementation
         // each in turn — the linear cost is fine at the scale a
         // multi-window session will reach in practice.
         bool OwnsSurface(ghostty_surface_t surface) const noexcept;
+
+        // Same shape as OwnsSurface but keyed by PaneId. Used by
+        // MainWindows::FindWindowByPaneId to route close_surface_cb —
+        // the userdata payload is a globally unique PaneId (App owns
+        // the allocator), so exactly one window returns true.
+        bool OwnsPane(PaneId id) const noexcept;
 
         // ----- IMainWindowView -----
         // Narrow surface the callback dispatcher / GhosttyActions
@@ -210,7 +216,6 @@ namespace winrt::GhosttyWin32::implementation
         ghostty::actions::tags::SizeLimit          m_sizeLimit;
         ghostty::actions::tags::Fullscreen         m_fullscreen;
         ghostty::actions::tags::WindowDecorations  m_windowDecorations;
-        PaneIdAllocator m_paneIds;
         Tabs m_tabs;
         // Focus-tracked active surface. Set by NotifySurfaceFocused
         // when a TerminalControl gains focus, cleared when the

--- a/App/MainWindows.cpp
+++ b/App/MainWindows.cpp
@@ -14,4 +14,13 @@ MainWindow* MainWindows::FindForSurface(ghostty_surface_t surface) const noexcep
     return nullptr;
 }
 
+MainWindow* MainWindows::FindForPaneId(PaneId id) const noexcept
+{
+    if (!id) return nullptr;
+    for (auto* w : m_windows) {
+        if (w && w->OwnsPane(id)) return w;
+    }
+    return nullptr;
+}
+
 }  // namespace winrt::GhosttyWin32::implementation

--- a/App/MainWindows.h
+++ b/App/MainWindows.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "Tabs/Panes/PaneId.h"
 #include "ghostty.h"
 
 #include <algorithm>
@@ -59,6 +60,12 @@ public:
     // Definition lives in MainWindows.cpp to break the header include
     // cycle (MainWindow needs to be complete for `OwnsSurface`).
     MainWindow* FindForSurface(ghostty_surface_t surface) const noexcept;
+
+    // Same shape as FindForSurface but keyed by PaneId. Used by the
+    // close_surface_cb path: ghostty hands us back the userdata we
+    // set on the surface (a PaneId), and we resolve it to the owning
+    // window by asking each in turn.
+    MainWindow* FindForPaneId(PaneId id) const noexcept;
 
     bool   Empty() const noexcept { return m_windows.empty(); }
     size_t Count() const noexcept { return m_windows.size(); }

--- a/App/MainWindows.h
+++ b/App/MainWindows.h
@@ -8,7 +8,7 @@
 
 namespace winrt::GhosttyWin32::implementation {
 
-class MainWindow;
+struct MainWindow;
 
 // Aggregate for the set of MainWindows live in the process. MainWindow
 // adds and removes itself as part of its own lifecycle; runtime

--- a/App/Tabs/Panes/PaneIdAllocator.h
+++ b/App/Tabs/Panes/PaneIdAllocator.h
@@ -5,12 +5,14 @@
 
 namespace winrt::GhosttyWin32::implementation {
 
-// Issues monotonically increasing PaneIds. One instance per MainWindow —
-// the counter is per-allocator (not process-global) so that test setups
-// or future multi-window scenarios get an isolated ID space without
-// having to clear hidden static state.
+// Issues monotonically increasing PaneIds. One instance lives on App
+// (process-wide) so every leaf across every MainWindow gets a unique
+// id — that's what makes `close_surface_cb`'s PaneId-in-userdata scheme
+// address the exact pane instead of a "first window's pane N" collision.
+// The `PaneId` type's uint64 value space is large enough that overflow
+// isn't a concern in practice.
 //
-// Move-disabled: fixed location for the lifetime of MainWindow.
+// Move-disabled: fixed location for App's lifetime.
 class PaneIdAllocator {
 public:
     PaneIdAllocator() = default;

--- a/Core/Ghostty/Actions/Actions.cpp
+++ b/Core/Ghostty/Actions/Actions.cpp
@@ -230,6 +230,18 @@ bool Actions::OnNewTab() {
     return true;
 }
 
+bool Actions::OnNewWindow() {
+    if (!m_newWindow) return false;
+    // Hop to the UI thread — CreateNewWindow builds a Xaml Window
+    // and every Xaml touch has to happen there. The `m_view`
+    // dispatch is a UI-thread hop that any live window can provide;
+    // we don't need our own dispatcher for this to arrive there.
+    m_view.Dispatch([this]() {
+        m_newWindow();
+    });
+    return true;
+}
+
 bool Actions::OnCloseTab(ghostty_surface_t surface) {
     if (!surface) return true;
     m_view.Dispatch([this, surface]() {

--- a/Core/Ghostty/Actions/Actions.h
+++ b/Core/Ghostty/Actions/Actions.h
@@ -3,6 +3,8 @@
 #include "Host/IWindow.h"
 #include "ghostty.h"
 #include <cstdint>
+#include <functional>
+#include <utility>
 
 namespace core::ghostty::actions {
 
@@ -24,7 +26,20 @@ namespace core::ghostty::actions {
 // the ghostty action_cb contract.
 class Actions {
 public:
-    explicit Actions(host::IWindow& view) noexcept : m_view(view) {}
+    // Spawns a top-level window at App scope. NEW_WINDOW is the one
+    // action that doesn't belong on IWindow — the per-window view
+    // doesn't own the "add another window" operation — so it's
+    // injected as a callable at construction time. Same shape as
+    // MainWindowRuntime's Host bundle for other cross-scope hooks.
+    using NewWindowFn = std::function<void()>;
+
+    // `newWindow` defaults to an empty `std::function` so unit tests
+    // that never exercise NEW_WINDOW keep the one-arg construction
+    // shape they already have; the OnNewWindow handler bails early
+    // when the slot is empty.
+    Actions(host::IWindow& view, NewWindowFn newWindow = {}) noexcept
+        : m_view(view)
+        , m_newWindow(std::move(newWindow)) {}
 
     // ----- terminal events -----
     bool OnRingBell();
@@ -51,9 +66,12 @@ public:
     bool OnResetWindowSize();
 
     // ----- tab lifecycle / navigation / title -----
-    // NEW_TAB and NEW_WINDOW both land here in the single-window
-    // build; multi-window (#55) will route NEW_WINDOW elsewhere.
     bool OnNewTab();
+    // NEW_WINDOW: spawn a fresh top-level MainWindow. Bounces
+    // through the injected NewWindowFn (which App fills with
+    // `App::g_app->CreateNewWindow()`); Actions doesn't know or
+    // care what a "window" is at that layer.
+    bool OnNewWindow();
     bool OnCloseTab(ghostty_surface_t surface);
     bool OnGotoTab(int requested);
     bool OnMoveTab(ghostty_action_move_tab_s move);
@@ -92,6 +110,7 @@ public:
 
 private:
     host::IWindow& m_view;
+    NewWindowFn    m_newWindow;
 
     // Initial window size from GHOSTTY_ACTION_INITIAL_SIZE
     // (physical pixels). Zero means "not yet received" —

--- a/Core/Ghostty/CallbackDispatcher.cpp
+++ b/Core/Ghostty/CallbackDispatcher.cpp
@@ -3,8 +3,12 @@
 namespace core::ghostty {
 
 std::unique_ptr<CallbackDispatcher>
-CallbackDispatcher::Create(host::IWindow& view) {
-    return std::unique_ptr<CallbackDispatcher>(new CallbackDispatcher(view));
+CallbackDispatcher::Create(host::IWindow& view,
+                           actions::Actions::NewWindowFn newWindow) {
+    // Default for `newWindow` lives on the declaration; the
+    // definition can't repeat it or the compiler flags a duplicate.
+    return std::unique_ptr<CallbackDispatcher>(
+        new CallbackDispatcher(view, std::move(newWindow)));
 }
 
 bool CallbackDispatcher::DispatchAction(ghostty_target_s target, ghostty_action_s action) {
@@ -51,11 +55,10 @@ bool CallbackDispatcher::DispatchAction(ghostty_target_s target, ghostty_action_
             return m_actions.OnResetWindowSize();
 
         // ----- tab lifecycle / navigation / title -----
-        // NEW_WINDOW collapses to NEW_TAB on the single-window
-        // build; multi-window (#55) will split them again.
         case GHOSTTY_ACTION_NEW_TAB:
-        case GHOSTTY_ACTION_NEW_WINDOW:
             return m_actions.OnNewTab();
+        case GHOSTTY_ACTION_NEW_WINDOW:
+            return m_actions.OnNewWindow();
         case GHOSTTY_ACTION_CLOSE_TAB:
             if (target.tag == GHOSTTY_TARGET_SURFACE)
                 return m_actions.OnCloseTab(target.target.surface);

--- a/Core/Ghostty/CallbackDispatcher.h
+++ b/Core/Ghostty/CallbackDispatcher.h
@@ -30,7 +30,13 @@ namespace core::ghostty {
 // call site — the option-value is the signature, not the body.
 class CallbackDispatcher {
 public:
-    static std::unique_ptr<CallbackDispatcher> Create(host::IWindow& view);
+    // `newWindow` defaults to empty so existing single-arg call
+    // sites (the CallbackDispatcher unit tests never fire
+    // NEW_WINDOW) stay compilable without the dispatcher spilling
+    // NEW_WINDOW knowledge into its factory contract.
+    static std::unique_ptr<CallbackDispatcher> Create(
+        host::IWindow& view,
+        actions::Actions::NewWindowFn newWindow = {});
 
     // Route a ghostty action_cb invocation. Returns true when the
     // action was handled (matches the ghostty action_cb contract:
@@ -39,8 +45,9 @@ public:
     bool DispatchAction(ghostty_target_s target, ghostty_action_s action);
 
 private:
-    explicit CallbackDispatcher(host::IWindow& view) noexcept
-        : m_actions(view) {}
+    CallbackDispatcher(host::IWindow& view,
+                       actions::Actions::NewWindowFn newWindow) noexcept
+        : m_actions(view, std::move(newWindow)) {}
 
     actions::Actions m_actions;
 };


### PR DESCRIPTION
## Summary

Wire NEW_WINDOW end-to-end. The action used to collapse to NEW_TAB in the dispatcher; this PR gives it real semantics — a fresh top-level MainWindow that plugs itself into the App-scope aggregate exactly the way the initial window does.

Requires and consumes the aggregate + registry + crash-lift work stacked below it.

## Stacked on

Sits on top of [#89](https://github.com/i999rri/GhosttyWin32/pull/89) (crash flag / SEH lift). GitHub auto-retargets to \`dev\` as the underlying PRs land.

## Commit-by-commit

| | Commit | What it does |
|---|---|---|
| 1 | \`Lift PaneIdAllocator to App scope for global uniqueness\` | \`PaneIdAllocator\` moves from MainWindow to App so ids are unique across every window (necessary for \`close_surface_cb\` to route to the correct owning MainWindow via the new lookup). Adds \`MainWindow::OwnsPane\` and \`MainWindows::FindForPaneId\` mirroring the existing \`OwnsSurface\` / \`FindForSurface\` shape. \`MainWindowRuntime::Host\` grows a \`findWindowByPaneId\` slot; \`OnCloseSurface\` uses it instead of \`anyWindow\`. |
| 2 | \`Introduce App::CreateNewWindow and hold windows in a vector\` | \`App::window\` (single field) → \`std::vector<Window> m_topLevelWindows\`. \`App::CreateNewWindow\` extracts the "spawn a top-level window" path — \`make<MainWindow>\`, register into the vector, subscribe to \`Closed\` for auto-erase, activate. \`OnLaunched\` uses it for the initial window too, so there's one path, one lifetime story. |
| 3 | \`Wire NEW_WINDOW action to App::CreateNewWindow\` | \`Actions::NewWindowFn\` type + \`OnNewWindow\` handler + \`Actions\` ctor takes the callable. \`CallbackDispatcher::Create\` grows a matching arg and forwards. \`MainWindow\`'s ctor supplies \`[]() { if (App::g_app) App::g_app->CreateNewWindow(); }\` when it builds its dispatcher. The dispatcher switch splits NEW_WINDOW from the NEW_TAB fallthrough. \`NewWindowFn\` defaults to empty so existing single-arg unit tests keep compiling. |
| 4 | \`Move MainWindow's Activated one-shot guard to a per-instance flag\` | \`static bool initialized\` inside the Activated lambda was function-scope, so window 2's first activation saw the flag already true from window 1's setup and returned early — no HWND, no tab factory, no first tab. Move the gate to \`MainWindow::m_activatedOnce\`. |

## Notes worth flagging

### Injection widening

\`MainWindowRuntime::Host\` now bundles four callables: \`isReady\`, \`wakeupTick\`, \`findWindowBySurface\`, \`anyWindow\`, and (new) \`findWindowByPaneId\`. Same struct-with-callable-fields pattern established in earlier PRs; adding a fifth slot didn't require touching the class body outside the struct.

### PaneId global uniqueness

Prerequisite for \`close_surface_cb\` to identify the correct pane in the correct window from userdata alone. Alternatives considered (heap-allocated \`{MainWindow*, PaneId}\` userdata, bit-packing) were more complex and had lifetime / portability drawbacks.

### App::CreateNewWindow's \`Closed\` handler

Captures \`this\` only; the closing Window arrives via event args' \`sender\`, so no strong reference is trapped in the handler. The vector entry erases on close.

## Known issues

Multi-window works but has follow-up problems observed in testing:

- **Focus ping-pong across overlapping windows** — cross-window activation transitions race with \`MainWindow\`'s spurious-deactivation recovery (originally added in #56 for HTCAPTION modal loops), causing focus to bounce back to window 1 after typing in window 2. Being addressed in a follow-up PR.
- **RO_E_CLOSED under certain tab-close sequences** ([#87](https://github.com/i999rri/GhosttyWin32/issues/87)) — pre-existing, unrelated to this PR.

## Test plan

- [ ] Startup, basic terminal use
- [ ] Ctrl+Shift+N spawns a second window (single-window path preserved)
- [ ] Window 2 registers via aggregate — actions, clipboard, close_surface all route to the correct window
- [ ] Shell \`exit\` in window 2's terminal closes window 2's tab, not window 1's
- [ ] Close window 2 via X button; window 1 survives
- [ ] Close last window → clean process exit
- [ ] Existing Core / Tests project builds against the defaulted \`NewWindowFn\` parameter (no test edits needed)