### PR TITLE
Anchor production release notes at the release-PR head, not the tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,11 @@ on:
 
 permissions:
   contents: write
+  # gh pr list (used by "Resolve release-PR head for changelog") reads
+  # the closed release/vX.Y.Z PR to locate the release-branch tip. Any
+  # explicit permissions: block sets unlisted scopes to none, so this
+  # needs to be spelled out.
+  pull-requests: read
 
 jobs:
   build:
@@ -149,10 +154,44 @@ jobs:
           echo "tag=$prev" >> "$GITHUB_OUTPUT"
           echo "Previous tag selected: ${prev:-<none>}"
 
+      # Locate the merged release PR (release/vX.Y.Z → main) for
+      # production tags so we can point the changelog generator at the
+      # release branch tip instead of the squashed merge commit main
+      # actually holds. Empty output for RC tags — those are on dev HEAD
+      # before any squash, so generate-notes off the tag itself already
+      # sees every dev-side PR merge.
+      - name: Resolve release-PR head for changelog
+        id: relpr
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          head_sha=""
+          if [[ "$REF_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            head_sha=$(gh pr list --state closed \
+              --search "head:release/${REF_NAME} base:main" \
+              --json headRefOid --jq '.[0].headRefOid // empty')
+          fi
+          echo "head_sha=$head_sha" >> "$GITHUB_OUTPUT"
+          echo "Release-PR head SHA: ${head_sha:-<none>}"
+
       # Generate the changelog body manually so we can pass
       # previous_tag_name explicitly. softprops/action-gh-release's
       # generate_release_notes: true would call the same API but with
       # GitHub's default baseline.
+      #
+      # Production tags need a workaround: the tag already exists by the
+      # time this workflow runs (we're triggered by its push), so the
+      # generate-notes API resolves tag_name → the squashed commit main
+      # actually holds and ignores target_commitish. That loses every
+      # dev-side PR that landed as an intermediate merge (the release/
+      # branch's history) because those commits aren't reachable from
+      # main's history. Pass a UNIQUE probe tag_name that doesn't exist,
+      # which forces the API to honour target_commitish=<release-PR head>,
+      # then rewrite the probe name in the returned body so the
+      # "Full Changelog" URL uses the real tag.
       - name: Generate release notes body
         id: notes
         shell: bash
@@ -160,19 +199,26 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REF_NAME: ${{ github.ref_name }}
           PREV_TAG: ${{ steps.prev.outputs.tag }}
+          RELPR_HEAD_SHA: ${{ steps.relpr.outputs.head_sha }}
         run: |
           set -euo pipefail
-          if [[ -n "$PREV_TAG" ]]; then
-            body=$(gh api "repos/${GITHUB_REPOSITORY}/releases/generate-notes" \
-              --method POST \
-              -f tag_name="$REF_NAME" \
-              -f previous_tag_name="$PREV_TAG" \
-              --jq '.body')
+          args=(--method POST)
+          if [[ -n "$RELPR_HEAD_SHA" ]]; then
+            probe_tag="${REF_NAME}-notes-probe"
+            args+=(-f "tag_name=$probe_tag" -f "target_commitish=$RELPR_HEAD_SHA")
           else
-            body=$(gh api "repos/${GITHUB_REPOSITORY}/releases/generate-notes" \
-              --method POST \
-              -f tag_name="$REF_NAME" \
-              --jq '.body')
+            probe_tag=""
+            args+=(-f "tag_name=$REF_NAME")
+          fi
+          if [[ -n "$PREV_TAG" ]]; then
+            args+=(-f "previous_tag_name=$PREV_TAG")
+          fi
+          body=$(gh api "repos/${GITHUB_REPOSITORY}/releases/generate-notes" \
+            "${args[@]}" --jq '.body')
+          # Undo the probe substitution so the Full Changelog URL points
+          # at the real tag.
+          if [[ -n "$probe_tag" ]]; then
+            body="${body//$probe_tag/$REF_NAME}"
           fi
           {
             echo "body<<RELEASE_NOTES_EOF"


### PR DESCRIPTION
## Summary

Production release notes were coming out truncated. The v0.4.0 tag saw only 17 PRs (all pre-WinUI-3), missing every dev-side PR that landed between v0.2.2 and v0.4.0 (#58 through #96). Anchor the changelog at the release-PR head instead of the squashed merge commit main actually holds.

<details><summary>日本語</summary>

production リリースの notes が正しく生成されていなかった。v0.4.0 タグに対して 17 PR しか出力されず、v0.2.2 以降 dev 側にマージされた PR (#58〜#96) が全部落ちていた。squashed merge commit ではなく release PR の head をアンカーに使うよう修正。

</details>

## Root cause

`release.yml` runs on tag push, so by the time the "Generate release notes body" step calls the GitHub `generate-notes` API, the tag already exists. The API resolves `tag_name` to the tag's target commit and **ignores `target_commitish`** when the tag exists — so the diff walked is `previous_tag_name..(squashed commit on main)`. The individual PR merges from dev only exist on the `release/vX.Y.Z` branch's history, which isn't reachable from main after `auto-tag-release-pr.yml` fires against the squash-merged PR.

That's why v0.4.0's auto-generated notes stopped at PR #39 — the last PR that ever hit main directly, before dev started collecting the WinUI 3 / multi-window work through the release-PR flow.

<details><summary>日本語</summary>

`release.yml` は tag push で走るので、"Generate release notes body" が GitHub の `generate-notes` API を呼ぶ時点でタグは既に存在している。API は tag_name を「そのタグの target commit」に解決し、タグが既存の場合は `target_commitish` を無視する — なので diff は `previous_tag_name..(main の squashed commit)` になる。dev 側の個別 PR マージは `release/vX.Y.Z` ブランチの履歴にしか無く、squash merge 後の main からは到達不能。

v0.4.0 の auto-generated notes が PR #39 で止まっていたのはこれが原因。#39 は dev が WinUI 3 / multi-window の作業を release-PR フローで積み始める前に、main に直接届いた最後の PR だった。

</details>

## Fix

Add a `Resolve release-PR head for changelog` step that looks up the closed `release/vX.Y.Z` PR (production tags only — RC tags sit on dev HEAD before any squash, so generate-notes off the tag works correctly for them). Then in `Generate release notes body`:

- If a release-PR head SHA is available, pass a unique probe `tag_name` (`${{ github.ref_name }}-notes-probe`) plus `target_commitish=<release-PR head SHA>`. The probe name doesn't exist as a tag, so the API honours `target_commitish` and walks the release-branch history — every intermediate PR merge shows up.
- The probe name leaks into the returned body's "Full Changelog" URL, so rewrite it back to the real ref name before emitting.
- If no release PR is found (edge case: a production tag created without going through the release-PR flow), fall through to the existing behaviour.

Also spell out `pull-requests: read` in the workflow's `permissions` block — explicit permissions blocks set unlisted scopes to `none`, so `gh pr list` needs it added.

<details><summary>日本語</summary>

`Resolve release-PR head for changelog` ステップを追加して、closed の `release/vX.Y.Z` PR を検索する (production tag 限定 — RC tag は squash 前の dev HEAD にあるので generate-notes がそのまま正しく動く)。その上で `Generate release notes body` を:

- release PR head SHA が取れたら、一意な probe `tag_name` (`${{ github.ref_name }}-notes-probe`) と `target_commitish=<release-PR head SHA>` を渡す。probe 名はタグとして存在しないので API は `target_commitish` を尊重し、release branch の履歴を辿る — 中間 PR マージが全部拾える
- probe 名は返される body の "Full Changelog" URL に混入するので、本物の ref 名に置換してから出力
- release PR が見つからない場合 (release-PR フローを通さず打った production tag などのエッジケース) は既存挙動にフォールバック

`pull-requests: read` を workflow の `permissions` ブロックに明記も追加 — 明示的 permissions は未列挙 scope が全部 `none` になる仕様なので、`gh pr list` 用に必要。

</details>

## Local verification

Simulated the workflow logic against v0.4.0's release PR (`release/v0.4.0`, head SHA `f437717`):

- Current release.yml logic: **17 PRs** in the generated body
- New logic: **57 PRs**, with `Full Changelog: v0.2.2...v0.4.0` intact

## What still needs manual repair

- v0.4.0's release page was already patched manually in this session — no repair needed
- Future production tags will pick this up automatically

## Verification

- [ ] Tag a `-rc` (e.g. `v0.4.1-rc1`) and confirm the RC path is untouched (no probe substitution, same body as before)
- [ ] Tag a production release (`v0.4.1` or `v0.5.0`) via the auto-tag flow and confirm the release body lists every dev-side PR merged since the previous production tag, with the correct `Full Changelog` URL
- [ ] `gh run view --log` shows no permission errors from `gh pr list` inside the "Resolve release-PR head for changelog" step
