### PR TITLE
Retire the Scoop distribution channel until signing is available

### DIFF
--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -1,7 +1,7 @@
 # リリース手順
 
 GhosttyWin32 のリリースは GitHub Actions で MSIX をビルド・自己署名 → GitHub Releases にアップロードする。
-Scoop / 手動どちらでもインストール可能な配布形態。
+正式な CA / OSS Foundation 署名が取得できるまで、Scoop チャネルは停止中 ([#46](https://github.com/i999rri/GhosttyWin32/issues/46))、配布は手動インストールのみ。
 
 ## ブランチとリリースの全体像
 
@@ -276,7 +276,7 @@ git push origin v0.3.0-rc1
 | `v0.3.0` (production) | `Ghostty-0.3.0-x64.msix` |
 | `v0.3.0-rc1` (RC) | `Ghostty-v0.3.0-rc1-x64.msix` |
 
-scoop manifest 側はこの違いを autoupdate URL pattern で吸収する (RC channel の manifest では `$matchHead` か full ref を使う)。
+(Scoop チャネル復帰時は、autoupdate URL pattern で `Ghostty-$version-x64.msix` (production) / `Ghostty-v$version-x64.msix` (RC) を吸収させる。)
 
 RC2 以降が必要になった場合は、dev に修正コミットを積んでから新タグ:
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -197,12 +197,12 @@ jobs:
 
             ## Installation
 
-            ### Scoop (recommended)
-            ```
-            scoop install ghostty
-            ```
+            Signed only with a self-signed publisher certificate (`CN=i999rri`)
+            — an established CA / OSS Foundation signature isn't in place yet
+            (see [#46](https://github.com/${{ github.repository }}/issues/46)),
+            so Windows requires the certificate to be trusted before the MSIX
+            will install. Manual install is the only supported path:
 
-            ### Manual install
             1. Download `Ghostty.cer` and the `.msix` from the assets above
             2. Trust the certificate (Local Machine → Trusted People store)
             3. Double-click the `.msix` to install

--- a/README.md
+++ b/README.md
@@ -98,31 +98,13 @@ ghostty.dll (Zig, from i999rri/ghostty windows-port branch)
 
 ## Install
 
-### Scoop (recommended)
-
-```powershell
-scoop bucket add ghostty https://github.com/i999rri/scoop-bucket
-scoop install ghosttywin32
-```
-
-**v0.2.x (current latest release):** the bucket ships a portable ZIP. No
-elevation required.
-
-**v0.3.0 and later (in development):** the bucket will ship a signed MSIX.
-Installation imports the signing certificate into
-`LocalMachine\TrustedPeople` and registers the MSIX via `Add-AppxPackage`,
-so `scoop install` has to run from an elevated PowerShell. See
-[issue #46](https://github.com/i999rri/GhosttyWin32/issues/46) for the
-in-flight migration to SignPath Foundation, which will remove the
-elevation requirement.
-
-### Manual install
-
-**v0.2.x:** download `GhosttyWin32-v<version>-x64.zip` from
-[Releases](https://github.com/i999rri/GhosttyWin32/releases) and unzip
-anywhere.
-
-**v0.3.0 and later:**
+The MSIX is signed only with a self-signed publisher certificate
+(`CN=i999rri`) — an established CA / OSS Foundation signature isn't in
+place yet (see [issue #46](https://github.com/i999rri/GhosttyWin32/issues/46)),
+so Windows requires the certificate to be trusted before the MSIX will
+install. Manual install is the only supported path today; a Scoop channel
+existed for the pre-MSIX ZIP builds (v0.2.x) and will return once signing
+is available.
 
 1. Download `Ghostty-<version>-x64.msix` and `Ghostty.cer` from
    [Releases](https://github.com/i999rri/GhosttyWin32/releases).

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -1,10 +1,10 @@
 # Install Guide / インストール手順
 
-Step-by-step manual install for the signed MSIX. If you use Scoop, you don't need this — the Scoop manifest handles the certificate trust step automatically.
+Step-by-step manual install for the self-signed MSIX. Manual install is the only supported path while an established CA / OSS Foundation signature is unavailable — see [issue #46](https://github.com/i999rri/GhosttyWin32/issues/46).
 
 <details><summary>日本語</summary>
 
-署名付き MSIX を手動インストールする手順。Scoop でインストールする場合は不要 (Scoop manifest が証明書信頼の手順を自動で行う)。
+自己署名 MSIX を手動インストールする手順。正式な CA / OSS Foundation 署名が取得できるまでは手動インストールが唯一のサポート経路 (詳細は [issue #46](https://github.com/i999rri/GhosttyWin32/issues/46))。
 
 </details>
 
@@ -146,29 +146,13 @@ If you see a different error code, check existing [GitHub Issues](https://github
 
 ### Removing Ghostty / Ghostty を削除
 
-For MSIX manual install:
-
 - **Settings → Apps → Installed apps** → search "Ghostty" → **⋯** → **Uninstall**
-
-For Scoop install:
-
-```powershell
-scoop uninstall ghosttywin32
-```
 
 User data under `%LOCALAPPDATA%\ghostty\` is not removed automatically. Delete that directory manually if you want a clean state.
 
 <details><summary>日本語</summary>
 
-MSIX 手動インストールの場合:
-
 - 「**設定 → アプリ → インストール済みアプリ**」で「Ghostty」を検索 → 「**⋯**」 → 「**アンインストール**」
-
-Scoop でインストールした場合:
-
-```powershell
-scoop uninstall ghosttywin32
-```
 
 `%LOCALAPPDATA%\ghostty\` 配下のユーザーデータは自動削除されない。完全に消したい場合は手動で削除。
 


### PR DESCRIPTION
## Summary

Drop the Scoop distribution channel offer everywhere it appears (release notes template, README, INSTALL.md, RELEASING.md). Every surface now points at the same manual (cert-trust + MSIX) flow, with a note pinning the reason to [#46](https://github.com/i999rri/GhosttyWin32/issues/46) so the Scoop offer can come back once an established CA / OSS Foundation signature is in place.

<details><summary>日本語</summary>

Scoop チャネルの提示を全ての箇所 (release notes テンプレート、README、INSTALL.md、RELEASING.md) から降ろす。全ての面で共通の手動 (cert trust + MSIX) 手順を案内し、理由を [#46](https://github.com/i999rri/GhosttyWin32/issues/46) にリンクして、正式な CA / OSS Foundation 署名が入ったら Scoop 復帰させられるようにしておく。

</details>

## Why now

The `i999rri/scoop-bucket` manifest hasn't kept up:

- Points at `v0.2.2` (April 2026 — the last ZIP release before the MSIX transition)
- `url` / `bin` / `shortcuts` fields assume a portable ZIP with `GhosttyWin32.exe`; v0.3.0+ ships `Ghostty-<version>-x64.msix` + `Ghostty.cer`
- `autoupdate` URL pattern (`GhosttyWin32-v$version-x64.zip`) can't match any current release asset

So `scoop install ghosttywin32` today silently installs a stale ZIP build. Leaving the recommendation live is worse than not offering it.

<details><summary>日本語</summary>

`i999rri/scoop-bucket` の manifest が追随できていない:

- `v0.2.2` (2026-04 の MSIX 化前 ZIP リリース) 止まり
- `url` / `bin` / `shortcuts` は `GhosttyWin32.exe` の入った ZIP 前提。v0.3.0+ は `Ghostty-<version>-x64.msix` + `Ghostty.cer` を配布
- `autoupdate` の URL pattern (`GhosttyWin32-v$version-x64.zip`) が現行 release の asset に一致しない

そのため `scoop install ghosttywin32` は今、無音で古い ZIP をインストールする状態。案内を残しておく方が実害が大きい。

</details>

## Changes

- `.github/workflows/release.yml` — replace the `### Scoop (recommended)` + `### Manual install` block with a single unsigned-cert notice + the 3-step manual flow
- `README.md` — drop the `### Scoop (recommended)` section, collapse the `v0.2.x` / `v0.3.0 and later` split in `### Manual install` into one path (v0.2.x is no longer shipped)
- `docs/INSTALL.md` — remove the "If you use Scoop, you don't need this" intro line and the `scoop uninstall` uninstall variant
- `.github/RELEASING.md` — replace the "Scoop / 手動どちらでも" line with the current single-path reality, and swap the "scoop manifest autoupdate URL pattern" note for a parenthetical describing the pattern to install if Scoop returns

The `i999rri/scoop-bucket` repo will get a matching README (pointing users at manual install while the channel is paused) and then be archived. That happens in the bucket repo, not here.

## Verification

- [ ] Next tagged release's notes body renders the new Installation section (no Scoop, single path, link to #46)
- [ ] Rendering: `Preview` tab on README.md and docs/INSTALL.md shows no orphan headings / broken links
- [ ] `.github/RELEASING.md` reads consistently end-to-end (no dangling references to Scoop-only paths)

<details><summary>日本語</summary>

- [ ] 次にタグを切った release の notes 本文が新しい Installation セクションでレンダリングされる (Scoop なし、単一経路、#46 リンク)
- [ ] README.md と docs/INSTALL.md の Preview で見出し孤立や壊れリンクがない
- [ ] `.github/RELEASING.md` を通して読んで、Scoop 前提の記述が残っていない

</details>
