### PR TITLE
Push release tags with a GitHub App installation token so release.yml fires

### DIFF
--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -173,6 +173,31 @@ Write-Host "PFX base64 をクリップボードにコピーしました"
 |---|---|
 | `SIGNING_PFX_BASE64` | クリップボードに入った Base64 文字列 |
 | `SIGNING_PFX_PASSWORD` | 手順 2 で入力したパスワード |
+| `RELEASE_APP_ID` | 手順 4a の GitHub App の App ID |
+| `RELEASE_APP_PRIVATE_KEY` | 手順 4a でダウンロードした `.pem` の中身全部 |
+
+#### 4a. Release tag push 用 GitHub App
+
+`auto-tag-release-pr.yml` は release PR merge 後に `main` にタグを打つ。この push
+を **default の `GITHUB_TOKEN` で行うと `release.yml` (`on: push: tags`) が発火しない**
+(GitHub の loop-prevention 仕様: `GITHUB_TOKEN` 起因のイベントは他 workflow を trigger
+しない)。回避策として GitHub App の installation token で push する。
+
+作成手順:
+
+1. Personal settings → Developer settings → **GitHub Apps** → New GitHub App
+2. Name: 任意 (例 `ghosttywin32-release-bot`)、Homepage URL: 任意
+3. **Webhook**: **Active チェック外し** (通知不要)
+4. **Repository permissions** → **Contents: Read and write** (これだけ)
+5. **Where can this app be installed**: **Only on this account**
+6. 作成 → General ページ下部の **Generate a private key** で `.pem` ダウンロード
+7. 上部の **Install App** タブ → 自分のアカウントに install → GhosttyWin32 のみ選択
+8. General ページ上部の **App ID** (6-7 桁数値) を `RELEASE_APP_ID` に登録
+9. `.pem` の中身をそのまま `RELEASE_APP_PRIVATE_KEY` に登録 (BEGIN/END 行含めて全部)
+
+`auto-tag-release-pr.yml` の `actions/create-github-app-token@v1` ステップが起動時に
+installation token を発行して checkout + push に食わせる。tag object は
+`<app-slug>[bot]` として annotate される。
 
 ### 5. Environments を作成
 

--- a/.github/workflows/auto-tag-release-pr.yml
+++ b/.github/workflows/auto-tag-release-pr.yml
@@ -9,14 +9,25 @@ name: Auto-tag release PR
 # rather than PR title — branch refs are immutable once created, while
 # titles can be edited after the fact and would silently break the
 # auto-tag path.
+#
+# The tag has to be pushed with a GitHub App installation token, NOT
+# the default GITHUB_TOKEN: GitHub deliberately does NOT fire further
+# workflows on events authored by GITHUB_TOKEN (loop-prevention), so a
+# tag pushed with it would never trigger release.yml. See
+# RELEASE_APP_ID / RELEASE_APP_PRIVATE_KEY in the repo secrets and
+# .github/RELEASING.md for the setup.
 
 on:
   pull_request:
     types: [closed]
     branches: [main]
 
-permissions:
-  contents: write
+# The tag push is authorised by the App token below (not GITHUB_TOKEN),
+# so no scopes on GITHUB_TOKEN are required. Explicit `permissions: {}`
+# reduces its blast radius to nothing — if a later step ever tries to
+# use GITHUB_TOKEN it will fail loudly instead of silently succeeding
+# with more privilege than the App token grants.
+permissions: {}
 
 jobs:
   tag:
@@ -26,10 +37,27 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      # Mint an installation token from the release-bot GitHub App.
+      # Its `contents: write` permission covers the tag push, and
+      # because the token is NOT GITHUB_TOKEN the subsequent push
+      # event WILL trigger release.yml (which is the whole point of
+      # this workflow).
+      - name: Generate App token for tag push
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@v4
         with:
           ref: main
           fetch-depth: 0
+          # Persist the App token as the remote's HTTPS credential so
+          # `git push` below authenticates as the App, not the workflow
+          # default. actions/checkout wires this into the local repo's
+          # git config for the duration of the job.
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Extract and validate version
         id: ver
@@ -61,10 +89,13 @@ jobs:
       - name: Tag main HEAD and push
         env:
           VERSION: ${{ steps.ver.outputs.version }}
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
         run: |
           set -euo pipefail
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          # Attribute the annotated tag object to the App's bot user
+          # so the audit trail matches the push authorisation.
+          git config user.name  "${APP_SLUG}[bot]"
+          git config user.email "${APP_SLUG}[bot]@users.noreply.github.com"
           git tag -a "$VERSION" -m "Release $VERSION"
           git push origin "$VERSION"
-          echo "Pushed tag $VERSION → release.yml will fire."
+          echo "Pushed tag $VERSION as ${APP_SLUG}[bot] → release.yml will fire."


### PR DESCRIPTION
## Summary

Fix the auto-tag → release pipeline so `release.yml` actually fires on production tag push. Today the tag is pushed as `github-actions[bot]` using the default `GITHUB_TOKEN`, which GitHub deliberately does not fire further workflows on (loop-prevention). v0.4.0 hit this and had to be re-tagged manually from a local shell to reach the release build.

<details><summary>日本語</summary>

auto-tag → release パイプラインを修正し、production tag push で `release.yml` がきちんと発火するようにする。現状は tag push が default の `GITHUB_TOKEN` (github-actions[bot]) で行われ、GitHub のループ防止仕様でその push イベントは他 workflow を trigger しない。v0.4.0 リリース時にこれに引っかかり、手動でローカルシェルから tag を打ち直す羽目になった。

</details>

## Change

Switch the tag push to an installation token minted from a dedicated **release-bot GitHub App**. Because the token isn't `GITHUB_TOKEN`, its push does trigger `release.yml`.

- New step `actions/create-github-app-token@v1` — reads `RELEASE_APP_ID` + `RELEASE_APP_PRIVATE_KEY` secrets and outputs an installation token
- `actions/checkout@v4` now passes that token, so the local repo's remote is wired to authenticate as the App
- The annotated tag object is attributed to `<app-slug>[bot]` — the audit trail matches the push authorisation
- Workflow's `permissions:` block is emptied — the App token covers everything this workflow needs; any future step reaching for `GITHUB_TOKEN` should fail loudly rather than silently succeed with more scope than intended

<details><summary>日本語</summary>

release-bot 用 GitHub App の installation token で tag を push する構成に切替。`GITHUB_TOKEN` ではないので、その push は `release.yml` を trigger する。

- 新規 step `actions/create-github-app-token@v1` が `RELEASE_APP_ID` + `RELEASE_APP_PRIVATE_KEY` を読んで installation token を発行
- `actions/checkout@v4` にその token を渡す → ローカルリポジトリの remote が App 認証で動く
- annotated tag は `<app-slug>[bot]` として tag → push 権限と監査ログが一致
- workflow の `permissions:` を空に → 今後うっかり `GITHUB_TOKEN` を触る step が入っても意図と違う権限で無音成功しないよう防護

</details>

## Setup (already done for i999rri/GhosttyWin32)

The GitHub App is `only-on-this-account`, has `Contents: Read and write` and nothing else, and is installed on this repo only. `RELEASING.md` records the full setup path so future operators can reconstitute the pipeline from scratch.

Required secrets on the repo:
- `RELEASE_APP_ID` — the App's 6-7 digit numeric ID (visible on the App's General page)
- `RELEASE_APP_PRIVATE_KEY` — full contents of the App's `.pem` private key, BEGIN / END lines included

<details><summary>日本語</summary>

App は Only-on-this-account、権限は `Contents: Read and write` のみ、install 先は本リポジトリのみ。`RELEASING.md` にゼロから再構築するための完全手順を残した。

repo の secret:
- `RELEASE_APP_ID` — App General ページの App ID (6-7 桁数値)
- `RELEASE_APP_PRIVATE_KEY` — App の `.pem` 秘密鍵の中身全部 (BEGIN / END 行含む)

</details>

## Verification

- [ ] Merging a `release/v*` PR triggers `auto-tag-release-pr.yml`
- [ ] `auto-tag-release-pr.yml` logs show `Pushed tag vX.Y.Z as <app-slug>[bot] → release.yml will fire.`
- [ ] `release.yml` starts automatically on that tag push (no manual re-push required)
- [ ] The published tag on GitHub shows the App bot as the tagger
