### PR TITLE
Finish multi-window action wiring: close scopes, clipboard routing, new-tab fallback

### DIFF
--- a/App/App.xaml.cpp
+++ b/App/App.xaml.cpp
@@ -309,6 +309,39 @@ namespace winrt::GhosttyWin32::implementation
     void App::CreateNewWindow()
     {
         auto w = make<MainWindow>();
+        TrackWindow(w);
+        w.Activate();
+    }
+
+    MainWindow* App::CreateTearOutWindow()
+    {
+        auto w = make<MainWindow>();
+        auto* impl = winrt::get_self<MainWindow>(w);
+        // Must be flagged before the first Activated runs its
+        // one-shot init: this window adopts the dragged tab instead
+        // of creating one.
+        impl->SuppressInitialTab();
+        TrackWindow(w);
+        // Deliberately no Activate(): the drop handler positions the
+        // window at the drop point after adopting the tab and decides
+        // activation itself.
+        return impl;
+    }
+
+    MainWindow* App::FindWindowByTabItem(
+        Microsoft::UI::Xaml::Controls::TabViewItem const& item) noexcept
+    {
+        for (auto const& w : m_topLevelWindows) {
+            if (auto typed = w.try_as<winrt::GhosttyWin32::MainWindow>()) {
+                auto* impl = winrt::get_self<MainWindow>(typed);
+                if (impl && impl->OwnsTabItem(item)) return impl;
+            }
+        }
+        return nullptr;
+    }
+
+    void App::TrackWindow(Microsoft::UI::Xaml::Window const& w)
+    {
         m_topLevelWindows.push_back(w);
         // Auto-erase the vector entry when the user closes the
         // window. Capture only `this`; the sender comes in through
@@ -326,7 +359,6 @@ namespace winrt::GhosttyWin32::implementation
                 m_topLevelWindows.erase(it);
             }
         });
-        w.Activate();
     }
 
     void App::CloseAllWindows()

--- a/App/App.xaml.cpp
+++ b/App/App.xaml.cpp
@@ -328,4 +328,30 @@ namespace winrt::GhosttyWin32::implementation
         });
         w.Activate();
     }
+
+    void App::CloseAllWindows()
+    {
+        // Work on a copy: each Close() re-enters through the Closed
+        // subscription installed by CreateNewWindow and erases the
+        // entry from m_topLevelWindows mid-iteration.
+        auto windows = m_topLevelWindows;
+        for (auto& w : windows) {
+            // Close() throws when a window has already begun tearing
+            // down; swallow so one dying window doesn't stop the
+            // sweep (same rationale as MainWindow::RequestClose).
+            try { w.Close(); } catch (winrt::hresult_error const&) {}
+        }
+    }
+
+    void App::Quit()
+    {
+        // Process lifetime is tied to live windows on this port, so
+        // quitting IS closing every window: once the last one goes
+        // the message loop ends and App tears down in member order
+        // (windows before m_ghostty). Deliberately NOT
+        // Application::Exit(), which would skip that orderly
+        // teardown — and with it ghostty_app_free and the renderer
+        // thread joins.
+        CloseAllWindows();
+    }
 }

--- a/App/App.xaml.h
+++ b/App/App.xaml.h
@@ -97,6 +97,18 @@ namespace winrt::GhosttyWin32::implementation
         // stale entries for windows that outlive their HWND.
         void CreateNewWindow();
 
+        // Close every live top-level window (CLOSE_ALL_WINDOWS
+        // action). Iterates a snapshot because each Close() erases
+        // its own vector entry through the Closed subscription.
+        void CloseAllWindows();
+
+        // QUIT action. Today identical in effect to
+        // CloseAllWindows() — process lifetime is tied to live
+        // windows — but kept as a distinct entry point so
+        // quit-specific behaviour (confirmation, session save) has
+        // a home when it arrives.
+        void Quit();
+
     private:
         // Subsequent-activation handler. The first activation runs through
         // OnLaunched; later activations (a second click of a notification,

--- a/App/App.xaml.h
+++ b/App/App.xaml.h
@@ -122,6 +122,26 @@ namespace winrt::GhosttyWin32::implementation
         MainWindow* FindWindowByTabItem(
             Microsoft::UI::Xaml::Controls::TabViewItem const& item) noexcept;
 
+        // The tab drag currently in flight, if any. Cross-window
+        // drag-and-drop rides OLE, which only marshals primitive
+        // DataPackage values — a TabViewItem stuffed into the
+        // package's Properties comes out empty on another window's
+        // TabStripDrop. Every window shares this process, so the
+        // dragged item travels through this slot instead: set in
+        // TabDragStarting, read by any window's drop handlers,
+        // cleared in TabDragCompleted (which fires on the source
+        // whether or not a drop landed).
+        void SetDraggedTab(
+            Microsoft::UI::Xaml::Controls::TabViewItem const& item)
+        {
+            m_draggedTab = item;
+        }
+        void ClearDraggedTab() noexcept { m_draggedTab = nullptr; }
+        Microsoft::UI::Xaml::Controls::TabViewItem DraggedTab() const noexcept
+        {
+            return m_draggedTab;
+        }
+
     private:
         // Shared tail of CreateNewWindow / CreateTearOutWindow:
         // strong-ref the window in m_topLevelWindows and subscribe
@@ -191,5 +211,8 @@ namespace winrt::GhosttyWin32::implementation
         // Token for the primary AppInstance's Activated event; the
         // subscription lives for the lifetime of the App.
         winrt::event_token m_activatedToken{};
+        // See SetDraggedTab. Strong ref for the duration of the drag
+        // only; TabDragCompleted always clears it.
+        Microsoft::UI::Xaml::Controls::TabViewItem m_draggedTab{ nullptr };
     };
 }

--- a/App/App.xaml.h
+++ b/App/App.xaml.h
@@ -109,7 +109,25 @@ namespace winrt::GhosttyWin32::implementation
         // a home when it arrives.
         void Quit();
 
+        // Spawn the window that will host a torn-out tab. Same
+        // tracking as CreateNewWindow, but with no initial tab (it
+        // adopts the dropped one) and no Activate() — the drop
+        // handler positions the window at the drop point after
+        // adopting the tab and decides activation itself.
+        MainWindow* CreateTearOutWindow();
+
+        // The live window whose tab strip owns `item`, or null.
+        // Locates the source window of a dragged tab on the drop
+        // paths (the drop target only receives the TabViewItem).
+        MainWindow* FindWindowByTabItem(
+            Microsoft::UI::Xaml::Controls::TabViewItem const& item) noexcept;
+
     private:
+        // Shared tail of CreateNewWindow / CreateTearOutWindow:
+        // strong-ref the window in m_topLevelWindows and subscribe
+        // the Closed auto-erase.
+        void TrackWindow(Microsoft::UI::Xaml::Window const& w);
+
         // Subsequent-activation handler. The first activation runs through
         // OnLaunched; later activations (a second click of a notification,
         // a relaunch from the Start menu, etc.) get redirected to this

--- a/App/Ghostty/MainWindowRuntime.cpp
+++ b/App/Ghostty/MainWindowRuntime.cpp
@@ -46,39 +46,54 @@ bool MainWindowRuntime::OnAction(ghostty_target_s target,
     return window->m_ghosttyDispatcher->DispatchAction(target, action);
 }
 
-bool MainWindowRuntime::OnReadClipboard(void* state)
+MainWindowRuntime::PaneRef
+MainWindowRuntime::ResolvePane(void* paneIdUserdata) const
+{
+    // The clipboard callbacks carry the same per-surface userdata as
+    // close_surface: the PaneId set in TabFactory::MakeLeaf. Globally
+    // unique (App-scope allocator), so this resolves to exactly one
+    // window / control even with several windows open. Null results
+    // mean the pane died before the callback landed — callers no-op.
+    PaneRef ref;
+    PaneId id = PaneId::FromUserdata(paneIdUserdata);
+    if (!id) return ref;
+    ref.window = m_host.findWindowByPaneId(id);
+    if (!ref.window) return ref;
+    ref.control = ref.window->ControlByPaneId(id);
+    return ref;
+}
+
+bool MainWindowRuntime::OnReadClipboard(void* paneIdUserdata, void* state)
 {
     if (!m_host.isReady()) return false;
-    auto* window = m_host.anyWindow();
-    if (!window) return false;
-    auto* tc = window->ActiveControl();
-    if (!tc || !tc->Surface()) return false;
+    auto ref = ResolvePane(paneIdUserdata);
+    if (!ref.control || !ref.control->Surface()) return false;
     auto utf8 = interop::Encoding::toUtf8(
-        win32::Clipboard::read(window->m_hwnd));
+        win32::Clipboard::read(ref.window->m_hwnd));
     if (utf8.empty()) return false;
-    tc->Surface().CompleteClipboardRequest(utf8.c_str(), state, false);
+    ref.control->Surface().CompleteClipboardRequest(utf8.c_str(), state, false);
     return true;
 }
 
-void MainWindowRuntime::OnConfirmReadClipboard(char const* content, void* state)
+void MainWindowRuntime::OnConfirmReadClipboard(void* paneIdUserdata,
+                                               char const* content,
+                                               void* state)
 {
     // Auto-confirm clipboard reads.
     if (!m_host.isReady()) return;
-    auto* window = m_host.anyWindow();
-    if (!window) return;
-    auto* tc = window->ActiveControl();
-    if (tc && tc->Surface()) {
-        tc->Surface().CompleteClipboardRequest(content, state, true);
+    auto ref = ResolvePane(paneIdUserdata);
+    if (ref.control && ref.control->Surface()) {
+        ref.control->Surface().CompleteClipboardRequest(content, state, true);
     }
 }
 
-void MainWindowRuntime::OnWriteClipboard(char const* utf8)
+void MainWindowRuntime::OnWriteClipboard(void* paneIdUserdata, char const* utf8)
 {
     if (!m_host.isReady()) return;
-    auto* window = m_host.anyWindow();
-    if (!window) return;
+    auto ref = ResolvePane(paneIdUserdata);
+    if (!ref.window) return;
     win32::Clipboard::write(
-        window->m_hwnd, interop::Encoding::toUtf16(utf8));
+        ref.window->m_hwnd, interop::Encoding::toUtf16(utf8));
 }
 
 void MainWindowRuntime::OnCloseSurface(void* paneIdUserdata)

--- a/App/Ghostty/MainWindowRuntime.h
+++ b/App/Ghostty/MainWindowRuntime.h
@@ -8,6 +8,7 @@
 namespace winrt::GhosttyWin32::implementation {
 
 struct MainWindow;
+struct TerminalControl;
 
 // App-side implementation of the runtime hooks ghostty calls back
 // into. The factory in Core does the C↔C++ translation; this class
@@ -42,8 +43,11 @@ public:
 
     // Returns any live window (currently: the first registered) or
     // null when the aggregate is empty. Called for callbacks that
-    // have no per-surface handle — wakeup, clipboard read/write with
-    // no explicit target, APP-target actions.
+    // genuinely have no per-surface identity — wakeup (only needs a
+    // DispatcherQueue, and every window shares the one UI thread)
+    // and APP-target actions. Surface-scoped callbacks (clipboard,
+    // close) must NOT use this: they carry a PaneId and route to the
+    // owning window.
     using AnyWindow = std::function<MainWindow*()>;
 
     // Returns the window whose tab tree owns the given `PaneId`, or
@@ -79,12 +83,24 @@ public:
     void OnWakeup() override;
     bool OnAction(ghostty_target_s target,
                   ghostty_action_s action) override;
-    bool OnReadClipboard(void* state) override;
-    void OnConfirmReadClipboard(char const* content, void* state) override;
-    void OnWriteClipboard(char const* utf8) override;
+    bool OnReadClipboard(void* paneIdUserdata, void* state) override;
+    void OnConfirmReadClipboard(void* paneIdUserdata,
+                                char const* content,
+                                void* state) override;
+    void OnWriteClipboard(void* paneIdUserdata, char const* utf8) override;
     void OnCloseSurface(void* paneIdUserdata) override;
 
 private:
+    // The window + control pair that owns a surface-scoped callback's
+    // PaneId userdata. Either pointer is null when the pane is gone
+    // (surface closed via UI before the callback landed) — callers
+    // treat that as a safe no-op, same as stale close callbacks.
+    struct PaneRef {
+        MainWindow*      window{ nullptr };
+        TerminalControl* control{ nullptr };
+    };
+    PaneRef ResolvePane(void* paneIdUserdata) const;
+
     Host m_host;
 };
 

--- a/App/MainWindow.xaml
+++ b/App/MainWindow.xaml
@@ -47,6 +47,7 @@
 
             <TabView x:Name="TabView" Grid.Column="0" Grid.ColumnSpan="2"
                      IsAddTabButtonVisible="True"
+                     CanDragTabs="True"
                      TabWidthMode="Equal"
                      VerticalAlignment="Top"
                      HorizontalAlignment="Stretch">

--- a/App/MainWindow.xaml.cpp
+++ b/App/MainWindow.xaml.cpp
@@ -296,6 +296,115 @@ namespace winrt::GhosttyWin32::implementation
 
             auto tv = TabView();
 
+            // ----- tab drag-out / merge (release-time semantics) -----
+            // Tab movement uses TabView's classic drag-and-drop flow
+            // (CanDragTabs, set in markup) rather than the WinAppSDK
+            // native tear-out (CanTearOutTabs). Native tear-out drives
+            // an OS move-size loop that spawns and drags a live window
+            // mid-drag; in practice it shipped broken
+            // (microsoft-ui-xaml#10154 raises the window request for
+            // plain clicks, #10156 zeroes the NewWindowId round-trip)
+            // and mispositions the grab point when the torn-out window
+            // appears. With drag-and-drop nothing happens until the
+            // user RELEASES: dropping on another window's strip merges
+            // the tab there, dropping anywhere else spawns a window at
+            // the drop point. Only a drag ghost is shown mid-drag.
+            //
+            // The dragged TabViewItem travels in the DataPackage
+            // properties — every window lives in this process, so the
+            // drop target reads the same IInspectable back out and no
+            // app-global drag state is needed.
+            tv.TabDragStarting([](auto const&, auto const& args) {
+                args.Data().Properties().Insert(L"GhosttyTornTab", args.Tab());
+                args.Data().RequestedOperation(
+                    winrt::Windows::ApplicationModel::DataTransfer::DataPackageOperation::Move);
+            });
+
+            tv.TabStripDragOver([](auto const&, auto const& e) {
+                if (e.DataView().Properties().HasKey(L"GhosttyTornTab")) {
+                    e.AcceptedOperation(
+                        winrt::Windows::ApplicationModel::DataTransfer::DataPackageOperation::Move);
+                }
+            });
+
+            tv.TabStripDrop([weakActivated](auto const& sender, auto const& e) {
+                auto self = weakActivated.get();
+                if (!self || !App::g_app) return;
+                // TabStripDrop is a plain DragEventHandler, so the
+                // sender arrives as IInspectable, not a typed TabView.
+                auto strip = sender.template try_as<muxc::TabView>();
+                if (!strip) return;
+                auto obj = e.DataView().Properties().TryLookup(L"GhosttyTornTab");
+                auto item = obj ? obj.template try_as<muxc::TabViewItem>() : nullptr;
+                if (!item) return;
+                auto* source = App::g_app->FindWindowByTabItem(item);
+                // Same-strip drops are reorders, which CanReorderTabs
+                // already handled natively.
+                if (!source || source == self.get()) return;
+                // Insert where the tab was dropped: before the first
+                // tab whose slot the pointer hasn't fully passed.
+                int32_t index = -1;
+                auto items = strip.TabItems();
+                for (uint32_t i = 0; i < items.Size(); ++i) {
+                    auto container = strip.ContainerFromIndex(i)
+                        .template try_as<muxc::TabViewItem>();
+                    if (!container) continue;
+                    if (e.GetPosition(container).X - container.ActualWidth() < 0) {
+                        index = static_cast<int32_t>(i);
+                        break;
+                    }
+                }
+                try {
+                    if (auto tab = source->ReleaseTornOutTab(item)) {
+                        self->AdoptTornOutTab(std::move(tab), index);
+                        source->CloseIfTornOutEmpty();
+                    }
+                } catch (winrt::hresult_error const&) {
+                    // A failed move must not take either window down;
+                    // whichever side holds the unique_ptr owns the tab.
+                }
+            });
+
+            tv.TabDroppedOutside([weakActivated](auto const&, auto const& args) {
+                auto self = weakActivated.get();
+                if (!self || !App::g_app) return;
+                auto item = args.Tab();
+                if (!item) return;
+                POINT cursor{};
+                bool haveCursor = GetCursorPos(&cursor) != 0;
+                // Offsets place the window so its tab strip lands near
+                // the pointer instead of the window's top-left corner.
+                int32_t dropX = static_cast<int32_t>(cursor.x) - 120;
+                int32_t dropY = static_cast<int32_t>(cursor.y) - 24;
+                // Dragging out the only tab must not leave an empty
+                // shell behind — just move this window to the drop
+                // point instead, browser-style.
+                if (self->m_tabs.Size() <= 1) {
+                    if (haveCursor) {
+                        self->AppWindow().Move({ dropX, dropY });
+                    }
+                    return;
+                }
+                auto* host = App::g_app->CreateTearOutWindow();
+                if (!host) return;
+                try {
+                    if (auto tab = self->ReleaseTornOutTab(item)) {
+                        host->AdoptTornOutTab(std::move(tab), -1);
+                        if (haveCursor) {
+                            host->AppWindow().Move({ dropX, dropY });
+                        }
+                        // The drag is over, so activation is safe —
+                        // hand the new window focus like a browser
+                        // does after a tab is torn off.
+                        host->Activate();
+                    } else {
+                        // Nothing moved; don't leak an empty host.
+                        host->RequestClose();
+                    }
+                } catch (winrt::hresult_error const&) {
+                }
+            });
+
             // Don't call Window.SetTitleBar(AppTitleBar()) — that would
             // make the whole chrome row OS-title-bar input, including the
             // tab headers. Double-clicking a tab header would then

--- a/App/MainWindow.xaml.cpp
+++ b/App/MainWindow.xaml.cpp
@@ -763,21 +763,20 @@ namespace winrt::GhosttyWin32::implementation
     {
         if (!m_hwnd) return;
 
-        // Drop new-tab requests when the chrome is hidden AND at least
-        // one tab already exists. The tab strip is part of AppTitleBar,
-        // so with chrome collapsed there's no UI to switch tabs — a
-        // second tab would be invisible and unreachable. Silently
-        // ignoring matches the upstream macOS behaviour, where
+        // Redirect new-tab requests to a new window when the chrome is
+        // hidden AND at least one tab already exists. The tab strip is
+        // part of AppTitleBar, so with chrome collapsed there's no UI
+        // to switch tabs — a second tab would be invisible and
+        // unreachable. Falling back to a fresh top-level window
+        // matches the upstream macOS behaviour, where
         // `window-decoration=false` disables native tabs entirely and
-        // new-tab requests fall back to new windows. Until multi-window
-        // (#55) lands, "fall back" here means "drop"; the user's
-        // recourse is to toggle decorations back on (ctrl+shift+d) or
-        // edit config. The first tab is exempt so the terminal can come
-        // up at all when the user launches with chrome already off.
+        // new-tab requests become new windows. The first tab is exempt
+        // so the terminal can come up at all when the user launches
+        // with chrome already off.
         if (!m_tabs.Empty()) {
             ghostty::Config cfg(m_ghosttyApp->ConfigHandle());
             if (!m_windowDecorations.Effective(cfg.WindowDecoratedByConfig())) {
-                OutputDebugStringW(L"[GhosttyWin32] CreateTab dropped: window-decoration=false; multi-window (#55) not yet wired\n");
+                if (App::g_app) App::g_app->CreateNewWindow();
                 return;
             }
         }

--- a/App/MainWindow.xaml.cpp
+++ b/App/MainWindow.xaml.cpp
@@ -310,18 +310,31 @@ namespace winrt::GhosttyWin32::implementation
             // the tab there, dropping anywhere else spawns a window at
             // the drop point. Only a drag ghost is shown mid-drag.
             //
-            // The dragged TabViewItem travels in the DataPackage
-            // properties — every window lives in this process, so the
-            // drop target reads the same IInspectable back out and no
-            // app-global drag state is needed.
+            // The dragged TabViewItem travels through App's
+            // dragged-tab slot (SetDraggedTab), NOT the DataPackage:
+            // a drop on another top-level window rides OLE, which
+            // only marshals primitive package values — a TabViewItem
+            // stuffed into Properties comes out missing on the other
+            // window and the merge silently degrades into a
+            // drop-outside. The package deliberately stays empty
+            // (operation only) so foreign drop targets — a text
+            // editor, say — have nothing to accept and can't swallow
+            // the drag away from TabDroppedOutside.
             tv.TabDragStarting([](auto const&, auto const& args) {
-                args.Data().Properties().Insert(L"GhosttyTornTab", args.Tab());
+                if (App::g_app) App::g_app->SetDraggedTab(args.Tab());
                 args.Data().RequestedOperation(
                     winrt::Windows::ApplicationModel::DataTransfer::DataPackageOperation::Move);
             });
 
+            // Fires on the source when the drag ends, whether or not
+            // any drop landed — the one reliable place to clear the
+            // in-flight slot.
+            tv.TabDragCompleted([](auto const&, auto const&) {
+                if (App::g_app) App::g_app->ClearDraggedTab();
+            });
+
             tv.TabStripDragOver([](auto const&, auto const& e) {
-                if (e.DataView().Properties().HasKey(L"GhosttyTornTab")) {
+                if (App::g_app && App::g_app->DraggedTab()) {
                     e.AcceptedOperation(
                         winrt::Windows::ApplicationModel::DataTransfer::DataPackageOperation::Move);
                 }
@@ -334,8 +347,9 @@ namespace winrt::GhosttyWin32::implementation
                 // sender arrives as IInspectable, not a typed TabView.
                 auto strip = sender.template try_as<muxc::TabView>();
                 if (!strip) return;
-                auto obj = e.DataView().Properties().TryLookup(L"GhosttyTornTab");
-                auto item = obj ? obj.template try_as<muxc::TabViewItem>() : nullptr;
+                // Source's TabDragCompleted (which clears the slot)
+                // fires only after this drop returns.
+                auto item = App::g_app->DraggedTab();
                 if (!item) return;
                 auto* source = App::g_app->FindWindowByTabItem(item);
                 // Same-strip drops are reorders, which CanReorderTabs

--- a/App/MainWindow.xaml.cpp
+++ b/App/MainWindow.xaml.cpp
@@ -84,7 +84,11 @@ namespace winrt::GhosttyWin32::implementation
             if (App::g_app) App::g_app->Windows().Register(this);
             auto windowNative = this->try_as<::IWindowNative>();
             if (windowNative) windowNative->get_WindowHandle(&m_hwnd);
-            if (m_hwnd) ShowWindow(m_hwnd, SW_HIDE);
+            // The pre-first-frame hide avoids flashing an empty window
+            // before ghostty presents. A drop host receives a tab that
+            // is already presenting, so it has frames to show from the
+            // first paint and skips the hide.
+            if (m_hwnd && !m_suppressInitialTab) ShowWindow(m_hwnd, SW_HIDE);
 
             // Remove the OS title bar (and with it the system caption
             // buttons) so only our XAML CaptionButtons render at the top.
@@ -291,6 +295,7 @@ namespace winrt::GhosttyWin32::implementation
             });
 
             auto tv = TabView();
+
             // Don't call Window.SetTitleBar(AppTitleBar()) — that would
             // make the whole chrome row OS-title-bar input, including the
             // tab headers. Double-clicking a tab header would then
@@ -531,7 +536,9 @@ namespace winrt::GhosttyWin32::implementation
             });
 
             InitGhostty();
-            CreateTab();
+            // Tear-out hosts don't create an initial tab: they adopt
+            // the dragged one (possibly before this handler even ran).
+            if (!m_suppressInitialTab) CreateTab();
             // Honour `window-decoration` from config at startup so
             // users who set it in their config see the chrome state
             // they asked for without having to fire the toggle
@@ -1696,6 +1703,120 @@ namespace winrt::GhosttyWin32::implementation
         auto lookup = m_tabs.FindByPaneId(id);
         if (!lookup.leaf) return nullptr;
         return Tab::LeafToTerminalControl(*lookup.leaf);
+    }
+
+    std::unique_ptr<Tab> MainWindow::ReleaseTornOutTab(
+        muxc::TabViewItem const& item)
+    {
+        auto* t = m_tabs.FindByItem(item);
+        if (!t) return nullptr;
+
+        // The focused-surface cache must not follow the tab out: the
+        // surfaces stay alive, but they stop being *this* window's
+        // surfaces. Walk the departing tab's leaves rather than just
+        // its active control — m_activeSurface can point at any pane.
+        if (m_activeSurface) {
+            if (auto* panelImpl =
+                    winrt::get_self<implementation::SplitPanel>(t->Panel())) {
+                std::vector<Pane*> leaves;
+                CollectLeaves(panelImpl->Root(), leaves);
+                for (auto* leaf : leaves) {
+                    auto* tc = Tab::LeafToTerminalControl(*leaf);
+                    if (tc && tc->Surface().Owns(m_activeSurface)) {
+                        m_activeSurface = nullptr;
+                        break;
+                    }
+                }
+            }
+        }
+
+        // Unparent the visual pieces but detach nothing: the swap
+        // chains keep presenting while the tab is in flight.
+        RemoveTabPanelFromAppContent(*t);
+        auto tv = TabView();
+        if (tv) {
+            uint32_t idx = 0;
+            if (tv.TabItems().IndexOf(item, idx)) {
+                tv.TabItems().RemoveAt(idx);
+            }
+        }
+        return m_tabs.Extract(item);
+    }
+
+    void MainWindow::AdoptTornOutTab(std::unique_ptr<Tab> tab, int32_t index)
+    {
+        if (!tab) return;
+
+        // A tear-out host adopts before its first Activated has run,
+        // so the HWND may not be captured yet. IWindowNative works
+        // from construction onward.
+        if (!m_hwnd) {
+            if (auto native = this->try_as<::IWindowNative>()) {
+                native->get_WindowHandle(&m_hwnd);
+            }
+        }
+
+        auto tv = TabView();
+        if (!tv) return;
+        auto items = tv.TabItems();
+        uint32_t size = items.Size();
+        uint32_t at = (index < 0 || static_cast<uint32_t>(index) > size)
+            ? size
+            : static_cast<uint32_t>(index);
+        items.InsertAt(at, tab->Item());
+
+        // Re-point every control at this window: IME coordinates and
+        // clipboard ownership key off the host HWND, and the focused
+        // callback must feed THIS window's active-surface cache. Raw
+        // `this` capture is safe by the same argument as InitGhostty's
+        // onLeafFocused — MainWindow outlives every control it hosts.
+        if (auto* panelImpl =
+                winrt::get_self<implementation::SplitPanel>(tab->Panel())) {
+            std::vector<Pane*> leaves;
+            CollectLeaves(panelImpl->Root(), leaves);
+            for (auto* leaf : leaves) {
+                if (auto* tc = Tab::LeafToTerminalControl(*leaf)) {
+                    tc->Rehost(m_hwnd, [this](ghostty_surface_t s) noexcept {
+                        NotifySurfaceFocused(s);
+                    });
+                }
+            }
+        }
+
+        // Same shape as CreateTab's post-Make sequence: parent the
+        // panel collapsed, register ownership, then select — the
+        // SelectionChanged handler reconciles panel visibility and
+        // focus for us.
+        tab->Panel().Visibility(winrt::Microsoft::UI::Xaml::Visibility::Collapsed);
+        AppContent().Children().Append(tab->Panel());
+        auto selected = tab->Item();
+        m_tabs.Add(std::move(tab));
+        tv.SelectedItem(selected);
+        UpdateActivePanelVisibility();
+        // SHOWNOACTIVATE, not SHOW: make the adopted tab visible
+        // without deciding focus here. Whether the window should be
+        // activated is the caller's call — the drop-outside handler
+        // activates its freshly spawned host, while a merge adopts
+        // into a window that is already visible and focused.
+        if (m_hwnd) ShowWindow(m_hwnd, SW_SHOWNOACTIVATE);
+    }
+
+    void MainWindow::CloseIfTornOutEmpty()
+    {
+        // Tearing the last tab out leaves an empty shell — close it,
+        // matching browser behaviour. Deferred through the dispatcher
+        // so window teardown never runs inside tear-out event
+        // dispatch, and re-checked on arrival in case a merge landed
+        // a tab here in the meantime.
+        if (!m_tabs.Empty()) return;
+        auto dq = DispatcherQueue();
+        auto weak = get_weak();
+        if (!dq) { RequestClose(); return; }
+        dq.TryEnqueue([weak]() {
+            if (auto self = weak.get()) {
+                if (self->m_tabs.Empty()) self->RequestClose();
+            }
+        });
     }
 
     void MainWindow::CloseSurfaceByPaneId(PaneId id)

--- a/App/MainWindow.xaml.cpp
+++ b/App/MainWindow.xaml.cpp
@@ -53,13 +53,17 @@ namespace winrt::GhosttyWin32::implementation
         // dispatcher here (rather than waiting for Activated) keeps
         // the action_cb forwarder safe even if it fires through any
         // pre-Activated edge case.
-        // NEW_WINDOW is App-scope: the "add another top-level window"
-        // operation doesn't belong on IWindow, so the factory takes
-        // it as a callable the App fills in. Same shape as
+        // The AppHooks slots are App-scope: "add another top-level
+        // window" and friends don't belong on IWindow, so the factory
+        // takes them as callables the App fills in. Same shape as
         // MainWindowRuntime's Host bundle for other cross-scope hooks.
         m_ghosttyDispatcher = ghostty::CallbackDispatcher::Create(
             *this,
-            []() { if (App::g_app) App::g_app->CreateNewWindow(); });
+            {
+                .newWindow = []() {
+                    if (App::g_app) App::g_app->CreateNewWindow();
+                },
+            });
 
         ExtendsContentIntoTitleBar(true);
 

--- a/App/MainWindow.xaml.cpp
+++ b/App/MainWindow.xaml.cpp
@@ -63,6 +63,12 @@ namespace winrt::GhosttyWin32::implementation
                 .newWindow = []() {
                     if (App::g_app) App::g_app->CreateNewWindow();
                 },
+                .closeAllWindows = []() {
+                    if (App::g_app) App::g_app->CloseAllWindows();
+                },
+                .quit = []() {
+                    if (App::g_app) App::g_app->Quit();
+                },
             });
 
         ExtendsContentIntoTitleBar(true);

--- a/App/MainWindow.xaml.cpp
+++ b/App/MainWindow.xaml.cpp
@@ -1692,6 +1692,13 @@ namespace winrt::GhosttyWin32::implementation
         panelImpl->InvalidateArrange();
     }
 
+    TerminalControl* MainWindow::ControlByPaneId(PaneId id) noexcept
+    {
+        auto lookup = m_tabs.FindByPaneId(id);
+        if (!lookup.leaf) return nullptr;
+        return Tab::LeafToTerminalControl(*lookup.leaf);
+    }
+
     void MainWindow::CloseSurfaceByPaneId(PaneId id)
     {
         auto lookup = m_tabs.FindByPaneId(id);

--- a/App/MainWindow.xaml.h
+++ b/App/MainWindow.xaml.h
@@ -192,6 +192,13 @@ namespace winrt::GhosttyWin32::implementation
         // list. Dispatched from close_surface_cb. UI thread only.
         void CloseSurfaceByPaneId(PaneId id);
 
+        // The TerminalControl hosting the pane carrying `id`, or null
+        // when no tab in this window owns it (already closed, or it
+        // lives in a sibling window). Used by MainWindowRuntime to
+        // complete surface-scoped callbacks (clipboard) on exactly
+        // the surface that issued them.
+        TerminalControl* ControlByPaneId(PaneId id) noexcept;
+
         // Push renderer-side visibility to every surface in this
         // window (all tabs, all panes). Driven by
         // Window.VisibilityChanged: while hidden/minimized each

--- a/App/MainWindow.xaml.h
+++ b/App/MainWindow.xaml.h
@@ -199,6 +199,45 @@ namespace winrt::GhosttyWin32::implementation
         // the surface that issued them.
         TerminalControl* ControlByPaneId(PaneId id) noexcept;
 
+        // ----- tab drag-out / merge (#55 follow-up) -----
+        // Mark this window as a drop host BEFORE its first Activated:
+        // it will receive a live, already-presenting tab instead of
+        // creating one, so the one-shot init skips the initial
+        // CreateTab and the pre-first-frame SW_HIDE (the adopted tab
+        // has frames to show from the first paint). Called by
+        // App::CreateTearOutWindow through the existing friendship.
+        void SuppressInitialTab() noexcept { m_suppressInitialTab = true; }
+
+        // Take `item`'s Tab out of this window alive: strip entry
+        // removed, panel unparented from AppContent, focused-surface
+        // cache cleared if it pointed into the tab — but nothing
+        // detached or destroyed, so a sibling window can adopt the
+        // same Tab. Returns null when this window doesn't own `item`.
+        std::unique_ptr<Tab> ReleaseTornOutTab(
+            winrt::Microsoft::UI::Xaml::Controls::TabViewItem const& item);
+
+        // Counterpart of ReleaseTornOutTab: insert the tab into this
+        // window's strip at `index` (clamped; negative appends),
+        // re-point its controls at this window (host HWND + focused
+        // callback), parent the panel, select it, and make sure the
+        // window is visible. Safe to call before this window's first
+        // Activated — the HWND is captured on demand.
+        void AdoptTornOutTab(std::unique_ptr<Tab> tab, int32_t index);
+
+        // Close this window once a tear-out leaves it without tabs,
+        // matching browser behaviour. Deferred through the dispatcher
+        // so teardown never runs inside tear-out event dispatch.
+        void CloseIfTornOutEmpty();
+
+        // True when this window's tab strip owns `item`. Used by the
+        // merge path to locate the source window of a torn-out tab.
+        bool OwnsTabItem(
+            winrt::Microsoft::UI::Xaml::Controls::TabViewItem const& item) const noexcept {
+            return m_tabs.FindByItem(item) != nullptr;
+        }
+
+        bool m_suppressInitialTab{ false };
+
         // Push renderer-side visibility to every surface in this
         // window (all tabs, all panes). Driven by
         // Window.VisibilityChanged: while hidden/minimized each

--- a/App/Tabs/Tabs.h
+++ b/App/Tabs/Tabs.h
@@ -114,6 +114,23 @@ public:
         return false;
     }
 
+    // Transfer ownership of the Tab wrapping `item` out of this
+    // collection without destroying it. Tab tear-out moves a live Tab
+    // — surfaces, swap chains, panel tree and all — into a sibling
+    // window's collection, so unlike Remove() the Tab must survive
+    // its departure from this list. Returns null when no tab here
+    // wraps `item`.
+    std::unique_ptr<Tab> Extract(Microsoft::UI::Xaml::Controls::TabViewItem const& item) {
+        for (auto it = m_tabs.begin(); it != m_tabs.end(); ++it) {
+            if (*it && (*it)->Item() == item) {
+                auto tab = std::move(*it);
+                m_tabs.erase(it);
+                return tab;
+            }
+        }
+        return nullptr;
+    }
+
     void Clear() noexcept { m_tabs.clear(); }
 
     bool Empty() const noexcept { return m_tabs.empty(); }

--- a/App/TerminalControl.xaml.h
+++ b/App/TerminalControl.xaml.h
@@ -124,6 +124,20 @@ namespace winrt::GhosttyWin32::implementation
         // safe.
         void Detach();
 
+        // Re-point this control at a new host window after a tab
+        // tear-out / adopt. The surface and swap chain move as-is —
+        // the SwapChainPanel keeps its composition binding across
+        // reparenting on the shared UI thread — but two things are
+        // derived from the owning window and must follow it: the host
+        // HWND (IME caret coordinates via ClientToScreen, clipboard
+        // ownership) and the focused callback, which feeds the owning
+        // window's active-surface cache.
+        void Rehost(HWND hostHwnd,
+                    std::function<void(ghostty_surface_t)> onFocused) noexcept {
+            m_hostHwnd  = hostHwnd;
+            m_onFocused = std::move(onFocused);
+        }
+
         // Renderer-thread callback registered with ghostty as
         // cfg.swap_chain_ready_cb. Hops to the UI thread and binds the
         // swap chain handle to the panel via ISwapChainPanelNative2.

--- a/App/pch.h
+++ b/App/pch.h
@@ -16,6 +16,7 @@
 #include <winrt/Windows.Foundation.h>
 #include <winrt/Windows.Foundation.Collections.h>
 #include <winrt/Windows.ApplicationModel.Activation.h>
+#include <winrt/Windows.ApplicationModel.DataTransfer.h>
 #include <winrt/Microsoft.UI.Composition.h>
 #include <winrt/Microsoft.UI.Xaml.h>
 #include <winrt/Microsoft.UI.Xaml.Controls.h>

--- a/Core/Ghostty/Actions/Actions.cpp
+++ b/Core/Ghostty/Actions/Actions.cpp
@@ -231,13 +231,13 @@ bool Actions::OnNewTab() {
 }
 
 bool Actions::OnNewWindow() {
-    if (!m_newWindow) return false;
+    if (!m_hooks.newWindow) return false;
     // Hop to the UI thread — CreateNewWindow builds a Xaml Window
     // and every Xaml touch has to happen there. The `m_view`
     // dispatch is a UI-thread hop that any live window can provide;
     // we don't need our own dispatcher for this to arrive there.
     m_view.Dispatch([this]() {
-        m_newWindow();
+        m_hooks.newWindow();
     });
     return true;
 }

--- a/Core/Ghostty/Actions/Actions.cpp
+++ b/Core/Ghostty/Actions/Actions.cpp
@@ -94,12 +94,32 @@ bool Actions::OnOpenUrl(ghostty_action_open_url_s ou) {
 // ===== window lifecycle =====
 
 bool Actions::OnCloseWindow() {
-    // Single-window builds collapse CLOSE_WINDOW, QUIT, and
-    // CLOSE_ALL_WINDOWS into the same effect — close the one
-    // window we have, which terminates the app. Multi-window
-    // (#55) will need to give these three distinct behaviours.
+    // Close the window that owns the action's target and nothing
+    // else. This Actions instance is per-window (the runtime routed
+    // the action here from its target surface), so m_view is that
+    // window; siblings survive.
     m_view.Dispatch([this]() {
         m_view.RequestClose();
+    });
+    return true;
+}
+
+bool Actions::OnCloseAllWindows() {
+    // Fixtures without the app hook degrade to closing the one
+    // window they can reach — the pre-split behaviour.
+    if (!m_hooks.closeAllWindows) return OnCloseWindow();
+    // UI-thread hop for the same reason as OnNewWindow: window
+    // teardown is XAML work, and every window shares this thread.
+    m_view.Dispatch([this]() {
+        m_hooks.closeAllWindows();
+    });
+    return true;
+}
+
+bool Actions::OnQuit() {
+    if (!m_hooks.quit) return OnCloseWindow();
+    m_view.Dispatch([this]() {
+        m_hooks.quit();
     });
     return true;
 }

--- a/Core/Ghostty/Actions/Actions.h
+++ b/Core/Ghostty/Actions/Actions.h
@@ -26,20 +26,27 @@ namespace core::ghostty::actions {
 // the ghostty action_cb contract.
 class Actions {
 public:
-    // Spawns a top-level window at App scope. NEW_WINDOW is the one
-    // action that doesn't belong on IWindow — the per-window view
-    // doesn't own the "add another window" operation — so it's
-    // injected as a callable at construction time. Same shape as
-    // MainWindowRuntime's Host bundle for other cross-scope hooks.
-    using NewWindowFn = std::function<void()>;
+    // App-scope operations injected at construction time. These are
+    // the actions that don't belong on IWindow — the per-window view
+    // doesn't own "add another window", "close every window", or
+    // "quit the app" — so App supplies them as callables. Same shape
+    // as MainWindowRuntime's Host bundle for other cross-scope hooks.
+    //
+    // Every slot defaults to empty so unit tests that never exercise
+    // these actions keep the bare one-arg construction; each handler
+    // degrades sensibly when its slot is missing (OnNewWindow bails,
+    // the close-scope handlers fall back to closing the one window
+    // they can reach — exactly the single-window behaviour these
+    // actions had before the split).
+    struct AppHooks {
+        std::function<void()> newWindow;
+        std::function<void()> closeAllWindows;
+        std::function<void()> quit;
+    };
 
-    // `newWindow` defaults to an empty `std::function` so unit tests
-    // that never exercise NEW_WINDOW keep the one-arg construction
-    // shape they already have; the OnNewWindow handler bails early
-    // when the slot is empty.
-    Actions(host::IWindow& view, NewWindowFn newWindow = {}) noexcept
+    Actions(host::IWindow& view, AppHooks hooks = {}) noexcept
         : m_view(view)
-        , m_newWindow(std::move(newWindow)) {}
+        , m_hooks(std::move(hooks)) {}
 
     // ----- terminal events -----
     bool OnRingBell();
@@ -68,7 +75,7 @@ public:
     // ----- tab lifecycle / navigation / title -----
     bool OnNewTab();
     // NEW_WINDOW: spawn a fresh top-level MainWindow. Bounces
-    // through the injected NewWindowFn (which App fills with
+    // through the injected newWindow hook (which App fills with
     // `App::g_app->CreateNewWindow()`); Actions doesn't know or
     // care what a "window" is at that layer.
     bool OnNewWindow();
@@ -110,7 +117,7 @@ public:
 
 private:
     host::IWindow& m_view;
-    NewWindowFn    m_newWindow;
+    AppHooks       m_hooks;
 
     // Initial window size from GHOSTTY_ACTION_INITIAL_SIZE
     // (physical pixels). Zero means "not yet received" —

--- a/Core/Ghostty/Actions/Actions.h
+++ b/Core/Ghostty/Actions/Actions.h
@@ -59,9 +59,18 @@ public:
     bool OnOpenUrl(ghostty_action_open_url_s url);
 
     // ----- window lifecycle -----
-    // Used for CLOSE_WINDOW / CLOSE_ALL_WINDOWS / QUIT — the
-    // single-window build collapses all three to the same effect.
+    // CLOSE_WINDOW: close the window that owns the action's target.
+    // This Actions instance is already per-window (the runtime
+    // routes actions by target surface), so closing m_view is the
+    // right scope — sibling windows survive.
     bool OnCloseWindow();
+    // CLOSE_ALL_WINDOWS / QUIT: app-scope teardown via the injected
+    // hooks. Distinct handlers because their scope differs from
+    // CLOSE_WINDOW in a multi-window session, even though on Windows
+    // (process lifetime == live windows) both currently resolve to
+    // "close every window".
+    bool OnCloseAllWindows();
+    bool OnQuit();
     bool OnToggleVisibility();
     bool OnToggleMaximize();
     bool OnPresentTerminal();

--- a/Core/Ghostty/CallbackDispatcher.cpp
+++ b/Core/Ghostty/CallbackDispatcher.cpp
@@ -30,13 +30,12 @@ bool CallbackDispatcher::DispatchAction(ghostty_target_s target, ghostty_action_
             return m_actions.OnOpenUrl(action.action.open_url);
 
         // ----- window lifecycle -----
-        // CLOSE_WINDOW / CLOSE_ALL_WINDOWS / QUIT all collapse to
-        // OnCloseWindow on the single-window build; multi-window
-        // (#55) will need to give these three distinct handlers.
         case GHOSTTY_ACTION_CLOSE_WINDOW:
-        case GHOSTTY_ACTION_CLOSE_ALL_WINDOWS:
-        case GHOSTTY_ACTION_QUIT:
             return m_actions.OnCloseWindow();
+        case GHOSTTY_ACTION_CLOSE_ALL_WINDOWS:
+            return m_actions.OnCloseAllWindows();
+        case GHOSTTY_ACTION_QUIT:
+            return m_actions.OnQuit();
         case GHOSTTY_ACTION_TOGGLE_VISIBILITY:
             return m_actions.OnToggleVisibility();
         case GHOSTTY_ACTION_TOGGLE_MAXIMIZE:

--- a/Core/Ghostty/CallbackDispatcher.cpp
+++ b/Core/Ghostty/CallbackDispatcher.cpp
@@ -4,11 +4,11 @@ namespace core::ghostty {
 
 std::unique_ptr<CallbackDispatcher>
 CallbackDispatcher::Create(host::IWindow& view,
-                           actions::Actions::NewWindowFn newWindow) {
-    // Default for `newWindow` lives on the declaration; the
+                           actions::Actions::AppHooks hooks) {
+    // Default for `hooks` lives on the declaration; the
     // definition can't repeat it or the compiler flags a duplicate.
     return std::unique_ptr<CallbackDispatcher>(
-        new CallbackDispatcher(view, std::move(newWindow)));
+        new CallbackDispatcher(view, std::move(hooks)));
 }
 
 bool CallbackDispatcher::DispatchAction(ghostty_target_s target, ghostty_action_s action) {

--- a/Core/Ghostty/CallbackDispatcher.h
+++ b/Core/Ghostty/CallbackDispatcher.h
@@ -30,13 +30,13 @@ namespace core::ghostty {
 // call site — the option-value is the signature, not the body.
 class CallbackDispatcher {
 public:
-    // `newWindow` defaults to empty so existing single-arg call
-    // sites (the CallbackDispatcher unit tests never fire
-    // NEW_WINDOW) stay compilable without the dispatcher spilling
-    // NEW_WINDOW knowledge into its factory contract.
+    // `hooks` defaults to empty so existing single-arg call sites
+    // (the CallbackDispatcher unit tests never fire the app-scope
+    // actions) stay compilable without the dispatcher spilling
+    // app-lifecycle knowledge into its factory contract.
     static std::unique_ptr<CallbackDispatcher> Create(
         host::IWindow& view,
-        actions::Actions::NewWindowFn newWindow = {});
+        actions::Actions::AppHooks hooks = {});
 
     // Route a ghostty action_cb invocation. Returns true when the
     // action was handled (matches the ghostty action_cb contract:
@@ -46,8 +46,8 @@ public:
 
 private:
     CallbackDispatcher(host::IWindow& view,
-                       actions::Actions::NewWindowFn newWindow) noexcept
-        : m_actions(view, std::move(newWindow)) {}
+                       actions::Actions::AppHooks hooks) noexcept
+        : m_actions(view, std::move(hooks)) {}
 
     actions::Actions m_actions;
 };

--- a/Core/Ghostty/IGhosttyRuntime.h
+++ b/Core/Ghostty/IGhosttyRuntime.h
@@ -49,24 +49,34 @@ public:
     virtual bool OnAction(ghostty_target_s target,
                           ghostty_action_s action) = 0;
 
-    // Terminal-initiated clipboard read. `state` is opaque ghostty
-    // bookkeeping the impl hands back to
+    // Terminal-initiated clipboard read. Like close_surface, the
+    // clipboard callbacks arrive with the *per-surface* userdata the
+    // host set in surface_config (a PaneId encoded as void*), not
+    // the runtime userdata — the request belongs to one surface and
+    // the completion must go back to exactly that surface, which
+    // matters as soon as more than one window exists. `state` is
+    // opaque ghostty bookkeeping the impl hands back to
     // `ghostty_surface_complete_clipboard_request` once the OS
     // clipboard has been read. Returns true when the host completed
     // the request (false leaves the request unresolved).
-    virtual bool OnReadClipboard(void* state) = 0;
+    virtual bool OnReadClipboard(void* paneIdUserdata, void* state) = 0;
 
     // Confirmation step for a previously-issued read. Ghostty issues
     // this when the read could be unsafe (bracketed paste with
     // newlines etc.); the impl decides whether to accept and then
-    // completes the request.
-    virtual void OnConfirmReadClipboard(char const* content,
+    // completes the request. Same per-surface userdata as
+    // OnReadClipboard.
+    virtual void OnConfirmReadClipboard(void* paneIdUserdata,
+                                        char const* content,
                                         void* state) = 0;
 
     // Terminal-initiated clipboard write — typically an OSC 52 from a
     // tmux / shell helper. The UTF-8 payload is non-null and non-empty
-    // by the time the factory invokes this.
-    virtual void OnWriteClipboard(char const* utf8) = 0;
+    // by the time the factory invokes this. Same per-surface userdata
+    // as OnReadClipboard (the write's clipboard owner should be the
+    // window that hosts the emitting surface).
+    virtual void OnWriteClipboard(void* paneIdUserdata,
+                                  char const* utf8) = 0;
 
     // Shell exited or ghostty otherwise asks the host to close the
     // surface. `paneIdUserdata` is the per-surface userdata the host

--- a/Core/Ghostty/RuntimeConfigFactory.cpp
+++ b/Core/Ghostty/RuntimeConfigFactory.cpp
@@ -7,20 +7,21 @@ namespace core::ghostty {
 
 namespace {
 
-// Latched on every Build() call. The close_surface_cb signature
-// doesn't include runtime userdata — ghostty hands us the per-surface
-// userdata (PaneId) instead — so we stash the runtime pointer here
-// for that one thunk to read.
+// Latched on every Build() call. The surface-scoped callbacks
+// (close_surface and all three clipboard hooks) don't receive the
+// runtime userdata — ghostty hands them the per-surface userdata
+// (PaneId) instead — so those thunks read the runtime pointer from
+// here and forward the surface userdata to the interface.
 //
 // Safe because the runtime always outlives ghostty_app_free's
 // surface-thread join (the standard member ordering on App).
-std::atomic<IGhosttyRuntime*> g_runtimeForCloseSurface{ nullptr };
+std::atomic<IGhosttyRuntime*> g_runtimeForSurfaceCallbacks{ nullptr };
 
 }  // namespace
 
 ghostty_runtime_config_s RuntimeConfigFactory::Build(IGhosttyRuntime* runtime)
 {
-    g_runtimeForCloseSurface.store(runtime, std::memory_order_release);
+    g_runtimeForSurfaceCallbacks.store(runtime, std::memory_order_release);
 
     ghostty_runtime_config_s rtConfig{};
     rtConfig.userdata                  = runtime;
@@ -47,37 +48,53 @@ bool RuntimeConfigFactory::Action(ghostty_app_t app,
     return runtime->OnAction(target, action);
 }
 
-bool RuntimeConfigFactory::ReadClipboard(void* userdata,
+// The clipboard callbacks are surface-scoped in libghostty: the first
+// parameter is the requesting surface's userdata (embedded.zig passes
+// `self.userdata`, i.e. the value the host set in surface_config —
+// a PaneId on this host), NOT the runtime userdata. Casting it to
+// IGhosttyRuntime* would virtual-call through a PaneId. Route through
+// the latched runtime instead and forward the pane userdata so the
+// impl can complete the request on the exact surface that issued it.
+
+bool RuntimeConfigFactory::ReadClipboard(void* paneIdUserdata,
                                           ghostty_clipboard_e,
                                           void* state)
 {
-    return static_cast<IGhosttyRuntime*>(userdata)->OnReadClipboard(state);
+    auto* runtime =
+        g_runtimeForSurfaceCallbacks.load(std::memory_order_acquire);
+    if (!runtime) return false;
+    return runtime->OnReadClipboard(paneIdUserdata, state);
 }
 
-void RuntimeConfigFactory::ConfirmReadClipboard(void* userdata,
+void RuntimeConfigFactory::ConfirmReadClipboard(void* paneIdUserdata,
                                                  char const* content,
                                                  void* state,
                                                  ghostty_clipboard_request_e)
 {
-    static_cast<IGhosttyRuntime*>(userdata)
-        ->OnConfirmReadClipboard(content, state);
+    auto* runtime =
+        g_runtimeForSurfaceCallbacks.load(std::memory_order_acquire);
+    if (!runtime) return;
+    runtime->OnConfirmReadClipboard(paneIdUserdata, content, state);
 }
 
-void RuntimeConfigFactory::WriteClipboard(void* userdata,
+void RuntimeConfigFactory::WriteClipboard(void* paneIdUserdata,
                                            ghostty_clipboard_e,
                                            ghostty_clipboard_content_s const* content,
                                            size_t count,
                                            bool)
 {
     if (!content || count == 0 || !content[0].data) return;
-    static_cast<IGhosttyRuntime*>(userdata)->OnWriteClipboard(content[0].data);
+    auto* runtime =
+        g_runtimeForSurfaceCallbacks.load(std::memory_order_acquire);
+    if (!runtime) return;
+    runtime->OnWriteClipboard(paneIdUserdata, content[0].data);
 }
 
 void RuntimeConfigFactory::CloseSurface(void* paneIdUserdata, bool /*process_alive*/)
 {
     if (!paneIdUserdata) return;
     auto* runtime =
-        g_runtimeForCloseSurface.load(std::memory_order_acquire);
+        g_runtimeForSurfaceCallbacks.load(std::memory_order_acquire);
     if (!runtime) return;
     runtime->OnCloseSurface(paneIdUserdata);
 }

--- a/Core/Ghostty/RuntimeConfigFactory.h
+++ b/Core/Ghostty/RuntimeConfigFactory.h
@@ -7,10 +7,11 @@ namespace core::ghostty {
 class IGhosttyRuntime;
 
 // Builds the `ghostty_runtime_config_s` that `ghostty_app_new` consumes.
-// Wires every callback to a small static thunk that unwraps the
-// `IGhosttyRuntime*` ghostty hands back (via `rtConfig.userdata` for
-// the wakeup / clipboard callbacks, via `ghostty_app_userdata` for the
-// action callback) and forwards into the typed methods.
+// Wires every callback to a small static thunk that finds the
+// `IGhosttyRuntime*` (via `rtConfig.userdata` for wakeup,
+// `ghostty_app_userdata` for the action callback, and a latched
+// file-scope pointer for the surface-scoped callbacks — see below)
+// and forwards into the typed methods.
 //
 // The factory has no App-side dependency; the only thing it knows about
 // is `IGhosttyRuntime`, which lives in Core. The provided `runtime`
@@ -30,25 +31,28 @@ private:
     static bool Action(ghostty_app_t app,
                        ghostty_target_s target,
                        ghostty_action_s action);
-    static bool ReadClipboard(void* userdata,
+    // The clipboard and close_surface callbacks are surface-scoped in
+    // libghostty: their first parameter is the requesting surface's
+    // userdata (the PaneId the host stored on surface_config), NOT
+    // the rtConfig userdata, so we can't reach the runtime through it
+    // directly. `Build()` stashes the runtime pointer in a file-scope
+    // atomic that these thunks read; the pane userdata is forwarded
+    // so the impl can resolve the exact surface. The pointer stays
+    // valid as long as the runtime outlives ghostty_app_free's
+    // surface-thread join — the standard member ordering on App
+    // guarantees that.
+    static bool ReadClipboard(void* paneIdUserdata,
                               ghostty_clipboard_e kind,
                               void* state);
-    static void ConfirmReadClipboard(void* userdata,
+    static void ConfirmReadClipboard(void* paneIdUserdata,
                                      char const* content,
                                      void* state,
                                      ghostty_clipboard_request_e request);
-    static void WriteClipboard(void* userdata,
+    static void WriteClipboard(void* paneIdUserdata,
                                ghostty_clipboard_e kind,
                                ghostty_clipboard_content_s const* content,
                                size_t count,
                                bool confirmed);
-    // The close_surface callback's userdata is per-surface (the
-    // PaneId the host stored on surface_config), NOT the rtConfig
-    // userdata, so we can't reach the runtime through it directly.
-    // `Build()` stashes the runtime pointer in a file-scope atomic
-    // that this thunk reads. The pointer stays valid as long as the
-    // runtime outlives ghostty_app_free's surface-thread join — the
-    // standard member ordering on App guarantees that.
     static void CloseSurface(void* paneIdUserdata, bool process_alive);
 };
 


### PR DESCRIPTION
## Summary

Finishes the remaining action wiring from #55 now that multiple windows exist.

<details><summary>日本語</summary>

multi-window 化 (#55) の残りの action 配線を仕上げる。

</details>

## What was done

1. **`Actions::AppHooks`** — the app-scope callables injected into `Actions` (previously a single bare `std::function` for NEW_WINDOW) become a named-slot aggregate. Pure mechanical refactor.
2. **Distinct CLOSE_WINDOW / CLOSE_ALL_WINDOWS / QUIT handlers** — all three collapsed to `OnCloseWindow`, so a quit or close-all keybind closed only the window owning the triggering surface. `CLOSE_WINDOW` stays per-window (the dispatcher is already routed by target surface); `CLOSE_ALL_WINDOWS`/`QUIT` sweep a snapshot of the top-level window list at App scope. `Quit()` deliberately avoids `Application::Exit()` so member-order teardown (`ghostty_app_free`, renderer-thread joins) still runs.
3. **Clipboard callbacks routed by surface** — libghostty passes the *surface* userdata (our PaneId) to `read/confirm/write_clipboard`, same contract as `close_surface`, but the factory thunks cast it to `IGhosttyRuntime*` (a virtual call through a PaneId bit pattern) and the impl completed requests on `anyWindow()`'s active control — the wrong surface as soon as two windows exist. The thunks now use the latched-runtime pattern `close_surface` already had, and `MainWindowRuntime` resolves PaneId → owning window → owning `TerminalControl` so completion lands on exactly the requesting surface.
4. **`window-decoration=false` new-tab fallback** — new-tab with hidden chrome used to drop the request ("multi-window not yet wired"); it now spawns a new top-level window, matching upstream macOS semantics.

<details><summary>日本語</summary>

1. **`Actions::AppHooks`** — Actions に注入する app スコープの callable (従来は NEW_WINDOW 用の裸の `std::function` 1個) を名前付きスロットの集約に。純粋な機械的リファクタ。
2. **CLOSE_WINDOW / CLOSE_ALL_WINDOWS / QUIT の分離** — 3つとも `OnCloseWindow` に集約されていたため、quit や close-all のキーバインドがトリガー元 surface のウインドウしか閉じなかった。`CLOSE_WINDOW` はウインドウ単位のまま (dispatcher は target surface でルーティング済み)、`CLOSE_ALL_WINDOWS`/`QUIT` は App スコープでウインドウリストのスナップショットを走査。`Quit()` は member 順の teardown (`ghostty_app_free`、renderer スレッド join) を壊さないよう `Application::Exit()` を意図的に避ける。
3. **clipboard コールバックの surface ルーティング** — libghostty は `read/confirm/write_clipboard` に *surface* の userdata (この port では PaneId) を渡す (`close_surface` と同じ契約) が、factory の thunk はそれを `IGhosttyRuntime*` にキャスト (PaneId のビットパターン経由の仮想呼び出し) し、impl は `anyWindow()` の active control で完了していた — 2窓以降は誤った surface。`close_surface` と同じ latched-runtime パターンに揃え、`MainWindowRuntime` が PaneId → 所有ウインドウ → 所有 `TerminalControl` を解決して、要求元 surface で正確に完了する。
4. **`window-decoration=false` 時の new-tab フォールバック** — chrome 非表示時の new-tab は「multi-window 未配線」として drop していたが、upstream macOS と同じく新しいトップレベルウインドウを生成するように。

</details>

## Verification

- [ ] `close_window` keybind closes only its window; siblings survive
- [ ] `close_all_windows` / `quit` keybinds close every window and exit the app cleanly (no crash on teardown)
- [ ] Paste (bracketed/terminal-requested) completes in the window that requested it, with two windows open
- [ ] OSC 52 copy from window B owns the clipboard under window B's HWND
- [ ] `window-decoration = false` + new-tab → a new window opens

<details><summary>日本語</summary>

- [ ] `close_window` キーバインドは自分のウインドウだけ閉じ、他は生存
- [ ] `close_all_windows` / `quit` は全ウインドウを閉じてアプリがクリーンに終了 (teardown でクラッシュしない)
- [ ] 2窓状態で、ターミナル起点の paste が要求元ウインドウで完了する
- [ ] ウインドウ B からの OSC 52 copy が B の HWND でクリップボードを所有
- [ ] `window-decoration = false` + new-tab → 新しいウインドウが開く

</details>
