### PR TITLE
Wire GOTO_WINDOW; ack SHOW_GTK_INSPECTOR (closes #100, #101)

### DIFF
--- a/App/App.xaml.cpp
+++ b/App/App.xaml.cpp
@@ -340,6 +340,48 @@ namespace winrt::GhosttyWin32::implementation
         return nullptr;
     }
 
+    void App::PresentWindow(ghostty_action_goto_window_e direction)
+    {
+        const size_t n = m_topLevelWindows.size();
+        // Nothing to navigate to when there's zero or one window.
+        // Explicit guard so the modulo / index math below stays
+        // well-defined even in the degenerate single-window case.
+        if (n < 2) return;
+
+        // Anchor at whichever window is currently the OS foreground.
+        // Not every top-level HWND has to be one of ours (there are
+        // legitimate cases like the taskbar preview scenario where the
+        // foreground briefly isn't a MainWindow), so fall through to
+        // window 0 when we can't find ourselves.
+        HWND fg = ::GetForegroundWindow();
+        size_t current = 0;
+        for (size_t i = 0; i < n; ++i) {
+            auto typed = m_topLevelWindows[i]
+                .try_as<winrt::GhosttyWin32::MainWindow>();
+            if (!typed) continue;
+            auto* impl = winrt::get_self<MainWindow>(typed);
+            if (impl && impl->Hwnd() == fg) {
+                current = i;
+                break;
+            }
+        }
+
+        // NEXT / PREVIOUS wrap around the window list; matches the
+        // upstream macOS shell behaviour.
+        size_t target = current;
+        switch (direction) {
+            case GHOSTTY_GOTO_WINDOW_NEXT:
+                target = (current + 1) % n;
+                break;
+            case GHOSTTY_GOTO_WINDOW_PREVIOUS:
+                target = (current + n - 1) % n;
+                break;
+        }
+        if (target == current) return;
+
+        m_topLevelWindows[target].Activate();
+    }
+
     void App::TrackWindow(Microsoft::UI::Xaml::Window const& w)
     {
         m_topLevelWindows.push_back(w);

--- a/App/App.xaml.h
+++ b/App/App.xaml.h
@@ -122,6 +122,11 @@ namespace winrt::GhosttyWin32::implementation
         MainWindow* FindWindowByTabItem(
             Microsoft::UI::Xaml::Controls::TabViewItem const& item) noexcept;
 
+        // GOTO_WINDOW: bring the previous / next top-level window
+        // forward relative to the currently-foreground one. No-op
+        // when only one window exists. UI thread only.
+        void PresentWindow(ghostty_action_goto_window_e direction);
+
         // The tab drag currently in flight, if any. Cross-window
         // drag-and-drop rides OLE, which only marshals primitive
         // DataPackage values — a TabViewItem stuffed into the

--- a/App/MainWindow.xaml.cpp
+++ b/App/MainWindow.xaml.cpp
@@ -69,6 +69,9 @@ namespace winrt::GhosttyWin32::implementation
                 .quit = []() {
                     if (App::g_app) App::g_app->Quit();
                 },
+                .gotoWindow = [](ghostty_action_goto_window_e d) {
+                    if (App::g_app) App::g_app->PresentWindow(d);
+                },
             });
 
         ExtendsContentIntoTitleBar(true);

--- a/Core/Ghostty/Actions/Actions.cpp
+++ b/Core/Ghostty/Actions/Actions.cpp
@@ -262,6 +262,16 @@ bool Actions::OnNewWindow() {
     return true;
 }
 
+bool Actions::OnGotoWindow(ghostty_action_goto_window_e direction) {
+    if (!m_hooks.gotoWindow) return false;
+    // Same UI-thread hop rationale as OnNewWindow — the hook calls
+    // Xaml Window::Activate under the hood.
+    m_view.Dispatch([this, direction]() {
+        m_hooks.gotoWindow(direction);
+    });
+    return true;
+}
+
 bool Actions::OnCloseTab(ghostty_surface_t surface) {
     if (!surface) return true;
     m_view.Dispatch([this, surface]() {

--- a/Core/Ghostty/Actions/Actions.h
+++ b/Core/Ghostty/Actions/Actions.h
@@ -42,6 +42,10 @@ public:
         std::function<void()> newWindow;
         std::function<void()> closeAllWindows;
         std::function<void()> quit;
+        // GOTO_WINDOW: bring another top-level window forward. App
+        // owns the window vector, so the traversal (previous / next
+        // relative to the currently-foreground window) lives there.
+        std::function<void(ghostty_action_goto_window_e)> gotoWindow;
     };
 
     Actions(host::IWindow& view, AppHooks hooks = {}) noexcept
@@ -90,6 +94,10 @@ public:
     bool OnNewWindow();
     bool OnCloseTab(ghostty_surface_t surface);
     bool OnGotoTab(int requested);
+    // GOTO_WINDOW: navigate to the previous / next top-level
+    // MainWindow. Bounces through the injected gotoWindow hook (App
+    // owns the window vector, so the traversal lives there).
+    bool OnGotoWindow(ghostty_action_goto_window_e direction);
     bool OnMoveTab(ghostty_action_move_tab_s move);
     // SET_TITLE and SET_TAB_TITLE collapse to the same handler —
     // this port has one title surface per tab.

--- a/Core/Ghostty/CallbackDispatcher.cpp
+++ b/Core/Ghostty/CallbackDispatcher.cpp
@@ -64,6 +64,8 @@ bool CallbackDispatcher::DispatchAction(ghostty_target_s target, ghostty_action_
             return false;
         case GHOSTTY_ACTION_GOTO_TAB:
             return m_actions.OnGotoTab(static_cast<int>(action.action.goto_tab));
+        case GHOSTTY_ACTION_GOTO_WINDOW:
+            return m_actions.OnGotoWindow(action.action.goto_window);
         case GHOSTTY_ACTION_MOVE_TAB:
             return m_actions.OnMoveTab(action.action.move_tab);
         // SET_TITLE / SET_TAB_TITLE: this port treats them

--- a/Core/Ghostty/CallbackDispatcher.cpp
+++ b/Core/Ghostty/CallbackDispatcher.cpp
@@ -164,6 +164,9 @@ bool CallbackDispatcher::DispatchAction(ghostty_target_s target, ghostty_action_
         case GHOSTTY_ACTION_SEARCH_SELECTED:
         case GHOSTTY_ACTION_INSPECTOR:
         case GHOSTTY_ACTION_RENDER_INSPECTOR:
+        // GTK-only, will never fire on Windows. Acked so it doesn't
+        // fall through to the default "unhandled action" return.
+        case GHOSTTY_ACTION_SHOW_GTK_INSPECTOR:
         case GHOSTTY_ACTION_TOGGLE_TAB_OVERVIEW:
         case GHOSTTY_ACTION_TOGGLE_QUICK_TERMINAL:
         case GHOSTTY_ACTION_TOGGLE_COMMAND_PALETTE:


### PR DESCRIPTION
## Summary

Close two coverage gaps left over from the v0.4.0 audit ([#57](https://github.com/i999rri/GhosttyWin32/issues/57)):

1. **`GHOSTTY_ACTION_GOTO_WINDOW`** — was falling through the dispatcher default. Wire it so a `goto_window:previous` / `goto_window:next` keybind brings the previous or next top-level `MainWindow` forward, wrapping at the ends the way the upstream macOS shell does. Closes [#100](https://github.com/i999rri/GhosttyWin32/issues/100).
2. **`GHOSTTY_ACTION_SHOW_GTK_INSPECTOR`** — GTK-only, will never fire on Windows. Add it to the acked-no-op group next to `INSPECTOR` / `RENDER_INSPECTOR` so libghostty stops logging every dispatch as "unhandled". Closes [#101](https://github.com/i999rri/GhosttyWin32/issues/101).

<details><summary>日本語</summary>

v0.4.0 のカバレッジ調査 ([#57](https://github.com/i999rri/GhosttyWin32/issues/57)) で残っていた 2 つの穴を塞ぐ:

1. **`GHOSTTY_ACTION_GOTO_WINDOW`** — dispatcher の default に落ちていた。`goto_window:previous` / `goto_window:next` のキーバインドで前 / 次のトップレベル `MainWindow` を前面に、両端はラップ (upstream macOS shell と同じ挙動)。Closes [#100](https://github.com/i999rri/GhosttyWin32/issues/100)。
2. **`GHOSTTY_ACTION_SHOW_GTK_INSPECTOR`** — GTK 専用で Windows では発火し得ない。`INSPECTOR` / `RENDER_INSPECTOR` の隣で acked no-op に足して、libghostty が毎ディスパッチを "unhandled" と log するのを止める。Closes [#101](https://github.com/i999rri/GhosttyWin32/issues/101)。

</details>

## Design notes

### GOTO_WINDOW

- Traversal lives on `App` — it already owns `m_topLevelWindows`; wrapping the navigation on the per-window `Actions` instance would need it to reach across scopes. `Actions::AppHooks` gets a new `gotoWindow` slot in the same shape as `newWindow` / `closeAllWindows` / `quit`.
- `App::PresentWindow(direction)` anchors at whichever window is currently the OS foreground (`GetForegroundWindow()`), the same source of truth `MainWindow::IsForeground()` already uses. No "last active" cursor is maintained — `GetForegroundWindow` is always accurate and needs no lifecycle bookkeeping to stay correct across window creates / closes.
- If the foreground isn't one of our windows (a transient taskbar / preview case), navigation falls through to window 0 rather than being dropped.
- No-op when only one window exists.
- UI-thread hop uses the existing `m_view.Dispatch` in `Actions::OnGotoWindow`, same pattern as `OnNewWindow`.

<details><summary>日本語</summary>

- 走査は `App` 側に置く — 既に `m_topLevelWindows` を所有しているため。ウインドウごとの `Actions` インスタンスからスコープを越えるより、`AppHooks` に `gotoWindow` スロットを新設して既存の `newWindow` / `closeAllWindows` / `quit` と同じ形にする。
- `App::PresentWindow(direction)` は現在 OS フォアグラウンドのウインドウを基準にする (`GetForegroundWindow()`、`MainWindow::IsForeground()` と同じ真理値ソース)。「最後にアクティブだったウインドウ」的な独自カーソルは持たない — `GetForegroundWindow` はライフサイクル管理なしでも常に正確。
- フォアグラウンドがうちのウインドウじゃない (タスクバー / preview 経由の一時状態など) 場合は window 0 にフォールバック。ナビゲーション自体は落とさない。
- ウインドウが 1 つのときは no-op。
- UI スレッドホップは `Actions::OnGotoWindow` の `m_view.Dispatch` で吸収 (`OnNewWindow` と同じパターン)。

</details>

### SHOW_GTK_INSPECTOR

One-line addition to the fall-through group in `CallbackDispatcher::DispatchAction`, with a short comment recording why (Linux-only, no host-side work possible).

## Verification

- [x] `keybind = ctrl+shift+bracket_right=goto_window:next` (or similar) cycles between two open windows, wraps at the last one
- [x] `keybind = ...=goto_window:previous` cycles the other way
- [x] Single-window session: keybind fires but nothing happens (no crash, no console warning)
- [ ] "unhandled action" log line no longer appears for `SHOW_GTK_INSPECTOR` (verify via Debug Output while the app runs)

<details><summary>日本語</summary>

- [x] `keybind = ctrl+shift+bracket_right=goto_window:next` (等) で 2 ウインドウを循環、最後のウインドウで先頭にラップ
- [x] `goto_window:previous` で逆方向に循環
- [x] シングルウインドウ時: キーバインドは発火するが何も起きない (クラッシュなし、ログノイズなし)
- [ ] `SHOW_GTK_INSPECTOR` の "unhandled action" ログが出なくなる (Debug Output で確認)

</details>

