### PR TITLE
Drop MainWindow spurious-deactivation self-Activate

### DIFF
--- a/App/MainWindow.xaml.cpp
+++ b/App/MainWindow.xaml.cpp
@@ -162,6 +162,24 @@ namespace winrt::GhosttyWin32::implementation
                     if (args.WindowActivationState() == State::Deactivated) {
                         if (auto* tc = self->ActiveControl()) {
                             tc->NotifyImeFocusLeave();
+                            // Window-level activation crosses windows
+                            // without firing the control's LostFocus
+                            // (XAML logical focus stays on the control
+                            // while the window is inactive), so drop
+                            // the renderer-side focus here. Gated on
+                            // the OS foreground truth + deduped:
+                            // WinUI3 Activated oscillates with
+                            // multiple windows on one thread, and
+                            // forwarding it verbatim spams the
+                            // renderer with .focus messages — each of
+                            // which produces a frame, which is enough
+                            // continuous presenting to re-trigger the
+                            // multi-window overlap flicker.
+                            if (self->m_rendererFocus &&
+                                !self->IsForeground()) {
+                                self->m_rendererFocus = false;
+                                tc->Surface().SetFocus(false);
+                            }
                         }
                         // Title-bar HTCAPTION modal-loop recovery is
                         // handled by the DragRegion PointerReleased
@@ -203,11 +221,38 @@ namespace winrt::GhosttyWin32::implementation
                             auto self = weakActivated.get();
                             if (!self) return;
                             try {
+                                // Bail unless this window is REALLY the
+                                // OS foreground by the time this runs.
+                                // With two windows on one thread the
+                                // Activated events oscillate, and
+                                // running this restore path on a
+                                // window that has already lost
+                                // activation is what sustains the
+                                // ping-pong: Focus() on an element in
+                                // an inactive window re-activates that
+                                // window, yanking foreground back from
+                                // the sibling — whose own pending
+                                // restore then yanks it again, forever.
+                                // The OS foreground check at execution
+                                // (not enqueue) time breaks the cycle:
+                                // a stale restore becomes a no-op.
+                                if (!self->IsForeground()) {
+                                    return;
+                                }
                                 if (auto* tab = self->ActiveTab()) {
                                     tab->Focus();
                                 }
                                 if (auto* tc = self->ActiveControl()) {
                                     tc->NotifyImeFocusEnter();
+                                    // Counterpart of the Deactivated
+                                    // branch: if XAML focus never left
+                                    // the control, GotFocus won't
+                                    // re-fire, so restore the renderer
+                                    // focus explicitly (deduped).
+                                    if (!self->m_rendererFocus) {
+                                        self->m_rendererFocus = true;
+                                        tc->Surface().SetFocus(true);
+                                    }
                                 }
                             } catch (winrt::hresult_error const&) {
                             }

--- a/App/MainWindow.xaml.cpp
+++ b/App/MainWindow.xaml.cpp
@@ -163,35 +163,23 @@ namespace winrt::GhosttyWin32::implementation
                         if (auto* tc = self->ActiveControl()) {
                             tc->NotifyImeFocusLeave();
                         }
-                        // Spurious-deactivation recovery, deferred.
-                        // The Win32 title-bar tracking modal loop
-                        // DefWindowProc runs for HTCAPTION clicks
-                        // briefly steals foreground for tracking
-                        // proxies, so a synchronous
-                        // GetForegroundWindow() check here reads a
-                        // transient non-our-HWND value and
-                        // misclassifies the spurious deactivation as
-                        // genuine. Bouncing through the dispatcher
-                        // delays the check until after the modal loop
-                        // returns and foreground state settles. If by
-                        // then our HWND is still foreground, we
-                        // self-Activate so the activated branch of
-                        // this same handler re-runs and queues the
-                        // focus restore. Genuine deactivation leaves
-                        // foreground on the other app, so the check
-                        // skips re-activation and the window properly
-                        // backgrounds.
-                        auto dq = self->DispatcherQueue();
-                        if (dq) {
-                            dq.TryEnqueue([weakActivated]() {
-                                auto self = weakActivated.get();
-                                if (!self || !self->m_hwnd) return;
-                                if (GetForegroundWindow() == self->m_hwnd) {
-                                    try { self->Activate(); }
-                                    catch (winrt::hresult_error const&) {}
-                                }
-                            });
-                        }
+                        // Title-bar HTCAPTION modal-loop recovery is
+                        // handled by the DragRegion PointerReleased
+                        // handler set up further down — it re-focuses
+                        // through the dispatcher regardless of how
+                        // Activated resolves the click, which is the
+                        // reliable path. The earlier
+                        // GetForegroundWindow-based re-Activate here
+                        // was a supplementary recovery for the same
+                        // scenario; with multiple top-level windows
+                        // it fires spuriously on legitimate cross-
+                        // window switches — the check briefly reads
+                        // our HWND while Windows is still routing the
+                        // WM_ACTIVATE pair between siblings — and
+                        // ping-pongs focus back to whichever window
+                        // deactivated last. Trust WinUI's Deactivated
+                        // as authoritative and let PointerReleased
+                        // handle the drag case.
                         return;
                     }
                     // Window came back into focus. Restoring focus

--- a/App/MainWindow.xaml.cpp
+++ b/App/MainWindow.xaml.cpp
@@ -261,6 +261,25 @@ namespace winrt::GhosttyWin32::implementation
                 }
             });
 
+            // Renderer-side occlusion. While the window is hidden
+            // (minimize, Win+D, tray) every surface's renderer thread
+            // can stop producing frames entirely instead of ticking
+            // blink / safety-net presents; VisibilityChanged fires for
+            // both directions and the restore path redraws once from
+            // the renderer's .visible handler, so no stale frame is
+            // shown. Same weak_ref/try-catch rationale as the
+            // Activated handler above.
+            VisibilityChanged([weakActivated](
+                winrt::Windows::Foundation::IInspectable const&,
+                winrt::Microsoft::UI::Xaml::WindowVisibilityChangedEventArgs const& args) {
+                auto self = weakActivated.get();
+                if (!self) return;
+                try {
+                    self->BroadcastOcclusion(args.Visible());
+                } catch (winrt::hresult_error const&) {
+                }
+            });
+
             auto tv = TabView();
             // Don't call Window.SetTitleBar(AppTitleBar()) — that would
             // make the whole chrome row OS-title-bar input, including the
@@ -1381,6 +1400,23 @@ namespace winrt::GhosttyWin32::implementation
                 }
             }
             return best;
+        }
+    }
+
+    void MainWindow::BroadcastOcclusion(bool visible)
+    {
+        for (auto& tab : m_tabs) {
+            if (!tab) continue;
+            auto* panelImpl =
+                winrt::get_self<implementation::SplitPanel>(tab->Panel());
+            if (!panelImpl) continue;
+            std::vector<Pane*> leaves;
+            CollectLeaves(panelImpl->Root(), leaves);
+            for (auto* leaf : leaves) {
+                if (auto* tc = Tab::LeafToTerminalControl(*leaf)) {
+                    tc->Surface().SetOcclusion(visible);
+                }
+            }
         }
     }
 

--- a/App/MainWindow.xaml.h
+++ b/App/MainWindow.xaml.h
@@ -192,6 +192,13 @@ namespace winrt::GhosttyWin32::implementation
         // list. Dispatched from close_surface_cb. UI thread only.
         void CloseSurfaceByPaneId(PaneId id);
 
+        // Push renderer-side visibility to every surface in this
+        // window (all tabs, all panes). Driven by
+        // Window.VisibilityChanged: while hidden/minimized each
+        // surface's renderer thread skips draws entirely instead of
+        // ticking its blink / safety-net presents. UI thread only.
+        void BroadcastOcclusion(bool visible);
+
         // True when this window's HWND is the OS foreground window.
         // WinUI3's Window.Activated oscillates continuously when
         // multiple windows share one UI thread, so activation-driven

--- a/App/MainWindow.xaml.h
+++ b/App/MainWindow.xaml.h
@@ -192,6 +192,23 @@ namespace winrt::GhosttyWin32::implementation
         // list. Dispatched from close_surface_cb. UI thread only.
         void CloseSurfaceByPaneId(PaneId id);
 
+        // True when this window's HWND is the OS foreground window.
+        // WinUI3's Window.Activated oscillates continuously when
+        // multiple windows share one UI thread, so activation-driven
+        // work must not trust the event state verbatim — this per-call
+        // Win32 query stays stable through the oscillation and always
+        // reflects reality without any lifecycle to maintain.
+        bool IsForeground() const noexcept {
+            return m_hwnd != nullptr && m_hwnd == ::GetForegroundWindow();
+        }
+
+        // Last renderer-side focus value forwarded for this window.
+        // Forwards are gated on IsForeground() and deduped here —
+        // every ghostty .focus message triggers a renderer frame, so
+        // redundant sends are not free. Starts true to match ghostty's
+        // surface default.
+        bool m_rendererFocus{ true };
+
         // Borrowed pointer into the App-scope core::ghostty::App
         // (owned by `winrt::App::m_ghostty`). Set in MainWindow's
         // constructor — App's OnLaunched creates ghostty BEFORE

--- a/App/TerminalControl.xaml.cpp
+++ b/App/TerminalControl.xaml.cpp
@@ -105,6 +105,12 @@ namespace winrt::GhosttyWin32::implementation
             if (self->m_onFocused && self->m_surface) {
                 self->m_onFocused(self->m_surface.Handle());
             }
+            // Tell the renderer thread this surface is the focused
+            // one. ghostty defaults every surface to focused, so
+            // without this the losing pane's renderer keeps the fast
+            // poll cadence and keeps blink-presenting alongside the
+            // gaining one.
+            self->m_surface.SetFocus(true);
         });
 
         LostFocus([weakSelf](auto&&, auto&&) {
@@ -112,6 +118,7 @@ namespace winrt::GhosttyWin32::implementation
             if (!self) return;
             if (self->m_editContext) self->m_editContext.NotifyFocusLeave();
             // No dim change here — see the GotFocus comment above.
+            self->m_surface.SetFocus(false);
         });
 
         PointerMoved([weakSelf](auto&&, muxi::PointerRoutedEventArgs const& args) {

--- a/Core/Ghostty/Surface.h
+++ b/Core/Ghostty/Surface.h
@@ -103,6 +103,12 @@ public:
     void SetFocus(bool focused) noexcept {
         if (m_handle) ghostty_surface_set_focus(m_handle, focused);
     }
+    // Renderer-side visibility. While false the renderer thread skips
+    // draws entirely and parks the surface's DComp visual; the frame
+    // shown at the time of hiding is redrawn on the next show.
+    void SetOcclusion(bool visible) noexcept {
+        if (m_handle) ghostty_surface_set_occlusion(m_handle, visible);
+    }
     void SetSize(uint32_t w, uint32_t h) noexcept {
         if (m_handle) ghostty_surface_set_size(m_handle, w, h);
     }

--- a/Core/Ghostty/Surface.h
+++ b/Core/Ghostty/Surface.h
@@ -96,6 +96,13 @@ public:
     void Refresh() noexcept {
         if (m_handle) ghostty_surface_refresh(m_handle);
     }
+    // Renderer-side focus state. Drives the renderer thread's cadence
+    // (focused surfaces poll faster) and cursor-blink gating; ghostty
+    // defaults every surface to focused, so without these calls every
+    // window keeps blink-presenting forever.
+    void SetFocus(bool focused) noexcept {
+        if (m_handle) ghostty_surface_set_focus(m_handle, focused);
+    }
     void SetSize(uint32_t w, uint32_t h) noexcept {
         if (m_handle) ghostty_surface_set_size(m_handle, w, h);
     }


### PR DESCRIPTION
## Summary

Remove the deferred \`self->Activate()\` inside \`MainWindow\`'s Deactivated branch. Single-window is unaffected (title-bar drag focus recovery still runs through the DragRegion PointerReleased handler); multi-window loses the worst of its focus-bouncing symptoms.

## Stacked on

Sits on [#90](https://github.com/i999rri/GhosttyWin32/pull/90) (NEW_WINDOW impl). Auto-retargets to \`dev\` as the underlying PRs land.

## Background

The removed code came from #56 (split-pane), evolved through several attempts to fix a specific single-window bug: clicking on title-bar caption areas would trigger Win32's HTCAPTION modal loop, WinUI observed a Deactivated it never cleanly recovered from, and focus / keyboard input died until the user clicked something else.

The version that reliably solves that bug is the \`DragRegion.PointerReleased\` handler further down in the same file (also from #56). It fires on any title-bar click and re-focuses the active tab through the dispatcher, independent of how the activation state resolves. With \`ExtendsContentIntoTitleBar(true)\`, the DragRegion covers the whole title bar strip, so PointerReleased catches every click that HTCAPTION intercepts.

The \`GetForegroundWindow()\`-based re-Activate here was supplementary — a second-chance path for the same scenario the PointerReleased handler already covers.

## Why it now hurts

With multiple top-level MainWindows, cross-window activation races the check. When Windows dispatches a WM_ACTIVATE pair from window A to window B:

- window A's WinUI Deactivated fires first
- the deferred foreground check runs before window B's WM_ACTIVATE(WA_ACTIVE) has settled Windows' foreground pointer
- \`GetForegroundWindow() == m_hwnd\` reads true briefly
- window A calls \`Activate()\` → snaps focus back
- window B then sees Deactivated → same code runs there
- infinite ping-pong: overlapping windows flicker, keystrokes typed in the "new" window arrive on the "old" one

Trust WinUI's Deactivated as authoritative — the pattern every mature WinUI-based multi-window app follows.

## Behaviour change

- **Multi-window**: cross-window focus is stable during the moment right after a click. Ping-pong is gone. Not every multi-window issue is solved (see below), but the specific "window 1 steals focus back from window 2" case is resolved.
- **Single-window**: HTCAPTION title-bar clicks continue to restore focus via the DragRegion PointerReleased path. Verified with title-bar drags and clicks in caption areas — no regression.

## Known remaining multi-window issues

Multi-window is still not fully polished after this PR — some interaction weirdness under overlap remains. Investigating separately; not a blocker for landing this fix, which is a net win on both single- and multi-window workloads.

## Test plan

- [ ] Single-window: click title bar in various positions (drag strip, tab-and-edge gap, tab-header area) → focus remains on active tab or restores immediately via DragRegion PointerReleased
- [ ] Single-window: drag title bar to move the window → IME state remains coherent
- [ ] Multi-window: spawn window 2, click on it → focus stays on window 2, no visible flicker
- [ ] Multi-window: type in window 2 → keys land on window 2's terminal (previously they'd bounce to window 1)