### PR TITLE
Split Debug and Release into distinct MSIX identities

### DIFF
--- a/Package/Package.Debug.appxmanifest
+++ b/Package/Package.Debug.appxmanifest
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+  Debug-configuration manifest. Selected by Package.wapproj when
+  building the Debug|* configurations; Release builds (including
+  every CI channel — dev-build / RC / production) use the sibling
+  Package.appxmanifest instead.
+
+  The only substantive differences from the Release manifest are:
+
+  - Identity/@Name: appended ".Dev" so Windows treats an F5-registered
+    debug loose install as a completely different app from the
+    installed production MSIX. Without this split, installing the
+    production MSIX after an F5 (or vice versa) trips 0x80073cfb
+    ("current user already installed a packaged / unpackaged version
+    of this app") and requires manual uninstall each round.
+  - DisplayName / VisualElements/@DisplayName: suffixed "(Dev)" so
+    the debug entry is visually distinguishable in Start Menu, task
+    switcher, and taskbar — you know at a glance which build you're
+    driving.
+  - ToastActivator CLSID: distinct GUID so the AppNotifications COM
+    registration doesn't fight the production install's own class
+    when both are present.
+
+  Everything else stays identical to Package.appxmanifest; any change
+  to permissions / extensions / capabilities has to be mirrored here.
+  A pre-build target in Package.wapproj could regenerate this from the
+  release manifest to remove the manual sync, but it's expensive
+  tooling for a two-file split — accept the mirror cost.
+-->
+<Package
+  xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
+  xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest"
+  xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
+  xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
+  xmlns:systemai="http://schemas.microsoft.com/appx/manifest/systemai/windows10"
+  xmlns:com="http://schemas.microsoft.com/appx/manifest/com/windows10"
+  xmlns:desktop="http://schemas.microsoft.com/appx/manifest/desktop/windows10"
+  IgnorableNamespaces="uap rescap systemai com desktop">
+
+  <Identity
+    Name="d10a94a6-8f98-4723-b26d-a8b117eac06c.Dev"
+    Publisher="CN=i999rri"
+    Version="1.0.0.0" />
+
+  <mp:PhoneIdentity PhoneProductId="d10a94a6-8f98-4723-b26d-a8b117eac06c" PhonePublisherId="00000000-0000-0000-0000-000000000000"/>
+
+  <Properties>
+    <DisplayName>Ghostty (Dev)</DisplayName>
+    <PublisherDisplayName>i999rri</PublisherDisplayName>
+    <Logo>Images\StoreLogo.png</Logo>
+  </Properties>
+
+  <Dependencies>
+    <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.17763.0" MaxVersionTested="10.0.26226.0" />
+    <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.17763.0" MaxVersionTested="10.0.26226.0" />
+  </Dependencies>
+
+  <Resources>
+    <Resource Language="x-generate"/>
+  </Resources>
+
+  <Applications>
+    <Application Id="App"
+      Executable="$targetnametoken$.exe"
+      EntryPoint="$targetentrypoint$">
+      <uap:VisualElements
+        DisplayName="Ghostty (Dev)"
+        Description="Ghostty (Dev)"
+        BackgroundColor="transparent"
+        Square150x150Logo="Images\Square150x150Logo.png"
+        Square44x44Logo="Images\Square44x44Logo.png">
+        <uap:DefaultTile Wide310x150Logo="Images\Wide310x150Logo.png" />
+        <uap:SplashScreen Image="Images\SplashScreen.png" />
+      </uap:VisualElements>
+      <Extensions>
+        <!-- COM activator class registration. Distinct CLSID from
+             Package.appxmanifest so a debug and a production install
+             don't fight over the same registration if both are
+             present on the same machine. See the comment on the
+             release manifest for what this actually unlocks. -->
+        <com:Extension Category="windows.comServer">
+          <com:ComServer>
+            <com:ExeServer Executable="GhosttyWin32.exe" Arguments="----AppNotificationActivated:" DisplayName="Ghostty Toast Activator (Dev)">
+              <com:Class Id="60457F0F-1240-411A-B45D-957479F5AADD" DisplayName="Ghostty Toast Activator (Dev)" />
+            </com:ExeServer>
+          </com:ComServer>
+        </com:Extension>
+        <desktop:Extension Category="windows.toastNotificationActivation">
+          <desktop:ToastNotificationActivation ToastActivatorCLSID="60457F0F-1240-411A-B45D-957479F5AADD" />
+        </desktop:Extension>
+      </Extensions>
+    </Application>
+  </Applications>
+
+  <Capabilities>
+    <rescap:Capability Name="runFullTrust" />
+    <systemai:Capability Name="systemAIModels"/>
+  </Capabilities>
+</Package>

--- a/Package/Package.wapproj
+++ b/Package/Package.wapproj
@@ -45,10 +45,34 @@
     <AppxPackageSigningEnabled>false</AppxPackageSigningEnabled>
     <EntryPointProjectUniqueName>..\App\App.vcxproj</EntryPointProjectUniqueName>
   </PropertyGroup>
-  <ItemGroup>
+  <!--
+    Manifest per configuration.
+
+    Debug|* → Package.Debug.appxmanifest (Identity Name ends in ".Dev",
+      distinct DisplayName + toast CLSID). Lets an F5-registered debug
+      loose install coexist with an installed production MSIX on the
+      same machine instead of tripping 0x80073cfb every round.
+
+    Release|* → Package.appxmanifest (the production identity CI signs
+      and ships). Every CI channel — dev-build / RC / production —
+      builds Release, so this is what ends up in every MSIX we publish.
+
+    See the comment at the top of Package.Debug.appxmanifest for the
+    fuller rationale and the two-file maintenance cost.
+  -->
+  <ItemGroup Condition="'$(Configuration)'!='Debug'">
     <AppxManifest Include="Package.appxmanifest">
       <SubType>Designer</SubType>
     </AppxManifest>
+  </ItemGroup>
+  <ItemGroup Condition="'$(Configuration)'=='Debug'">
+    <AppxManifest Include="Package.Debug.appxmanifest">
+      <SubType>Designer</SubType>
+    </AppxManifest>
+    <None Include="Package.appxmanifest" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(Configuration)'!='Debug'">
+    <None Include="Package.Debug.appxmanifest" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="Images\SplashScreen.scale-200.png" />


### PR DESCRIPTION
## Summary

Give Debug builds their own MSIX identity so an F5-registered debug loose install stops fighting the installed production MSIX. Currently they share `Identity Name`, and Windows only allows one variant (packaged OR unpackaged) of a given identity per user — so every switch between "debug what I just built" and "run the release I have installed" needs a manual `Remove-AppxPackage` round trip and hits `0x80073cfb` if you forget.

<details><summary>日本語</summary>

Debug ビルドに独立した MSIX Identity を与えて、F5 で登録される loose install と、インストール済みの production MSIX が衝突しないようにする。現状は Identity Name が同一で、Windows は同 Identity について packaged / unpackaged のどちらか片方しか受け付けない仕様なので、「今ビルドしたやつをデバッグ」と「入れてある正式版を触る」を切替えるたびに `Remove-AppxPackage` の手作業が必要で、忘れると `0x80073cfb`。

</details>

## What changed

- **`Package/Package.Debug.appxmanifest`** (new) — a near-copy of `Package/Package.appxmanifest` with:
  - `Identity/@Name` suffixed `.Dev` (`d10a94a6-...-a8b117eac06c.Dev`) so Windows treats it as a distinct app entirely.
  - `Properties/DisplayName` and `VisualElements/@DisplayName` suffixed `(Dev)` so the Start Menu / task switcher / taskbar entry is unambiguous — you know at a glance which build you're driving.
  - Toast activator CLSID differs by one nibble (`...F5AAFD` → `...F5AADD`) so the two AppNotifications COM class registrations don't collide when both installs coexist.
  - Everything else identical to the release manifest.
- **`Package/Package.wapproj`** — configuration-conditional `<ItemGroup>` selects `Package.Debug.appxmanifest` for `Debug|*` and `Package.appxmanifest` for everything else. The non-selected manifest is included as `<None>` so both files show up in Solution Explorer.

<details><summary>日本語</summary>

- **`Package/Package.Debug.appxmanifest`** (新規) — `Package.appxmanifest` の派生版:
  - `Identity/@Name` を `.Dev` サフィックス (`d10a94a6-...-a8b117eac06c.Dev`) — Windows が別アプリと認識する
  - `Properties/DisplayName` と `VisualElements/@DisplayName` を `(Dev)` サフィックス — Start Menu / task switcher / taskbar でどっちを触っているか一目
  - Toast activator の CLSID を 1 nibble 変える (`...F5AAFD` → `...F5AADD`) — 両方 install されていても AppNotifications COM 登録が衝突しない
  - 上記以外は release manifest と完全同一
- **`Package/Package.wapproj`** — 構成条件付き `<ItemGroup>` で、`Debug|*` は `Package.Debug.appxmanifest`、それ以外は `Package.appxmanifest`。選ばれなかった方は `<None>` で入れて Solution Explorer に両方見える。

</details>

## Why only Release ships to CI

Every CI channel — `dev-build.yml`, `release.yml` (RC + production) — builds `Release|x64`. The release manifest is what they patch (version bump) and sign. Debug never leaves a developer's machine, so its identity is a pure local-development concern.

<details><summary>日本語</summary>

CI (`dev-build.yml`, `release.yml` の RC / production 両方) はすべて `Release|x64` でビルドする。Version bump と署名の対象は release manifest 側。Debug は開発者のマシンから出ないので、その Identity は純粋にローカル開発の関心事。

</details>

## Maintenance cost

Any change to capabilities / extensions / dependencies has to be mirrored across both files. Manifests rarely change (last touch was months ago at the toast-COM setup), so a two-file mirror is cheaper than a build-time regeneration target. The PR body of the debug manifest documents this so future readers know why the split exists.

<details><summary>日本語</summary>

capabilities / extensions / dependencies の変更は両方の manifest に同じ内容を反映する必要がある。manifest は滅多に触らない (直近は toast COM 追加時、数ヶ月前) ので、ビルド時再生成の仕組みを組むより 2 ファイル手動同期の方が安い。debug manifest 冒頭のコメントに理由を残した。

</details>

## Verification

- [ ] `Debug|x64` F5 in VS: Start Menu shows `Ghostty (Dev)` alongside the installed `Ghostty` (both visible)
- [ ] Installed v0.4.0 (production `Ghostty`) still opens without touching the debug entry, and vice versa
- [ ] `Get-AppxPackage | Where-Object { $_.Publisher -like "*i999rri*" }` shows both `d10a94a6-...` and `d10a94a6-....Dev` as separate `Name`s
- [ ] Toast notification fired from the debug build appears with `(Dev)` in the source name / doesn't route to the production process
- [ ] `Release|x64` build produces MSIX with the production identity (no `.Dev` suffix)

<details><summary>日本語</summary>

- [ ] `Debug|x64` を F5: Start Menu にインストール済みの `Ghostty` と並んで `Ghostty (Dev)` が両方見える
- [ ] インストール済みの v0.4.0 (production `Ghostty`) を触っても debug エントリに影響なし、その逆も同様
- [ ] `Get-AppxPackage | Where-Object { $_.Publisher -like "*i999rri*" }` で `d10a94a6-...` と `d10a94a6-....Dev` が別 `Name` として並ぶ
- [ ] Debug ビルドから出したトースト通知が `(Dev)` 表示で来る、または production プロセスにルーティングされない
- [ ] `Release|x64` ビルドは production identity (`.Dev` サフィックスなし) の MSIX を生成する

</details>
