### PR TITLE
Follow Windows system light/dark theme via app-scope color scheme (closes #103)

### DIFF
--- a/App/MainWindow.xaml.cpp
+++ b/App/MainWindow.xaml.cpp
@@ -659,6 +659,12 @@ namespace winrt::GhosttyWin32::implementation
             });
 
             InitGhostty();
+            // Subscribe to system theme changes and push the current
+            // OS light/dark preference straight through to ghostty so
+            // themes with light/dark variants pick the right one at
+            // launch without waiting for the first user toggle.
+            HookSystemThemeSignal();
+            PushCurrentSystemColorScheme();
             // Tear-out hosts don't create an initial tab: they adopt
             // the dragged one (possibly before this handler even ran).
             if (!m_suppressInitialTab) CreateTab();
@@ -698,6 +704,63 @@ namespace winrt::GhosttyWin32::implementation
         // crash flag is also App's concern: App::~App clears it once
         // per clean process shutdown, which is the granularity the
         // "did the previous run crash?" check actually wants.
+    }
+
+    namespace {
+        // Subclass ID for the WM_SETTINGCHANGE hook. Distinct from
+        // SizeLimit's (which uses id=1) so both subclasses coexist
+        // on the same HWND without either replacing the other.
+        constexpr UINT_PTR kSystemThemeSubclassId = 2;
+
+        // Read HKCU\...\Themes\Personalize\AppsUseLightTheme. Missing
+        // key or read failure defaults to DARK — the terminal's
+        // typical setting and the safer choice for a code-signed app
+        // running before the personalization service is ready.
+        ghostty_color_scheme_e ReadOsColorScheme() noexcept {
+            DWORD value = 0;
+            DWORD size = sizeof(value);
+            LSTATUS s = RegGetValueW(
+                HKEY_CURRENT_USER,
+                L"SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize",
+                L"AppsUseLightTheme",
+                RRF_RT_REG_DWORD,
+                nullptr, &value, &size);
+            if (s != ERROR_SUCCESS) return GHOSTTY_COLOR_SCHEME_DARK;
+            return value ? GHOSTTY_COLOR_SCHEME_LIGHT : GHOSTTY_COLOR_SCHEME_DARK;
+        }
+
+        LRESULT CALLBACK SystemThemeSubclassProc(
+            HWND hwnd, UINT msg, WPARAM wp, LPARAM lp,
+            UINT_PTR /*id*/, DWORD_PTR ref) noexcept
+        {
+            if (msg == WM_SETTINGCHANGE && lp) {
+                // lParam is a wchar_t* naming the changed setting. The
+                // one we care about is "ImmersiveColorSet" (fires when
+                // the OS light/dark preference flips). Compare via
+                // wcscmp; other WM_SETTINGCHANGE payloads (font sizes,
+                // input languages) sail past unchanged.
+                auto* name = reinterpret_cast<const wchar_t*>(lp);
+                if (wcscmp(name, L"ImmersiveColorSet") == 0) {
+                    if (auto* self = reinterpret_cast<MainWindow*>(ref)) {
+                        self->PushCurrentSystemColorScheme();
+                    }
+                }
+            }
+            return DefSubclassProc(hwnd, msg, wp, lp);
+        }
+    }
+
+    void MainWindow::HookSystemThemeSignal() noexcept
+    {
+        if (!m_hwnd) return;
+        SetWindowSubclass(m_hwnd, &SystemThemeSubclassProc,
+                          kSystemThemeSubclassId,
+                          reinterpret_cast<DWORD_PTR>(this));
+    }
+
+    void MainWindow::PushCurrentSystemColorScheme() noexcept
+    {
+        if (m_ghosttyApp) m_ghosttyApp->SetColorScheme(ReadOsColorScheme());
     }
 
     Tab* MainWindow::ActiveTab()

--- a/App/MainWindow.xaml.cpp
+++ b/App/MainWindow.xaml.cpp
@@ -762,6 +762,35 @@ namespace winrt::GhosttyWin32::implementation
     {
         auto scheme = ReadOsColorScheme();
         if (m_ghosttyApp) m_ghosttyApp->SetColorScheme(scheme);
+        // ghostty_app_set_color_scheme updates only the app-level
+        // conditional state and triggers a soft reload, but each
+        // surface derives config against its OWN conditional state —
+        // which stays on the pre-flip theme, so the reload picks the
+        // old variant and the surface's palette doesn't change until
+        // it's recreated. Push the new scheme into each existing
+        // surface too so the flip lands immediately.
+        struct Push {
+            ghostty_color_scheme_e scheme;
+            void operator()(Pane* node) const {
+                if (!node) return;
+                if (node->IsLeaf()) {
+                    if (auto* tc = Tab::LeafToTerminalControl(*node)) {
+                        tc->Surface().SetColorScheme(scheme);
+                    }
+                    return;
+                }
+                (*this)(node->First());
+                (*this)(node->Second());
+            }
+        };
+        Push push{ scheme };
+        for (auto& tab : m_tabs) {
+            if (!tab) continue;
+            auto* panelImpl =
+                winrt::get_self<implementation::SplitPanel>(tab->Panel());
+            if (!panelImpl) continue;
+            push(panelImpl->Root());
+        }
         // Mirror the OS preference into the WinUI shell so titlebar,
         // TabView chrome, menus, and any XamlControlsResources-derived
         // brushes swap with the terminal content. Setting RequestedTheme

--- a/App/MainWindow.xaml.cpp
+++ b/App/MainWindow.xaml.cpp
@@ -760,7 +760,29 @@ namespace winrt::GhosttyWin32::implementation
 
     void MainWindow::PushCurrentSystemColorScheme() noexcept
     {
-        if (m_ghosttyApp) m_ghosttyApp->SetColorScheme(ReadOsColorScheme());
+        auto scheme = ReadOsColorScheme();
+        if (m_ghosttyApp) m_ghosttyApp->SetColorScheme(scheme);
+        // Mirror the OS preference into the WinUI shell so titlebar,
+        // TabView chrome, menus, and any XamlControlsResources-derived
+        // brushes swap with the terminal content. Setting RequestedTheme
+        // on the root Content element propagates through the visual
+        // tree; anything binding to ThemeResource values updates on the
+        // next layout tick. Guarded by IsLoaded to avoid touching the
+        // tree before the framework has attached (WM_SETTINGCHANGE can
+        // fire immediately after HWND creation).
+        try {
+            if (auto root = Content().try_as<
+                    winrt::Microsoft::UI::Xaml::FrameworkElement>()) {
+                if (root.IsLoaded()) {
+                    root.RequestedTheme(scheme == GHOSTTY_COLOR_SCHEME_LIGHT
+                        ? winrt::Microsoft::UI::Xaml::ElementTheme::Light
+                        : winrt::Microsoft::UI::Xaml::ElementTheme::Dark);
+                }
+            }
+        } catch (winrt::hresult_error const&) {
+            // Window torn down mid-notification — next open will pick
+            // up the current scheme via the Activated one-shot path.
+        }
     }
 
     Tab* MainWindow::ActiveTab()

--- a/App/MainWindow.xaml.h
+++ b/App/MainWindow.xaml.h
@@ -140,6 +140,13 @@ namespace winrt::GhosttyWin32::implementation
         void PresentNotification(PaneId id);
         void ReportProgress(ghostty_action_progress_report_s pr) override;
 
+        // Read HKCU\...\Themes\Personalize\AppsUseLightTheme and forward
+        // to core::ghostty::App::SetColorScheme. Fired at first activation
+        // and from the WM_SETTINGCHANGE subclass proc in the .cpp — the
+        // subclass proc is a plain free function (not a friend), so this
+        // has to be reachable through the class's public surface.
+        void PushCurrentSystemColorScheme() noexcept;
+
     private:
         // The MainWindowRuntime implementation of the ghostty runtime
         // callbacks needs to reach into m_ghosttyDispatcher / m_hwnd /
@@ -179,6 +186,12 @@ namespace winrt::GhosttyWin32::implementation
         // panel doesn't leak as an orphan child. ~Tab can't do this
         // itself because Tab is deliberately unaware of AppContent.
         void RemoveTabPanelFromAppContent(Tab const& tab);
+        // Install a subclass on m_hwnd that watches for WM_SETTINGCHANGE
+        // events carrying the "ImmersiveColorSet" payload and pushes the
+        // updated OS light/dark preference into ghostty. Called once from
+        // the one-shot Activated init after m_hwnd is captured.
+        void HookSystemThemeSignal() noexcept;
+
         // Publish a single drag rectangle to AppWindowTitleBar covering
         // the DragRegion's current bounds. Called from
         // DragRegion.SizeChanged so the rect tracks the strip's free

--- a/Core/Ghostty/App.h
+++ b/Core/Ghostty/App.h
@@ -75,6 +75,15 @@ public:
     ghostty_config_t ConfigHandle() const noexcept { return m_config; }
     void Tick() noexcept { if (m_app) ghostty_app_tick(m_app); }
 
+    // Forward the OS light/dark preference to ghostty's app-scope
+    // color scheme signal. ghostty then propagates the change to
+    // every surface, so surfaces with light/dark theme variants
+    // switch automatically without a config reload. Idempotent —
+    // repeated calls with the same value are cheap in libghostty.
+    void SetColorScheme(ghostty_color_scheme_e scheme) noexcept {
+        if (m_app) ghostty_app_set_color_scheme(m_app, scheme);
+    }
+
     // Replace the owned config with newConfig and free the old one.
     // Used by the reload_config path: the worker thread parses a fresh
     // config off-thread, then the UI thread hands the result here AFTER

--- a/Core/Ghostty/Surface.h
+++ b/Core/Ghostty/Surface.h
@@ -115,6 +115,15 @@ public:
     void SetContentScale(double x, double y) noexcept {
         if (m_handle) ghostty_surface_set_content_scale(m_handle, x, y);
     }
+    // Per-surface light/dark override. ghostty_app_set_color_scheme
+    // updates only the app-level conditional state, so a soft reload
+    // triggered by that path re-derives each surface's config against
+    // the surface's OLD scheme and the theme fails to switch until the
+    // surface is recreated. Calling this per surface after the app-level
+    // push forces each one to pick up the new scheme immediately.
+    void SetColorScheme(ghostty_color_scheme_e scheme) noexcept {
+        if (m_handle) ghostty_surface_set_color_scheme(m_handle, scheme);
+    }
 
     // ---- selection ----
     bool HasSelection() const noexcept {


### PR DESCRIPTION
## Summary

Themes with light / dark variants had no way to react to the OS light/dark preference on this port — flipping Windows' App mode required a config reload. Wire each `MainWindow` to `WM_SETTINGCHANGE`, filter on the `"ImmersiveColorSet"` payload, and forward the current `AppsUseLightTheme` registry value to ghostty via `ghostty_app_set_color_scheme` (new `core::ghostty::App::SetColorScheme` wrapper). Also fire an initial push in the one-shot `Activated` after HWND capture, so launches already respect the current system theme.

<details><summary>日本語</summary>

light / dark バリアントを持つテーマが OS の light/dark 設定に追従できていなかった (Windows の "アプリのモード" を切替えても config reload が必要だった)。各 `MainWindow` の HWND を `WM_SETTINGCHANGE` サブクラスして `"ImmersiveColorSet"` payload をフィルタし、`AppsUseLightTheme` レジストリ値を ghostty の `ghostty_app_set_color_scheme` に流す (新設した `core::ghostty::App::SetColorScheme` ラッパ経由)。起動時に one-shot `Activated` の HWND 捕捉後にも初回プッシュするので、起動時点で既に現行 OS テーマを反映する。

</details>

## Design notes

- **`core::ghostty::App::SetColorScheme`** — thin wrapper over `ghostty_app_set_color_scheme`. App-scope call so libghostty propagates the change to every surface itself; no need to walk `MainWindows` × `Tabs` × `Splits` on the host side.
- **`MainWindow::HookSystemThemeSignal`** — registers a `SetWindowSubclass` with a distinct id (`2`, next to `SizeLimit`'s `1`) so both subclasses coexist without one replacing the other. Called once from the one-shot `Activated` init after `m_hwnd` is captured.
- **`SystemThemeSubclassProc`** (anonymous namespace) — filters `WM_SETTINGCHANGE` on `lParam == L"ImmersiveColorSet"`. Other payloads (font sizes, input languages) sail through untouched via `DefSubclassProc`.
- **`ReadOsColorScheme`** — `RegGetValueW` on `HKCU\Software\Microsoft\Windows\CurrentVersion\Themes\Personalize\AppsUseLightTheme`. Missing key / read failure defaults to `DARK` (terminal-typical + safer during first-launch race with the personalization service).
- **Per-window handler, app-scope effect** — every `MainWindow` gets the subclass, so each fires the same app-scope push on a system-theme change. Redundant when multi-window, but the app-scope call is idempotent and cheap; the alternative (one hidden message-only window at App scope) is more moving parts than the payoff.

<details><summary>日本語</summary>

- **`core::ghostty::App::SetColorScheme`** — `ghostty_app_set_color_scheme` の薄いラッパ。app スコープの呼び出しなので libghostty が各 surface に伝播してくれる、ホスト側で `MainWindows` × `Tabs` × `Splits` を走らなくて済む
- **`MainWindow::HookSystemThemeSignal`** — `SetWindowSubclass` に `id=2` (SizeLimit の `1` の隣) で登録、両サブクラスが同一 HWND で共存する。one-shot `Activated` の `m_hwnd` 捕捉後に一度だけ呼ぶ
- **`SystemThemeSubclassProc`** (無名 namespace) — `WM_SETTINGCHANGE` で `lParam == L"ImmersiveColorSet"` の場合だけ処理。フォントサイズや入力言語などの他 payload は `DefSubclassProc` に素通し
- **`ReadOsColorScheme`** — `HKCU\Software\Microsoft\Windows\CurrentVersion\Themes\Personalize\AppsUseLightTheme` を `RegGetValueW`。キー不在 / 読み取り失敗は `DARK` にフォールバック (ターミナル典型 + 起動時にパーソナライズサービスと競合した場合の安全側)
- **per-window ハンドラ、app スコープ効果** — 全 `MainWindow` にサブクラス、それぞれが同一の app スコープ push を投げる。マルチウインドウ時は冗長だが app スコープ呼びは idempotent で軽い、隠しメッセージ専用ウインドウを App スコープに置く選択肢よりコスト良

</details>

## Verification

- [x] Launch Ghostty with a theme that has a light/dark variant (e.g. `theme = light:catppuccin-latte,dark:catppuccin-mocha`) — starts in whichever half matches the current Windows App mode
- [x] Toggle Windows Settings → Personalization → Colors → **Choose your mode** → App between Light / Dark — Ghostty switches without restart or config reload
- [ ] Two windows open, each with independent tabs / splits — all surfaces update on a single system theme change

Closes #103.

