### PR TITLE
Wire renderer focus/occlusion to stop multi-window overlap flicker

### DIFF
--- a/App/MainWindow.xaml.cpp
+++ b/App/MainWindow.xaml.cpp
@@ -162,6 +162,24 @@ namespace winrt::GhosttyWin32::implementation
                     if (args.WindowActivationState() == State::Deactivated) {
                         if (auto* tc = self->ActiveControl()) {
                             tc->NotifyImeFocusLeave();
+                            // Window-level activation crosses windows
+                            // without firing the control's LostFocus
+                            // (XAML logical focus stays on the control
+                            // while the window is inactive), so drop
+                            // the renderer-side focus here. Gated on
+                            // the OS foreground truth + deduped:
+                            // WinUI3 Activated oscillates with
+                            // multiple windows on one thread, and
+                            // forwarding it verbatim spams the
+                            // renderer with .focus messages — each of
+                            // which produces a frame, which is enough
+                            // continuous presenting to re-trigger the
+                            // multi-window overlap flicker.
+                            if (self->m_rendererFocus &&
+                                !self->IsForeground()) {
+                                self->m_rendererFocus = false;
+                                tc->Surface().SetFocus(false);
+                            }
                         }
                         // Title-bar HTCAPTION modal-loop recovery is
                         // handled by the DragRegion PointerReleased
@@ -203,11 +221,38 @@ namespace winrt::GhosttyWin32::implementation
                             auto self = weakActivated.get();
                             if (!self) return;
                             try {
+                                // Bail unless this window is REALLY the
+                                // OS foreground by the time this runs.
+                                // With two windows on one thread the
+                                // Activated events oscillate, and
+                                // running this restore path on a
+                                // window that has already lost
+                                // activation is what sustains the
+                                // ping-pong: Focus() on an element in
+                                // an inactive window re-activates that
+                                // window, yanking foreground back from
+                                // the sibling — whose own pending
+                                // restore then yanks it again, forever.
+                                // The OS foreground check at execution
+                                // (not enqueue) time breaks the cycle:
+                                // a stale restore becomes a no-op.
+                                if (!self->IsForeground()) {
+                                    return;
+                                }
                                 if (auto* tab = self->ActiveTab()) {
                                     tab->Focus();
                                 }
                                 if (auto* tc = self->ActiveControl()) {
                                     tc->NotifyImeFocusEnter();
+                                    // Counterpart of the Deactivated
+                                    // branch: if XAML focus never left
+                                    // the control, GotFocus won't
+                                    // re-fire, so restore the renderer
+                                    // focus explicitly (deduped).
+                                    if (!self->m_rendererFocus) {
+                                        self->m_rendererFocus = true;
+                                        tc->Surface().SetFocus(true);
+                                    }
                                 }
                             } catch (winrt::hresult_error const&) {
                             }

--- a/App/MainWindow.xaml.cpp
+++ b/App/MainWindow.xaml.cpp
@@ -261,6 +261,25 @@ namespace winrt::GhosttyWin32::implementation
                 }
             });
 
+            // Renderer-side occlusion. While the window is hidden
+            // (minimize, Win+D, tray) every surface's renderer thread
+            // can stop producing frames entirely instead of ticking
+            // blink / safety-net presents; VisibilityChanged fires for
+            // both directions and the restore path redraws once from
+            // the renderer's .visible handler, so no stale frame is
+            // shown. Same weak_ref/try-catch rationale as the
+            // Activated handler above.
+            VisibilityChanged([weakActivated](
+                winrt::Windows::Foundation::IInspectable const&,
+                winrt::Microsoft::UI::Xaml::WindowVisibilityChangedEventArgs const& args) {
+                auto self = weakActivated.get();
+                if (!self) return;
+                try {
+                    self->BroadcastOcclusion(args.Visible());
+                } catch (winrt::hresult_error const&) {
+                }
+            });
+
             auto tv = TabView();
             // Don't call Window.SetTitleBar(AppTitleBar()) — that would
             // make the whole chrome row OS-title-bar input, including the
@@ -1381,6 +1400,23 @@ namespace winrt::GhosttyWin32::implementation
                 }
             }
             return best;
+        }
+    }
+
+    void MainWindow::BroadcastOcclusion(bool visible)
+    {
+        for (auto& tab : m_tabs) {
+            if (!tab) continue;
+            auto* panelImpl =
+                winrt::get_self<implementation::SplitPanel>(tab->Panel());
+            if (!panelImpl) continue;
+            std::vector<Pane*> leaves;
+            CollectLeaves(panelImpl->Root(), leaves);
+            for (auto* leaf : leaves) {
+                if (auto* tc = Tab::LeafToTerminalControl(*leaf)) {
+                    tc->Surface().SetOcclusion(visible);
+                }
+            }
         }
     }
 

--- a/App/MainWindow.xaml.h
+++ b/App/MainWindow.xaml.h
@@ -192,6 +192,13 @@ namespace winrt::GhosttyWin32::implementation
         // list. Dispatched from close_surface_cb. UI thread only.
         void CloseSurfaceByPaneId(PaneId id);
 
+        // Push renderer-side visibility to every surface in this
+        // window (all tabs, all panes). Driven by
+        // Window.VisibilityChanged: while hidden/minimized each
+        // surface's renderer thread skips draws entirely instead of
+        // ticking its blink / safety-net presents. UI thread only.
+        void BroadcastOcclusion(bool visible);
+
         // True when this window's HWND is the OS foreground window.
         // WinUI3's Window.Activated oscillates continuously when
         // multiple windows share one UI thread, so activation-driven

--- a/App/MainWindow.xaml.h
+++ b/App/MainWindow.xaml.h
@@ -192,6 +192,23 @@ namespace winrt::GhosttyWin32::implementation
         // list. Dispatched from close_surface_cb. UI thread only.
         void CloseSurfaceByPaneId(PaneId id);
 
+        // True when this window's HWND is the OS foreground window.
+        // WinUI3's Window.Activated oscillates continuously when
+        // multiple windows share one UI thread, so activation-driven
+        // work must not trust the event state verbatim — this per-call
+        // Win32 query stays stable through the oscillation and always
+        // reflects reality without any lifecycle to maintain.
+        bool IsForeground() const noexcept {
+            return m_hwnd != nullptr && m_hwnd == ::GetForegroundWindow();
+        }
+
+        // Last renderer-side focus value forwarded for this window.
+        // Forwards are gated on IsForeground() and deduped here —
+        // every ghostty .focus message triggers a renderer frame, so
+        // redundant sends are not free. Starts true to match ghostty's
+        // surface default.
+        bool m_rendererFocus{ true };
+
         // Borrowed pointer into the App-scope core::ghostty::App
         // (owned by `winrt::App::m_ghostty`). Set in MainWindow's
         // constructor — App's OnLaunched creates ghostty BEFORE

--- a/App/TerminalControl.xaml.cpp
+++ b/App/TerminalControl.xaml.cpp
@@ -105,6 +105,12 @@ namespace winrt::GhosttyWin32::implementation
             if (self->m_onFocused && self->m_surface) {
                 self->m_onFocused(self->m_surface.Handle());
             }
+            // Tell the renderer thread this surface is the focused
+            // one. ghostty defaults every surface to focused, so
+            // without this the losing pane's renderer keeps the fast
+            // poll cadence and keeps blink-presenting alongside the
+            // gaining one.
+            self->m_surface.SetFocus(true);
         });
 
         LostFocus([weakSelf](auto&&, auto&&) {
@@ -112,6 +118,7 @@ namespace winrt::GhosttyWin32::implementation
             if (!self) return;
             if (self->m_editContext) self->m_editContext.NotifyFocusLeave();
             // No dim change here — see the GotFocus comment above.
+            self->m_surface.SetFocus(false);
         });
 
         PointerMoved([weakSelf](auto&&, muxi::PointerRoutedEventArgs const& args) {

--- a/Core/Ghostty/Surface.h
+++ b/Core/Ghostty/Surface.h
@@ -103,6 +103,12 @@ public:
     void SetFocus(bool focused) noexcept {
         if (m_handle) ghostty_surface_set_focus(m_handle, focused);
     }
+    // Renderer-side visibility. While false the renderer thread skips
+    // draws entirely and parks the surface's DComp visual; the frame
+    // shown at the time of hiding is redrawn on the next show.
+    void SetOcclusion(bool visible) noexcept {
+        if (m_handle) ghostty_surface_set_occlusion(m_handle, visible);
+    }
     void SetSize(uint32_t w, uint32_t h) noexcept {
         if (m_handle) ghostty_surface_set_size(m_handle, w, h);
     }

--- a/Core/Ghostty/Surface.h
+++ b/Core/Ghostty/Surface.h
@@ -96,6 +96,13 @@ public:
     void Refresh() noexcept {
         if (m_handle) ghostty_surface_refresh(m_handle);
     }
+    // Renderer-side focus state. Drives the renderer thread's cadence
+    // (focused surfaces poll faster) and cursor-blink gating; ghostty
+    // defaults every surface to focused, so without these calls every
+    // window keeps blink-presenting forever.
+    void SetFocus(bool focused) noexcept {
+        if (m_handle) ghostty_surface_set_focus(m_handle, focused);
+    }
     void SetSize(uint32_t w, uint32_t h) noexcept {
         if (m_handle) ghostty_surface_set_size(m_handle, w, h);
     }


### PR DESCRIPTION
## Why

Overlapping two top-level windows makes the window area strobe continuously even when idle (NVIDIA). Root cause is on the libghostty side: the native DirectX render loop presented a full frame every 4/16 ms per surface unconditionally, and two overlapping flip-model swap chains presenting every cycle cause DWM overlay-plane (MPO) churn. Fixed by making the render loop event-driven in i999rri/ghostty#42 — this PR is the host-side counterpart.

The host never called `ghostty_surface_set_focus` / `ghostty_surface_set_occlusion`, so every surface's renderer thread permanently believed it was focused and visible: every window kept the fast poll cadence and kept blink-presenting even while inactive or minimized.

Note: the earlier attempt to fix the flicker by skipping `GHOSTTY_ACTION_RENDER` for non-foreground windows is **not** included in this branch (it sits only on `feat/multi-window-polish`). That action only triggers `ghostty_app_tick` and never touches Present, so it could not stop the flicker and would only freeze background windows' app ticks.

<details><summary>日本語</summary>

2つのトップレベルウインドウを重ねると、アイドルでも全面がちらつく (NVIDIA)。根本原因は libghostty 側: native DirectX render loop が surface ごとに 4/16ms で無条件にフル Present しており、重なった2つの flip-model swapchain の毎サイクル Present が DWM の overlay plane (MPO) churn を引き起こす。i999rri/ghostty#42 で render loop をイベント駆動化して修正 — 本 PR はそのホスト側対応。

ホストは `ghostty_surface_set_focus` / `ghostty_surface_set_occlusion` を一度も呼んでおらず、全 surface の renderer スレッドが常に「focused かつ visible」と認識: 全ウインドウが非アクティブ時・最小化時も高速ポーリングと blink Present を続けていた。

補足: 非フォアグラウンドウインドウの `GHOSTTY_ACTION_RENDER` をスキップする以前の修正案は本ブランチには**含まれない** (`feat/multi-window-polish` のみに存在)。この action は `ghostty_app_tick` を呼ぶだけで Present に関与しないため、ちらつきは止まらず、バックグラウンドウインドウの app tick を凍結するだけになる。

</details>

## What was done

* **Focus** (`Surface::SetFocus`): forwarded from the two focus boundaries the app already tracks — `TerminalControl` GotFocus/LostFocus (pane/tab switches; same events that drive the IME EditContext) and `MainWindow` Activated (window-level activation crosses windows without firing control-level focus events).
* **Occlusion** (`Surface::SetOcclusion`): `Window.VisibilityChanged` → `BroadcastOcclusion` fans the state out to every pane in every tab, so hidden/minimized windows stop producing frames entirely; the renderer redraws once on re-show.

<details><summary>日本語</summary>

* **Focus** (`Surface::SetFocus`): アプリが既に追跡している2つのフォーカス境界から転送 — `TerminalControl` の GotFocus/LostFocus (pane/tab 切替。IME EditContext を駆動するのと同じイベント) と `MainWindow` の Activated (ウインドウ間のアクティブ化はコントロールレベルのフォーカスイベントを発火させずに遷移するため)。
* **Occlusion** (`Surface::SetOcclusion`): `Window.VisibilityChanged` → `BroadcastOcclusion` が全タブ・全ペインへ状態を配布。非表示/最小化中のウインドウはフレーム生成を完全停止し、再表示時に renderer が一度再描画する。

</details>

## Verification

Requires the DLL built from i999rri/ghostty#42 (`zig build -Doptimize=ReleaseSafe -Drenderer=directx`, picked up from `zig-out` by the VS build).

- [ ] Two overlapping windows, idle: no flicker
- [ ] Background window still updates on PTY output (unlike the RENDER-skip approach)
- [ ] Only the active window's cursor blinks; inactive window shows a solid cursor
- [ ] Minimize → restore: content intact, no stale frame
- [ ] IME focus behaviour unchanged across window switches
- [ ] Split panes: only the focused pane blinks

<details><summary>日本語</summary>

i999rri/ghostty#42 からビルドした DLL が必要 (`zig build -Doptimize=ReleaseSafe -Drenderer=directx`、VS ビルドが `zig-out` から取り込む)。

- [ ] 2ウインドウを重ねてアイドル: ちらつきなし
- [ ] バックグラウンドウインドウも PTY 出力で更新される (RENDER スキップ方式との違い)
- [ ] アクティブウインドウのカーソルのみ blink、非アクティブ側は実線カーソル
- [ ] 最小化 → 復帰: 内容が保持され stale フレームなし
- [ ] ウインドウ切替をまたぐ IME フォーカス挙動が不変
- [ ] split pane: フォーカスされた pane のみ blink

</details>

## Follow-up

* Bump `external/ghostty` in a standalone commit once i999rri/ghostty#42 lands on `windows-port`.

<details><summary>日本語</summary>

* i999rri/ghostty#42 が `windows-port` に入ったら、`external/ghostty` の bump を単独コミットで行う。

</details>
