### PR TITLE
Show foreground process name in tab title (closes #105)

### DIFF
--- a/App/MainWindow.xaml.cpp
+++ b/App/MainWindow.xaml.cpp
@@ -19,10 +19,14 @@
 #include <winrt/Microsoft.Windows.AppNotifications.Builder.h>
 #include <winrt/Windows.Graphics.h>
 #include <algorithm>
+#include <cctype>
+#include <chrono>
 #include <cmath>
+#include <cwctype>
 #include <filesystem>
 #include <fstream>
 #include <limits>
+#include <string_view>
 #include <vector>
 #pragma comment(lib, "dwmapi.lib")
 #pragma comment(lib, "shell32.lib")
@@ -662,6 +666,10 @@ namespace winrt::GhosttyWin32::implementation
             // Tear-out hosts don't create an initial tab: they adopt
             // the dragged one (possibly before this handler even ran).
             if (!m_suppressInitialTab) CreateTab();
+            // Start the 1 Hz foreground-pid poll now that ghostty is
+            // up and a tab exists (or, for tear-out hosts, is about to
+            // be adopted). Idempotent — the timer only starts once.
+            StartForegroundPidPoll();
             // Honour `window-decoration` from config at startup so
             // users who set it in their config see the chrome state
             // they asked for without having to fire the toggle
@@ -685,6 +693,15 @@ namespace winrt::GhosttyWin32::implementation
 
     MainWindow::~MainWindow()
     {
+        // Stop the foreground-pid poll before anything else in this
+        // destructor runs — its Tick callback captures a weak_ref
+        // that would return null at this point anyway, but Stopping
+        // explicitly avoids one final call sneaking through XAML's
+        // dispatch queue during teardown.
+        if (m_foregroundPidTimer) {
+            try { m_foregroundPidTimer.Stop(); }
+            catch (winrt::hresult_error const&) {}
+        }
         // Take ourselves off the App-scope aggregate before anything
         // else — subsequent runtime callbacks that fire during
         // ghostty_app_free's join land in the FindForSurface / Any
@@ -1143,6 +1160,92 @@ namespace winrt::GhosttyWin32::implementation
     {
         if (auto* t = m_tabs.FindBySurface(surface)) {
             t->Item().Header(box_value(winrt::hstring(title)));
+            // Once the shell has spoken, the foreground-pid poll
+            // stops overwriting the header for this tab.
+            t->MarkExplicitTitle();
+        }
+    }
+
+    namespace {
+        // Resolve a Win32 PID to its executable's basename without an
+        // extension (e.g. 12345 -> "vim", "ssh"). Returns an empty
+        // hstring when the process handle can't be opened (rights,
+        // rapid exit) or the query fails — the caller falls back to
+        // whatever the header already shows.
+        winrt::hstring PidToBasename(uint32_t pid) noexcept {
+            if (!pid) return {};
+            // QUERY_LIMITED_INFORMATION is the minimum right that
+            // still lets QueryFullProcessImageNameW read the image
+            // path — QUERY_INFORMATION is stronger and can fail on
+            // protected processes we don't need to see.
+            HANDLE h = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION,
+                                   FALSE, pid);
+            if (!h) return {};
+            wchar_t buf[MAX_PATH];
+            DWORD size = static_cast<DWORD>(std::size(buf));
+            BOOL ok = QueryFullProcessImageNameW(h, 0, buf, &size);
+            CloseHandle(h);
+            if (!ok || size == 0) return {};
+            // Trim to basename without ".exe". The upstream ghostty
+            // tab title convention is `command` (no path, no
+            // extension) so match it.
+            std::wstring_view sv{ buf, size };
+            auto slash = sv.find_last_of(L"\\/");
+            if (slash != std::wstring_view::npos) sv.remove_prefix(slash + 1);
+            constexpr std::wstring_view kExe{ L".exe" };
+            if (sv.size() > kExe.size()) {
+                auto tail = sv.substr(sv.size() - kExe.size());
+                bool matches = true;
+                for (size_t i = 0; i < kExe.size(); ++i) {
+                    if (::towlower(tail[i]) != kExe[i]) { matches = false; break; }
+                }
+                if (matches) sv.remove_suffix(kExe.size());
+            }
+            return winrt::hstring(sv);
+        }
+    }
+
+    void MainWindow::StartForegroundPidPoll()
+    {
+        if (m_foregroundPidTimer) return;  // already running
+        auto dq = DispatcherQueue();
+        if (!dq) return;
+        m_foregroundPidTimer = dq.CreateTimer();
+        m_foregroundPidTimer.Interval(std::chrono::seconds{1});
+        // Weak `this`: the timer is a member (holds an unrelated
+        // WinUI ref count), and MainWindow's destructor stops it,
+        // but capturing weak plus swallowing an empty get() means
+        // teardown edge cases can't reach into a half-torn window.
+        auto weak = get_weak();
+        m_foregroundPidTimer.Tick([weak](auto&&, auto&&) {
+            if (auto self = weak.get()) self->UpdateForegroundNames();
+        });
+        m_foregroundPidTimer.Start();
+    }
+
+    void MainWindow::UpdateForegroundNames() noexcept
+    {
+        for (auto& tab : m_tabs) {
+            if (!tab) continue;
+            // Shell-supplied titles are sticky — leave them alone.
+            if (tab->HasExplicitTitle()) continue;
+            auto* tc = tab->ActiveControl();
+            if (!tc) continue;
+            uint32_t pid = tc->Surface().ForegroundPid();
+            if (!pid) continue;
+            // Same PID as last tick: keep whatever's already on the
+            // header, no per-process work.
+            if (tab->LastForegroundPid() == pid) continue;
+            auto name = PidToBasename(pid);
+            if (name.empty()) continue;
+            tab->SetForegroundCache(pid, name);
+            try {
+                tab->Item().Header(winrt::box_value(name));
+            } catch (winrt::hresult_error const&) {
+                // Tab may be tearing down (drag between windows,
+                // close race). Not our problem — next tick will
+                // find it gone.
+            }
         }
     }
 

--- a/App/MainWindow.xaml.h
+++ b/App/MainWindow.xaml.h
@@ -309,6 +309,24 @@ namespace winrt::GhosttyWin32::implementation
         // member ordering), so the dispatcher can't observe a
         // half-torn-down ghostty handle from any of its handlers.
         std::unique_ptr<ghostty::CallbackDispatcher> m_ghosttyDispatcher;
+
+        // 1 Hz poll that walks each Tab, asks ghostty for the
+        // foreground process pid of the active pane, resolves it to
+        // an executable basename, and (if the shell hasn't set an
+        // OSC title on this tab yet) writes the name into the
+        // TabViewItem header. See StartForegroundPidPoll for the
+        // scheduling story.
+        winrt::Microsoft::UI::Dispatching::DispatcherQueueTimer
+            m_foregroundPidTimer{ nullptr };
+
+        // Kick off the foreground-pid poll after the first tab
+        // exists. Idempotent — safe to call more than once (won't
+        // create a second timer).
+        void StartForegroundPidPoll();
+
+        // One tick of the poll. Body is inline in the .cpp; walks
+        // m_tabs and updates the header where appropriate.
+        void UpdateForegroundNames() noexcept;
     };
 }
 

--- a/App/Tabs/Tab.h
+++ b/App/Tabs/Tab.h
@@ -95,6 +95,26 @@ public:
 
     Microsoft::UI::Xaml::Controls::TabViewItem const& Item() const noexcept { return m_item; }
 
+    // True once the shell has set an explicit title via SET_TITLE /
+    // SET_TAB_TITLE (OSC 0/2 or `set_title` action). The foreground-
+    // pid poll uses this to decide whether the tab header is theirs
+    // to overwrite: shell-supplied titles win, auto-computed process
+    // names only fill in when the shell has said nothing.
+    bool HasExplicitTitle() const noexcept { return m_hasExplicitTitle; }
+    void MarkExplicitTitle() noexcept { m_hasExplicitTitle = true; }
+
+    // Last PID resolved for this tab's active pane's foreground
+    // process, and the basename cached from it. The poll updates both
+    // when the PID changes so QueryFullProcessImageNameW only runs on
+    // transitions (running `git` for a while doesn't re-open the
+    // handle every tick).
+    uint32_t LastForegroundPid() const noexcept { return m_lastForegroundPid; }
+    winrt::hstring const& LastForegroundName() const noexcept { return m_lastForegroundName; }
+    void SetForegroundCache(uint32_t pid, winrt::hstring name) noexcept {
+        m_lastForegroundPid = pid;
+        m_lastForegroundName = std::move(name);
+    }
+
     // Read-only access to the SplitPanel hosting this tab's tree, used
     // by Tabs::FindBySurface to walk every leaf and locate the one
     // whose TerminalControl owns a given ghostty_surface_t.
@@ -211,6 +231,14 @@ private:
     // Reset to nullptr or another leaf on tree mutations before any
     // leaf is destroyed.
     Pane* m_activeLeaf{ nullptr };
+
+    // See HasExplicitTitle. Sticky: once the shell sets a title the
+    // poll leaves it alone for the rest of the tab's life.
+    bool m_hasExplicitTitle{ false };
+
+    // Foreground-pid poll cache. Zero means "not yet resolved".
+    uint32_t         m_lastForegroundPid{ 0 };
+    winrt::hstring   m_lastForegroundName{};
 };
 
 }  // namespace winrt::GhosttyWin32::implementation

--- a/Core/Ghostty/Surface.h
+++ b/Core/Ghostty/Surface.h
@@ -116,6 +116,15 @@ public:
         if (m_handle) ghostty_surface_set_content_scale(m_handle, x, y);
     }
 
+    // PID of the current foreground process in this surface's PTY —
+    // not necessarily the shell (that's the ancestor). Used by the
+    // tab-title poll to show the running command's name (`vim`,
+    // `ssh host`) instead of just the shell name. Returns 0 when
+    // no surface, no PTY yet, or no foreground process.
+    uint32_t ForegroundPid() const noexcept {
+        return m_handle ? ghostty_surface_foreground_pid(m_handle) : 0;
+    }
+
     // ---- selection ----
     bool HasSelection() const noexcept {
         return m_handle && ghostty_surface_has_selection(m_handle);


### PR DESCRIPTION
## Summary

Populate each tab's title with the current foreground process's name (`vim`, `ssh`, `git`, ...) using `ghostty_surface_foreground_pid` + Win32 `QueryFullProcessImageNameW`. Idle tabs previously read as whatever the shell (or the initial `" "` placeholder) set — indistinguishable once you had five tabs of `pwsh`. Now a glance at the tab strip tells you what's actually running where.

<details><summary>日本語</summary>

`ghostty_surface_foreground_pid` + Win32 `QueryFullProcessImageNameW` を使って、各タブのタイトルに現在フォアグラウンドで動いているプロセス名 (`vim`, `ssh`, `git`, ...) を表示する。今までは idle タブが「シェルが設定した値」か初期の `" "` のままで、`pwsh` のタブが 5 個並ぶと区別が付かなかった。

</details>

## How it works

- **Per-window 1 Hz `DispatcherQueueTimer`** — walks `m_tabs`, asks each active pane's `Surface` for its foreground pid, resolves to an image-name basename with `OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION)` + `QueryFullProcessImageNameW`, and writes the result into the `TabViewItem.Header`. The `.exe` suffix is stripped so the display matches the upstream tab-title convention.
- **Per-Tab cache** — Tab remembers the last (pid, basename) pair. When the pid doesn't change tick-to-tick, we skip Win32 entirely. An editor left open costs one call, then nothing.
- **Shell OSC titles win** — `SetTabTitleForSurface` flips a sticky bit on the Tab; the poll skips any tab whose bit is set. The moment the shell says `myproject $` once, that tab is out of the poll's write set for the rest of its life.
- **Teardown-safe** — `~MainWindow` stops the timer before touching the App-scope aggregate, so a final tick can't race the destructor.

<details><summary>日本語</summary>

- **ウインドウごとの 1 Hz `DispatcherQueueTimer`** — `m_tabs` を歩き、各アクティブペインの `Surface` にフォアグラウンド pid を聞き、`OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION)` + `QueryFullProcessImageNameW` で basename に解決して `TabViewItem.Header` に書く。`.exe` は upstream の慣例に合わせて削る。
- **Tab ごとのキャッシュ** — Tab が (pid, basename) を覚える。前 tick と pid が変わらなければ Win32 呼び出しをスキップ。エディタを開きっぱなしなら初回 1 発、以降ゼロ。
- **シェル OSC タイトルが勝つ** — `SetTabTitleForSurface` が Tab に sticky bit を立てる。ポールはそのタブをスキップ。一度でもシェルが `myproject $` と言った瞬間、そのタブは以降ポールの書き込み対象から外れる。
- **teardown 安全** — `~MainWindow` がタイマーを Stop してから App スコープ集約を触るので、最後の tick が destructor と競合しない。

</details>

## Notes / caveats

- PID reuse (rare, after a fast-fork loop) can briefly show the wrong name. Cosmetic — corrected on the next tick when the poll observes a new PID.
- `PROCESS_QUERY_LIMITED_INFORMATION` is intentional: enough for `QueryFullProcessImageNameW`, and it works against processes the stronger `QUERY_INFORMATION` right can't touch.
- The initial poll runs after `CreateTab` in the one-shot `Activated`, so the very first frame the user sees may still say `" "`; the second tick (≤1 second later) fills it in. Not worth eager-firing to save one second.

<details><summary>日本語</summary>

- PID 再利用 (fast-fork ループの直後などレア) で一瞬違う名前が出ることはある。次の tick で正しい名前に戻るので視覚的なだけ
- `PROCESS_QUERY_LIMITED_INFORMATION` は意図的。`QueryFullProcessImageNameW` にはこれで十分で、`QUERY_INFORMATION` が届かないプロセスにも通る
- 初回ポールは one-shot `Activated` の `CreateTab` の後に起動するので、ユーザーが見る最初のフレームは `" "` のまま。次の tick (≤1 秒後) で埋まる。1 秒節約のために別途 fire するほどではない

</details>

## Verification

- [ ] Fresh tab starts with the shell basename (`pwsh`, `cmd`) after ≤1 second
- [x] Run `vim README.md` — tab flips to `vim`, back to `pwsh` on `:q`
- [ ] Run `ssh someone@somewhere` — tab flips to `ssh`
- [x] Have the shell OSC-set a title (`Set-PSReadLineOption -PromptText '...'` in PowerShell, or `PROMPT_COMMAND` in bash setting `\e]0;title\a`) — the process name stops overwriting and the shell title sticks for the rest of the tab's life
- [ ] Close the tab / drag it to another window — no crash, no orphan timer callback

Closes #105.

