### PR TITLE
Wire GHOSTTY_ACTION_FLOAT_WINDOW as always-on-top toggle (closes #104)

### DIFF
--- a/App/MainWindow.xaml.cpp
+++ b/App/MainWindow.xaml.cpp
@@ -1202,6 +1202,29 @@ namespace winrt::GhosttyWin32::implementation
         ApplyWindowDecorationsAppearance();
     }
 
+    void MainWindow::SetFloatOnTop(ghostty_action_float_window_e mode)
+    {
+        if (!m_hwnd) return;
+        // ON / OFF are absolute; TOGGLE flips the current Z-order
+        // state. GWL_EXSTYLE's WS_EX_TOPMOST is the source of truth —
+        // reading it means we don't need a bool member that has to
+        // stay in sync with the actual window state (something else
+        // like an external always-on-top utility could have moved
+        // the window in either direction).
+        bool desired;
+        switch (mode) {
+            case GHOSTTY_FLOAT_WINDOW_ON:  desired = true;  break;
+            case GHOSTTY_FLOAT_WINDOW_OFF: desired = false; break;
+            case GHOSTTY_FLOAT_WINDOW_TOGGLE:
+            default:
+                desired = (GetWindowLongPtrW(m_hwnd, GWL_EXSTYLE) & WS_EX_TOPMOST) == 0;
+                break;
+        }
+        HWND after = desired ? HWND_TOPMOST : HWND_NOTOPMOST;
+        SetWindowPos(m_hwnd, after, 0, 0, 0, 0,
+                     SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE);
+    }
+
     void MainWindow::ApplyWindowDecorationsAppearance()
     {
         // Collapse AppTitleBar as a single unit — it wraps the entire

--- a/App/MainWindow.xaml.h
+++ b/App/MainWindow.xaml.h
@@ -111,6 +111,7 @@ namespace winrt::GhosttyWin32::implementation
         void ApplySizeLimit(ghostty_action_size_limit_s limit) override;
         void ToggleFullscreen() override;
         void ToggleWindowDecorations() override;
+        void SetFloatOnTop(ghostty_action_float_window_e mode) override;
         // Apply the current decoration state (config + any override
         // installed by ToggleWindowDecorations) to the XAML caption
         // buttons / drag region. Called once at startup so the config

--- a/Core/Ghostty/Actions/Actions.cpp
+++ b/Core/Ghostty/Actions/Actions.cpp
@@ -172,6 +172,16 @@ bool Actions::OnPresentTerminal() {
     return true;
 }
 
+bool Actions::OnFloatWindow(ghostty_action_float_window_e mode) {
+    // Route through the view: the view owns the HWND and remembers
+    // the current topmost state so TOGGLE can flip without the
+    // dispatcher tracking it.
+    m_view.Dispatch([this, mode]() {
+        m_view.SetFloatOnTop(mode);
+    });
+    return true;
+}
+
 bool Actions::OnShowOnScreenKeyboard() {
     // Touch / pen users without a physical keyboard. The OSK is
     // its own top-level window; we just launch it and let the user

--- a/Core/Ghostty/Actions/Actions.h
+++ b/Core/Ghostty/Actions/Actions.h
@@ -76,6 +76,11 @@ public:
     bool OnPresentTerminal();
     bool OnShowOnScreenKeyboard();
     bool OnOpenConfig();
+    // FLOAT_WINDOW: toggle always-on-top for this window. macOS's
+    // NSWindowLevelFloating maps to Win32 HWND_TOPMOST via
+    // SetWindowPos; the actual call lives on the view (state tracking
+    // + HWND access), this handler just bounces there.
+    bool OnFloatWindow(ghostty_action_float_window_e mode);
 
     // ----- sizing -----
     bool OnInitialSize(ghostty_action_initial_size_s size);

--- a/Core/Ghostty/CallbackDispatcher.cpp
+++ b/Core/Ghostty/CallbackDispatcher.cpp
@@ -110,6 +110,8 @@ bool CallbackDispatcher::DispatchAction(ghostty_target_s target, ghostty_action_
             return m_actions.OnToggleFullscreen();
         case GHOSTTY_ACTION_TOGGLE_WINDOW_DECORATIONS:
             return m_actions.OnToggleWindowDecorations();
+        case GHOSTTY_ACTION_FLOAT_WINDOW:
+            return m_actions.OnFloatWindow(action.action.float_window);
 
         // ----- split-pane (surface-targeted) -----
         case GHOSTTY_ACTION_NEW_SPLIT:
@@ -179,11 +181,6 @@ bool CallbackDispatcher::DispatchAction(ghostty_target_s target, ghostty_action_
         // interaction with the DComp surface crashed the process
         // on URL click); the URL click path itself still works.
         case GHOSTTY_ACTION_MOUSE_OVER_LINK:
-        // FLOAT_WINDOW: no keybind reaches us yet; ghostty's
-        // dispatch path for it isn't understood on this port.
-        // Acking avoids "unhandled action" noise once that's
-        // fixed and the keybind starts firing.
-        case GHOSTTY_ACTION_FLOAT_WINDOW:
         // TOGGLE_BACKGROUND_OPACITY: dispatched but not yet
         // implemented — tracked in #69. (The layered-alpha approach
         // sketched in the issue body doesn't work over a flip-model

--- a/Core/Host/IWindow.h
+++ b/Core/Host/IWindow.h
@@ -147,6 +147,14 @@ struct IWindow {
     // window; we don't track it and the user dismisses it normally.
     virtual void ShowOnScreenKeyboard() = 0;
 
+    // FLOAT_WINDOW / toggle_window_float_on_top on macOS maps to
+    // NSWindowLevelFloating; on Windows the equivalent is the
+    // topmost Z-order via SetWindowPos(HWND_TOPMOST / HWND_NOTOPMOST).
+    // Payload is ON/OFF/TOGGLE; the view owns the current-state
+    // tracking so TOGGLE can flip without the dispatcher having to
+    // remember anything.
+    virtual void SetFloatOnTop(ghostty_action_float_window_e mode) = 0;
+
     // ----- terminal-driven appearance + lifecycle -----
 
     // Apply a new background colour (caption bar + XAML root) in

--- a/Tests/MockMainWindowView.h
+++ b/Tests/MockMainWindowView.h
@@ -129,6 +129,13 @@ struct MockMainWindowView : core::host::IWindow {
     int toggleWindowDecorationsCalls = 0;
     void ToggleWindowDecorations() override { ++toggleWindowDecorationsCalls; }
 
+    int setFloatOnTopCalls = 0;
+    ghostty_action_float_window_e lastFloatOnTopMode{};
+    void SetFloatOnTop(ghostty_action_float_window_e mode) override {
+        ++setFloatOnTopCalls;
+        lastFloatOnTopMode = mode;
+    }
+
     int presentTerminalCalls = 0;
     void PresentTerminal() override { ++presentTerminalCalls; }
 


### PR DESCRIPTION
## Summary

Wire `GHOSTTY_ACTION_FLOAT_WINDOW` as an always-on-top toggle. The action was previously acked as a no-op with a comment noting the dispatch route wasn't understood — but the payload and semantics are unambiguous: it's the `toggle_window_float_on_top` keybind, targeting a surface, with an ON / OFF / TOGGLE mode. macOS ghostty maps it to `NSWindowLevelFloating`; the Windows equivalent is `WS_EX_TOPMOST` via `SetWindowPos(HWND_TOPMOST / HWND_NOTOPMOST)`.

<details><summary>日本語</summary>

`GHOSTTY_ACTION_FLOAT_WINDOW` を always-on-top トグルとして配線する。以前は no-op ack で「ディスパッチ経路が不明」とコメントを残していたが、実際は `toggle_window_float_on_top` キーバインドから surface target で ON / OFF / TOGGLE を渡してくる明確な action。macOS ghostty は `NSWindowLevelFloating` にマップしていて、Windows での等価は `SetWindowPos` 経由の `WS_EX_TOPMOST`。

</details>

## Design notes

- New `IWindow::SetFloatOnTop(mode)` — window-scope, the view owns the HWND and reads the current Z-order.
- `Actions::OnFloatWindow` just bounces through `m_view.Dispatch` (same shape as `OnToggleFullscreen`).
- For TOGGLE, read `WS_EX_TOPMOST` via `GetWindowLongPtrW(GWL_EXSTYLE)` rather than tracking the state in a member — the ex-style bit is the source of truth and stays correct even when an external process / layout tool moved the window's Z-order.
- `SWP_NOACTIVATE` on the `SetWindowPos` call so the toggle doesn't steal focus (common for global-hotkey bindings the user might trigger from another app).

<details><summary>日本語</summary>

- `IWindow::SetFloatOnTop(mode)` を新設 (window スコープ、view が HWND と現在の Z-order を所有)
- `Actions::OnFloatWindow` は `m_view.Dispatch` で view に投げるだけ (`OnToggleFullscreen` と同じ形)
- TOGGLE は独自に状態メンバを持たず、`GetWindowLongPtrW(GWL_EXSTYLE)` から `WS_EX_TOPMOST` を読む — 外部プロセス / レイアウトツールが Z-order を触っていても正しい真理値になる
- `SetWindowPos` に `SWP_NOACTIVATE` を渡して、トグル時にフォーカスを奪わない (別アプリからグローバルホットキーで叩くケースを想定)

</details>

## Verification

Config to test:

```ini
keybind = ctrl+shift+t=toggle_window_float_on_top
```

- [x] `Ctrl+Shift+T` puts the window on top (verify by clicking another window — the Ghostty window stays visible in front)
- [x] Second press restores normal Z-order
- [ ] `keybind = ...=float_window:on` explicitly sets on, `:off` explicitly clears
- [ ] Toggling doesn't steal focus (activate another window first, hit the hotkey — the other window keeps focus)

Closes #104.

