### PR TITLE
Move tabs between windows with release-time drag-and-drop

### DIFF
--- a/App/App.xaml.cpp
+++ b/App/App.xaml.cpp
@@ -309,6 +309,39 @@ namespace winrt::GhosttyWin32::implementation
     void App::CreateNewWindow()
     {
         auto w = make<MainWindow>();
+        TrackWindow(w);
+        w.Activate();
+    }
+
+    MainWindow* App::CreateTearOutWindow()
+    {
+        auto w = make<MainWindow>();
+        auto* impl = winrt::get_self<MainWindow>(w);
+        // Must be flagged before the first Activated runs its
+        // one-shot init: this window adopts the dragged tab instead
+        // of creating one.
+        impl->SuppressInitialTab();
+        TrackWindow(w);
+        // Deliberately no Activate(): the drop handler positions the
+        // window at the drop point after adopting the tab and decides
+        // activation itself.
+        return impl;
+    }
+
+    MainWindow* App::FindWindowByTabItem(
+        Microsoft::UI::Xaml::Controls::TabViewItem const& item) noexcept
+    {
+        for (auto const& w : m_topLevelWindows) {
+            if (auto typed = w.try_as<winrt::GhosttyWin32::MainWindow>()) {
+                auto* impl = winrt::get_self<MainWindow>(typed);
+                if (impl && impl->OwnsTabItem(item)) return impl;
+            }
+        }
+        return nullptr;
+    }
+
+    void App::TrackWindow(Microsoft::UI::Xaml::Window const& w)
+    {
         m_topLevelWindows.push_back(w);
         // Auto-erase the vector entry when the user closes the
         // window. Capture only `this`; the sender comes in through
@@ -326,7 +359,6 @@ namespace winrt::GhosttyWin32::implementation
                 m_topLevelWindows.erase(it);
             }
         });
-        w.Activate();
     }
 
     void App::CloseAllWindows()

--- a/App/App.xaml.h
+++ b/App/App.xaml.h
@@ -122,6 +122,26 @@ namespace winrt::GhosttyWin32::implementation
         MainWindow* FindWindowByTabItem(
             Microsoft::UI::Xaml::Controls::TabViewItem const& item) noexcept;
 
+        // The tab drag currently in flight, if any. Cross-window
+        // drag-and-drop rides OLE, which only marshals primitive
+        // DataPackage values — a TabViewItem stuffed into the
+        // package's Properties comes out empty on another window's
+        // TabStripDrop. Every window shares this process, so the
+        // dragged item travels through this slot instead: set in
+        // TabDragStarting, read by any window's drop handlers,
+        // cleared in TabDragCompleted (which fires on the source
+        // whether or not a drop landed).
+        void SetDraggedTab(
+            Microsoft::UI::Xaml::Controls::TabViewItem const& item)
+        {
+            m_draggedTab = item;
+        }
+        void ClearDraggedTab() noexcept { m_draggedTab = nullptr; }
+        Microsoft::UI::Xaml::Controls::TabViewItem DraggedTab() const noexcept
+        {
+            return m_draggedTab;
+        }
+
     private:
         // Shared tail of CreateNewWindow / CreateTearOutWindow:
         // strong-ref the window in m_topLevelWindows and subscribe
@@ -191,5 +211,8 @@ namespace winrt::GhosttyWin32::implementation
         // Token for the primary AppInstance's Activated event; the
         // subscription lives for the lifetime of the App.
         winrt::event_token m_activatedToken{};
+        // See SetDraggedTab. Strong ref for the duration of the drag
+        // only; TabDragCompleted always clears it.
+        Microsoft::UI::Xaml::Controls::TabViewItem m_draggedTab{ nullptr };
     };
 }

--- a/App/App.xaml.h
+++ b/App/App.xaml.h
@@ -109,7 +109,25 @@ namespace winrt::GhosttyWin32::implementation
         // a home when it arrives.
         void Quit();
 
+        // Spawn the window that will host a torn-out tab. Same
+        // tracking as CreateNewWindow, but with no initial tab (it
+        // adopts the dropped one) and no Activate() — the drop
+        // handler positions the window at the drop point after
+        // adopting the tab and decides activation itself.
+        MainWindow* CreateTearOutWindow();
+
+        // The live window whose tab strip owns `item`, or null.
+        // Locates the source window of a dragged tab on the drop
+        // paths (the drop target only receives the TabViewItem).
+        MainWindow* FindWindowByTabItem(
+            Microsoft::UI::Xaml::Controls::TabViewItem const& item) noexcept;
+
     private:
+        // Shared tail of CreateNewWindow / CreateTearOutWindow:
+        // strong-ref the window in m_topLevelWindows and subscribe
+        // the Closed auto-erase.
+        void TrackWindow(Microsoft::UI::Xaml::Window const& w);
+
         // Subsequent-activation handler. The first activation runs through
         // OnLaunched; later activations (a second click of a notification,
         // a relaunch from the Start menu, etc.) get redirected to this

--- a/App/MainWindow.xaml
+++ b/App/MainWindow.xaml
@@ -47,6 +47,7 @@
 
             <TabView x:Name="TabView" Grid.Column="0" Grid.ColumnSpan="2"
                      IsAddTabButtonVisible="True"
+                     CanDragTabs="True"
                      TabWidthMode="Equal"
                      VerticalAlignment="Top"
                      HorizontalAlignment="Stretch">

--- a/App/MainWindow.xaml.cpp
+++ b/App/MainWindow.xaml.cpp
@@ -296,6 +296,115 @@ namespace winrt::GhosttyWin32::implementation
 
             auto tv = TabView();
 
+            // ----- tab drag-out / merge (release-time semantics) -----
+            // Tab movement uses TabView's classic drag-and-drop flow
+            // (CanDragTabs, set in markup) rather than the WinAppSDK
+            // native tear-out (CanTearOutTabs). Native tear-out drives
+            // an OS move-size loop that spawns and drags a live window
+            // mid-drag; in practice it shipped broken
+            // (microsoft-ui-xaml#10154 raises the window request for
+            // plain clicks, #10156 zeroes the NewWindowId round-trip)
+            // and mispositions the grab point when the torn-out window
+            // appears. With drag-and-drop nothing happens until the
+            // user RELEASES: dropping on another window's strip merges
+            // the tab there, dropping anywhere else spawns a window at
+            // the drop point. Only a drag ghost is shown mid-drag.
+            //
+            // The dragged TabViewItem travels in the DataPackage
+            // properties — every window lives in this process, so the
+            // drop target reads the same IInspectable back out and no
+            // app-global drag state is needed.
+            tv.TabDragStarting([](auto const&, auto const& args) {
+                args.Data().Properties().Insert(L"GhosttyTornTab", args.Tab());
+                args.Data().RequestedOperation(
+                    winrt::Windows::ApplicationModel::DataTransfer::DataPackageOperation::Move);
+            });
+
+            tv.TabStripDragOver([](auto const&, auto const& e) {
+                if (e.DataView().Properties().HasKey(L"GhosttyTornTab")) {
+                    e.AcceptedOperation(
+                        winrt::Windows::ApplicationModel::DataTransfer::DataPackageOperation::Move);
+                }
+            });
+
+            tv.TabStripDrop([weakActivated](auto const& sender, auto const& e) {
+                auto self = weakActivated.get();
+                if (!self || !App::g_app) return;
+                // TabStripDrop is a plain DragEventHandler, so the
+                // sender arrives as IInspectable, not a typed TabView.
+                auto strip = sender.template try_as<muxc::TabView>();
+                if (!strip) return;
+                auto obj = e.DataView().Properties().TryLookup(L"GhosttyTornTab");
+                auto item = obj ? obj.template try_as<muxc::TabViewItem>() : nullptr;
+                if (!item) return;
+                auto* source = App::g_app->FindWindowByTabItem(item);
+                // Same-strip drops are reorders, which CanReorderTabs
+                // already handled natively.
+                if (!source || source == self.get()) return;
+                // Insert where the tab was dropped: before the first
+                // tab whose slot the pointer hasn't fully passed.
+                int32_t index = -1;
+                auto items = strip.TabItems();
+                for (uint32_t i = 0; i < items.Size(); ++i) {
+                    auto container = strip.ContainerFromIndex(i)
+                        .template try_as<muxc::TabViewItem>();
+                    if (!container) continue;
+                    if (e.GetPosition(container).X - container.ActualWidth() < 0) {
+                        index = static_cast<int32_t>(i);
+                        break;
+                    }
+                }
+                try {
+                    if (auto tab = source->ReleaseTornOutTab(item)) {
+                        self->AdoptTornOutTab(std::move(tab), index);
+                        source->CloseIfTornOutEmpty();
+                    }
+                } catch (winrt::hresult_error const&) {
+                    // A failed move must not take either window down;
+                    // whichever side holds the unique_ptr owns the tab.
+                }
+            });
+
+            tv.TabDroppedOutside([weakActivated](auto const&, auto const& args) {
+                auto self = weakActivated.get();
+                if (!self || !App::g_app) return;
+                auto item = args.Tab();
+                if (!item) return;
+                POINT cursor{};
+                bool haveCursor = GetCursorPos(&cursor) != 0;
+                // Offsets place the window so its tab strip lands near
+                // the pointer instead of the window's top-left corner.
+                int32_t dropX = static_cast<int32_t>(cursor.x) - 120;
+                int32_t dropY = static_cast<int32_t>(cursor.y) - 24;
+                // Dragging out the only tab must not leave an empty
+                // shell behind — just move this window to the drop
+                // point instead, browser-style.
+                if (self->m_tabs.Size() <= 1) {
+                    if (haveCursor) {
+                        self->AppWindow().Move({ dropX, dropY });
+                    }
+                    return;
+                }
+                auto* host = App::g_app->CreateTearOutWindow();
+                if (!host) return;
+                try {
+                    if (auto tab = self->ReleaseTornOutTab(item)) {
+                        host->AdoptTornOutTab(std::move(tab), -1);
+                        if (haveCursor) {
+                            host->AppWindow().Move({ dropX, dropY });
+                        }
+                        // The drag is over, so activation is safe —
+                        // hand the new window focus like a browser
+                        // does after a tab is torn off.
+                        host->Activate();
+                    } else {
+                        // Nothing moved; don't leak an empty host.
+                        host->RequestClose();
+                    }
+                } catch (winrt::hresult_error const&) {
+                }
+            });
+
             // Don't call Window.SetTitleBar(AppTitleBar()) — that would
             // make the whole chrome row OS-title-bar input, including the
             // tab headers. Double-clicking a tab header would then

--- a/App/MainWindow.xaml.cpp
+++ b/App/MainWindow.xaml.cpp
@@ -310,18 +310,31 @@ namespace winrt::GhosttyWin32::implementation
             // the tab there, dropping anywhere else spawns a window at
             // the drop point. Only a drag ghost is shown mid-drag.
             //
-            // The dragged TabViewItem travels in the DataPackage
-            // properties — every window lives in this process, so the
-            // drop target reads the same IInspectable back out and no
-            // app-global drag state is needed.
+            // The dragged TabViewItem travels through App's
+            // dragged-tab slot (SetDraggedTab), NOT the DataPackage:
+            // a drop on another top-level window rides OLE, which
+            // only marshals primitive package values — a TabViewItem
+            // stuffed into Properties comes out missing on the other
+            // window and the merge silently degrades into a
+            // drop-outside. The package deliberately stays empty
+            // (operation only) so foreign drop targets — a text
+            // editor, say — have nothing to accept and can't swallow
+            // the drag away from TabDroppedOutside.
             tv.TabDragStarting([](auto const&, auto const& args) {
-                args.Data().Properties().Insert(L"GhosttyTornTab", args.Tab());
+                if (App::g_app) App::g_app->SetDraggedTab(args.Tab());
                 args.Data().RequestedOperation(
                     winrt::Windows::ApplicationModel::DataTransfer::DataPackageOperation::Move);
             });
 
+            // Fires on the source when the drag ends, whether or not
+            // any drop landed — the one reliable place to clear the
+            // in-flight slot.
+            tv.TabDragCompleted([](auto const&, auto const&) {
+                if (App::g_app) App::g_app->ClearDraggedTab();
+            });
+
             tv.TabStripDragOver([](auto const&, auto const& e) {
-                if (e.DataView().Properties().HasKey(L"GhosttyTornTab")) {
+                if (App::g_app && App::g_app->DraggedTab()) {
                     e.AcceptedOperation(
                         winrt::Windows::ApplicationModel::DataTransfer::DataPackageOperation::Move);
                 }
@@ -334,8 +347,9 @@ namespace winrt::GhosttyWin32::implementation
                 // sender arrives as IInspectable, not a typed TabView.
                 auto strip = sender.template try_as<muxc::TabView>();
                 if (!strip) return;
-                auto obj = e.DataView().Properties().TryLookup(L"GhosttyTornTab");
-                auto item = obj ? obj.template try_as<muxc::TabViewItem>() : nullptr;
+                // Source's TabDragCompleted (which clears the slot)
+                // fires only after this drop returns.
+                auto item = App::g_app->DraggedTab();
                 if (!item) return;
                 auto* source = App::g_app->FindWindowByTabItem(item);
                 // Same-strip drops are reorders, which CanReorderTabs

--- a/App/MainWindow.xaml.cpp
+++ b/App/MainWindow.xaml.cpp
@@ -84,7 +84,11 @@ namespace winrt::GhosttyWin32::implementation
             if (App::g_app) App::g_app->Windows().Register(this);
             auto windowNative = this->try_as<::IWindowNative>();
             if (windowNative) windowNative->get_WindowHandle(&m_hwnd);
-            if (m_hwnd) ShowWindow(m_hwnd, SW_HIDE);
+            // The pre-first-frame hide avoids flashing an empty window
+            // before ghostty presents. A drop host receives a tab that
+            // is already presenting, so it has frames to show from the
+            // first paint and skips the hide.
+            if (m_hwnd && !m_suppressInitialTab) ShowWindow(m_hwnd, SW_HIDE);
 
             // Remove the OS title bar (and with it the system caption
             // buttons) so only our XAML CaptionButtons render at the top.
@@ -291,6 +295,7 @@ namespace winrt::GhosttyWin32::implementation
             });
 
             auto tv = TabView();
+
             // Don't call Window.SetTitleBar(AppTitleBar()) — that would
             // make the whole chrome row OS-title-bar input, including the
             // tab headers. Double-clicking a tab header would then
@@ -531,7 +536,9 @@ namespace winrt::GhosttyWin32::implementation
             });
 
             InitGhostty();
-            CreateTab();
+            // Tear-out hosts don't create an initial tab: they adopt
+            // the dragged one (possibly before this handler even ran).
+            if (!m_suppressInitialTab) CreateTab();
             // Honour `window-decoration` from config at startup so
             // users who set it in their config see the chrome state
             // they asked for without having to fire the toggle
@@ -1696,6 +1703,120 @@ namespace winrt::GhosttyWin32::implementation
         auto lookup = m_tabs.FindByPaneId(id);
         if (!lookup.leaf) return nullptr;
         return Tab::LeafToTerminalControl(*lookup.leaf);
+    }
+
+    std::unique_ptr<Tab> MainWindow::ReleaseTornOutTab(
+        muxc::TabViewItem const& item)
+    {
+        auto* t = m_tabs.FindByItem(item);
+        if (!t) return nullptr;
+
+        // The focused-surface cache must not follow the tab out: the
+        // surfaces stay alive, but they stop being *this* window's
+        // surfaces. Walk the departing tab's leaves rather than just
+        // its active control — m_activeSurface can point at any pane.
+        if (m_activeSurface) {
+            if (auto* panelImpl =
+                    winrt::get_self<implementation::SplitPanel>(t->Panel())) {
+                std::vector<Pane*> leaves;
+                CollectLeaves(panelImpl->Root(), leaves);
+                for (auto* leaf : leaves) {
+                    auto* tc = Tab::LeafToTerminalControl(*leaf);
+                    if (tc && tc->Surface().Owns(m_activeSurface)) {
+                        m_activeSurface = nullptr;
+                        break;
+                    }
+                }
+            }
+        }
+
+        // Unparent the visual pieces but detach nothing: the swap
+        // chains keep presenting while the tab is in flight.
+        RemoveTabPanelFromAppContent(*t);
+        auto tv = TabView();
+        if (tv) {
+            uint32_t idx = 0;
+            if (tv.TabItems().IndexOf(item, idx)) {
+                tv.TabItems().RemoveAt(idx);
+            }
+        }
+        return m_tabs.Extract(item);
+    }
+
+    void MainWindow::AdoptTornOutTab(std::unique_ptr<Tab> tab, int32_t index)
+    {
+        if (!tab) return;
+
+        // A tear-out host adopts before its first Activated has run,
+        // so the HWND may not be captured yet. IWindowNative works
+        // from construction onward.
+        if (!m_hwnd) {
+            if (auto native = this->try_as<::IWindowNative>()) {
+                native->get_WindowHandle(&m_hwnd);
+            }
+        }
+
+        auto tv = TabView();
+        if (!tv) return;
+        auto items = tv.TabItems();
+        uint32_t size = items.Size();
+        uint32_t at = (index < 0 || static_cast<uint32_t>(index) > size)
+            ? size
+            : static_cast<uint32_t>(index);
+        items.InsertAt(at, tab->Item());
+
+        // Re-point every control at this window: IME coordinates and
+        // clipboard ownership key off the host HWND, and the focused
+        // callback must feed THIS window's active-surface cache. Raw
+        // `this` capture is safe by the same argument as InitGhostty's
+        // onLeafFocused — MainWindow outlives every control it hosts.
+        if (auto* panelImpl =
+                winrt::get_self<implementation::SplitPanel>(tab->Panel())) {
+            std::vector<Pane*> leaves;
+            CollectLeaves(panelImpl->Root(), leaves);
+            for (auto* leaf : leaves) {
+                if (auto* tc = Tab::LeafToTerminalControl(*leaf)) {
+                    tc->Rehost(m_hwnd, [this](ghostty_surface_t s) noexcept {
+                        NotifySurfaceFocused(s);
+                    });
+                }
+            }
+        }
+
+        // Same shape as CreateTab's post-Make sequence: parent the
+        // panel collapsed, register ownership, then select — the
+        // SelectionChanged handler reconciles panel visibility and
+        // focus for us.
+        tab->Panel().Visibility(winrt::Microsoft::UI::Xaml::Visibility::Collapsed);
+        AppContent().Children().Append(tab->Panel());
+        auto selected = tab->Item();
+        m_tabs.Add(std::move(tab));
+        tv.SelectedItem(selected);
+        UpdateActivePanelVisibility();
+        // SHOWNOACTIVATE, not SHOW: make the adopted tab visible
+        // without deciding focus here. Whether the window should be
+        // activated is the caller's call — the drop-outside handler
+        // activates its freshly spawned host, while a merge adopts
+        // into a window that is already visible and focused.
+        if (m_hwnd) ShowWindow(m_hwnd, SW_SHOWNOACTIVATE);
+    }
+
+    void MainWindow::CloseIfTornOutEmpty()
+    {
+        // Tearing the last tab out leaves an empty shell — close it,
+        // matching browser behaviour. Deferred through the dispatcher
+        // so window teardown never runs inside tear-out event
+        // dispatch, and re-checked on arrival in case a merge landed
+        // a tab here in the meantime.
+        if (!m_tabs.Empty()) return;
+        auto dq = DispatcherQueue();
+        auto weak = get_weak();
+        if (!dq) { RequestClose(); return; }
+        dq.TryEnqueue([weak]() {
+            if (auto self = weak.get()) {
+                if (self->m_tabs.Empty()) self->RequestClose();
+            }
+        });
     }
 
     void MainWindow::CloseSurfaceByPaneId(PaneId id)

--- a/App/MainWindow.xaml.h
+++ b/App/MainWindow.xaml.h
@@ -199,6 +199,45 @@ namespace winrt::GhosttyWin32::implementation
         // the surface that issued them.
         TerminalControl* ControlByPaneId(PaneId id) noexcept;
 
+        // ----- tab drag-out / merge (#55 follow-up) -----
+        // Mark this window as a drop host BEFORE its first Activated:
+        // it will receive a live, already-presenting tab instead of
+        // creating one, so the one-shot init skips the initial
+        // CreateTab and the pre-first-frame SW_HIDE (the adopted tab
+        // has frames to show from the first paint). Called by
+        // App::CreateTearOutWindow through the existing friendship.
+        void SuppressInitialTab() noexcept { m_suppressInitialTab = true; }
+
+        // Take `item`'s Tab out of this window alive: strip entry
+        // removed, panel unparented from AppContent, focused-surface
+        // cache cleared if it pointed into the tab — but nothing
+        // detached or destroyed, so a sibling window can adopt the
+        // same Tab. Returns null when this window doesn't own `item`.
+        std::unique_ptr<Tab> ReleaseTornOutTab(
+            winrt::Microsoft::UI::Xaml::Controls::TabViewItem const& item);
+
+        // Counterpart of ReleaseTornOutTab: insert the tab into this
+        // window's strip at `index` (clamped; negative appends),
+        // re-point its controls at this window (host HWND + focused
+        // callback), parent the panel, select it, and make sure the
+        // window is visible. Safe to call before this window's first
+        // Activated — the HWND is captured on demand.
+        void AdoptTornOutTab(std::unique_ptr<Tab> tab, int32_t index);
+
+        // Close this window once a tear-out leaves it without tabs,
+        // matching browser behaviour. Deferred through the dispatcher
+        // so teardown never runs inside tear-out event dispatch.
+        void CloseIfTornOutEmpty();
+
+        // True when this window's tab strip owns `item`. Used by the
+        // merge path to locate the source window of a torn-out tab.
+        bool OwnsTabItem(
+            winrt::Microsoft::UI::Xaml::Controls::TabViewItem const& item) const noexcept {
+            return m_tabs.FindByItem(item) != nullptr;
+        }
+
+        bool m_suppressInitialTab{ false };
+
         // Push renderer-side visibility to every surface in this
         // window (all tabs, all panes). Driven by
         // Window.VisibilityChanged: while hidden/minimized each

--- a/App/Tabs/Tabs.h
+++ b/App/Tabs/Tabs.h
@@ -114,6 +114,23 @@ public:
         return false;
     }
 
+    // Transfer ownership of the Tab wrapping `item` out of this
+    // collection without destroying it. Tab tear-out moves a live Tab
+    // — surfaces, swap chains, panel tree and all — into a sibling
+    // window's collection, so unlike Remove() the Tab must survive
+    // its departure from this list. Returns null when no tab here
+    // wraps `item`.
+    std::unique_ptr<Tab> Extract(Microsoft::UI::Xaml::Controls::TabViewItem const& item) {
+        for (auto it = m_tabs.begin(); it != m_tabs.end(); ++it) {
+            if (*it && (*it)->Item() == item) {
+                auto tab = std::move(*it);
+                m_tabs.erase(it);
+                return tab;
+            }
+        }
+        return nullptr;
+    }
+
     void Clear() noexcept { m_tabs.clear(); }
 
     bool Empty() const noexcept { return m_tabs.empty(); }

--- a/App/TerminalControl.xaml.h
+++ b/App/TerminalControl.xaml.h
@@ -124,6 +124,20 @@ namespace winrt::GhosttyWin32::implementation
         // safe.
         void Detach();
 
+        // Re-point this control at a new host window after a tab
+        // tear-out / adopt. The surface and swap chain move as-is —
+        // the SwapChainPanel keeps its composition binding across
+        // reparenting on the shared UI thread — but two things are
+        // derived from the owning window and must follow it: the host
+        // HWND (IME caret coordinates via ClientToScreen, clipboard
+        // ownership) and the focused callback, which feeds the owning
+        // window's active-surface cache.
+        void Rehost(HWND hostHwnd,
+                    std::function<void(ghostty_surface_t)> onFocused) noexcept {
+            m_hostHwnd  = hostHwnd;
+            m_onFocused = std::move(onFocused);
+        }
+
         // Renderer-thread callback registered with ghostty as
         // cfg.swap_chain_ready_cb. Hops to the UI thread and binds the
         // swap chain handle to the panel via ISwapChainPanelNative2.

--- a/App/pch.h
+++ b/App/pch.h
@@ -16,6 +16,7 @@
 #include <winrt/Windows.Foundation.h>
 #include <winrt/Windows.Foundation.Collections.h>
 #include <winrt/Windows.ApplicationModel.Activation.h>
+#include <winrt/Windows.ApplicationModel.DataTransfer.h>
 #include <winrt/Microsoft.UI.Composition.h>
 #include <winrt/Microsoft.UI.Xaml.h>
 #include <winrt/Microsoft.UI.Xaml.Controls.h>


### PR DESCRIPTION
## Summary

Move tabs between windows with **release-time drag-and-drop** (`CanDragTabs` + `TabDroppedOutside` / `TabStripDrop`): while dragging, only the drag ghost is shown; on release, dropping on another window's tab strip **merges** the tab there, and dropping anywhere else **spawns a new window** at the drop point. Stacked on #94.

<details><summary>日本語</summary>

**リリース時分岐の drag-and-drop** (`CanDragTabs` + `TabDroppedOutside` / `TabStripDrop`) でタブをウインドウ間移動する: ドラッグ中はゴーストのみ表示し、離した位置が別ウインドウのタブストリップなら**合成**、それ以外なら**その位置に新ウインドウ生成**。#94 の上に積んでいる。

</details>

## How it works

A moved tab is a **live** `Tab` — surfaces, swap chains and the SplitPanel tree move as-is; nothing detaches or re-creates. The SwapChainPanel keeps its composition binding across reparenting because every window shares the one UI thread. What must follow the window is re-pointed by `TerminalControl::Rehost`: the host HWND (IME caret coordinates, clipboard ownership) and the focused callback (feeds the owning window's active-surface cache). PaneId-keyed routing (clipboard, close_surface) follows automatically since it walks the windows' live trees.

The dragged `TabViewItem` travels through an App-scope in-flight slot (`SetDraggedTab` / `DraggedTab` / cleared in `TabDragCompleted`), **not** the DataPackage: a drop on another top-level window rides OLE, which only marshals primitive package values, so a TabViewItem stored in `Properties` arrives missing on the target window and the merge silently degrades into a drop-outside spawn. The package deliberately stays empty (operation only) so foreign drop targets have nothing to accept and can't swallow the drag away from `TabDroppedOutside`. Dragging out a window's **only** tab just moves that window to the drop point (no empty shell left behind).

Commits (one concern each):
1. `Tabs::Extract` — take a Tab out alive instead of destroying it
2. Tab-move machinery — `TerminalControl::Rehost`, `MainWindow::ReleaseTornOutTab` / `AdoptTornOutTab` / `CloseIfTornOutEmpty`, `SuppressInitialTab`
3. App-scope plumbing — `CreateTearOutWindow` (drop host: no initial tab, caller decides placement/activation), `FindWindowByTabItem`, shared `TrackWindow`
4. Drag-and-drop wiring — `CanDragTabs` + `TabDragStarting` / `TabStripDragOver` / `TabStripDrop` / `TabDroppedOutside` on every window's TabView

<details><summary>日本語</summary>

移動するタブは**生きた** `Tab` — surface・swapchain・SplitPanel ツリーがそのまま移動し、detach も作り直しもしない。全ウインドウが同一 UI スレッドなので SwapChainPanel は再親付けをまたいで composition バインディングを維持する。ウインドウ由来の情報だけ `TerminalControl::Rehost` で張り替える: host HWND (IME キャレット座標、クリップボード所有) と focused コールバック。PaneId ベースのルーティングはライブツリーを歩くので自動追従。

ドラッグ中の `TabViewItem` は App スコープの in-flight スロット (`SetDraggedTab` / `DraggedTab` / `TabDragCompleted` でクリア) で運ぶ — DataPackage では**ない**。別トップレベルウインドウへのドロップは OLE 経由になり primitive しかマーシャルされないため、`Properties` に積んだ TabViewItem はドロップ先で消えて合成が drop-outside に化ける。DataPackage は意図的に空 (operation のみ) にして、外部アプリのドロップ先が何も受け取れないようにし、`TabDroppedOutside` からドラッグを奪えないようにしている。**唯一の**タブをドラッグアウトした場合はそのウインドウをドロップ位置へ動かすだけ (空殻を残さない)。

コミット構成 (関心事ごと):
1. `Tabs::Extract` — Tab を破棄せず生きたまま取り出す
2. 引っ越し機構 — `TerminalControl::Rehost`、`ReleaseTornOutTab` / `AdoptTornOutTab` / `CloseIfTornOutEmpty`、`SuppressInitialTab`
3. App 配管 — `CreateTearOutWindow` (drop ホスト: 初期タブなし、配置とアクティブ化は呼び出し側)、`FindWindowByTabItem`、共通 `TrackWindow`
4. drag-and-drop 配線 — 全ウインドウの TabView に `CanDragTabs` + 4 ハンドラ

</details>

## Why not the native tear-out (`CanTearOutTabs`)

The WinAppSDK 1.6+ native tear-out was implemented first and rejected. It drives an OS move-size loop that spawns and drags a live window mid-drag, and in practice it shipped broken:

- [microsoft-ui-xaml#10154](https://github.com/microsoft/microsoft-ui-xaml/issues/10154) — `TabTearOutWindowRequested` fires for gestures that never become a tear-out (even a plain click on a tab header), leaking invisible host windows.
- [microsoft-ui-xaml#10156](https://github.com/microsoft/microsoft-ui-xaml/issues/10156) — the `NewWindowId` handed out in `TabTearOutWindowRequested` arrives **zeroed** in `TabTearOutRequested`, requiring an app-side pending-id workaround.
- The grab point jumps sideways the moment the torn-out window appears (WinUI's `m_dragPositionOffset` correction, TabView.cpp, doesn't hold up in this app's layout), and any activation inside the modal move-size loop cancels the whole drag (`WM_CANCELMODE`).

Release-time semantics also simply match the desired UX: nothing materializes until the user lets go.

<details><summary>日本語</summary>

WinAppSDK 1.6+ のネイティブ tear-out を先に実装したが棄却した。OS の move-size ループでドラッグ中に実ウインドウを生成して引きずる設計で、実際には壊れている:

- [#10154](https://github.com/microsoft/microsoft-ui-xaml/issues/10154) — tear-out にならないジェスチャ (タブヘッダの単純クリック等) でも `TabTearOutWindowRequested` が発火し、不可視ホストがリークする。
- [#10156](https://github.com/microsoft/microsoft-ui-xaml/issues/10156) — `TabTearOutWindowRequested` で渡した `NewWindowId` が `TabTearOutRequested` では **0** で届き、アプリ側の pending-id 回避策が必要になる。
- 切り離しウインドウが現れた瞬間に掴み位置が横へズレる (WinUI の `m_dragPositionOffset` 補正がこのアプリのレイアウトでは成立しない)。また、モーダル move-size ループ内でのアクティブ化はドラッグ全体をキャンセルする (`WM_CANCELMODE`)。

そもそも「離すまで何も起きない」リリース時分岐が求める UX に合致している。

</details>

## Verification

- [ ] Drag a tab: only the drag ghost appears mid-drag (no window)
- [ ] Release outside any strip → new window appears at the drop point, focused, grab point correct
- [ ] Release on another window's strip → tab merges at the drop position; source window closes if emptied
- [ ] Drag out the only tab of a window → the window itself moves to the drop point
- [ ] In-strip drag still reorders tabs
- [ ] After a move: typing, IME composition (caret position), paste, OSC 52 all act on the new window
- [ ] Splits inside a moved tab keep working; DPI-mixed monitors render at destination scale

<details><summary>日本語</summary>

- [ ] タブをドラッグ: ドラッグ中はゴーストのみ (ウインドウは出ない)
- [ ] strip 外で離す → ドロップ位置に新ウインドウ (フォーカスあり、掴み位置正常)
- [ ] 別ウインドウの strip 上で離す → その位置に合成、空になった元ウインドウは閉じる
- [ ] 唯一のタブをドラッグアウト → ウインドウ自体がドロップ位置へ移動
- [ ] strip 内ドラッグでの並べ替えは従来どおり
- [ ] 移動後: タイプ、IME 変換 (キャレット位置)、paste、OSC 52 が新ウインドウ基準
- [ ] 移動したタブ内の split が動作、DPI 混在モニタで移動先スケール描画

</details>
