### PR TITLE
Prompt before closing when panes have running processes (closes #102)

### DIFF
--- a/App/MainWindow.xaml.cpp
+++ b/App/MainWindow.xaml.cpp
@@ -860,6 +860,79 @@ namespace winrt::GhosttyWin32::implementation
         try { Close(); } catch (winrt::hresult_error const&) {}
     }
 
+    void MainWindow::TryClose()
+    {
+        // Walk every leaf in every tab: if any surface reports
+        // needs_confirm_quit=true, gate the close on a
+        // WinUI ContentDialog. Otherwise close straight through.
+        //
+        // ghostty_surface_needs_confirm_quit already factors in the
+        // `confirm-close-surface` config, so users who set it false
+        // sail through without a dialog on every close.
+        //
+        // Inline recursion (rather than reusing CollectLeaves defined
+        // later in this file) so this can sit close to RequestClose
+        // where the surrounding close-path handlers already live.
+        struct Check {
+            bool any = false;
+            void operator()(Pane* node) {
+                if (any || !node) return;
+                if (node->IsLeaf()) {
+                    if (auto* tc = Tab::LeafToTerminalControl(*node)) {
+                        if (tc->Surface().NeedsConfirmQuit()) any = true;
+                    }
+                    return;
+                }
+                (*this)(node->First());
+                (*this)(node->Second());
+            }
+        };
+        Check check;
+        for (auto& tab : m_tabs) {
+            if (!tab) continue;
+            auto* panelImpl =
+                winrt::get_self<implementation::SplitPanel>(tab->Panel());
+            if (!panelImpl) continue;
+            check(panelImpl->Root());
+            if (check.any) break;
+        }
+        bool anyNeedsConfirm = check.any;
+
+        if (!anyNeedsConfirm) {
+            RequestClose();
+            return;
+        }
+
+        // XamlRoot is required for a ContentDialog to know which
+        // Window / island to overlay. Fall back to a plain close
+        // if the tree isn't realised yet (shouldn't happen — a
+        // close reaching TryClose means the window has been shown).
+        auto content = Content();
+        auto xamlRoot = content ? content.XamlRoot() : nullptr;
+        if (!xamlRoot) {
+            RequestClose();
+            return;
+        }
+
+        muxc::ContentDialog dlg;
+        dlg.XamlRoot(xamlRoot);
+        dlg.Title(winrt::box_value(winrt::hstring{ L"Close window?" }));
+        dlg.Content(winrt::box_value(winrt::hstring{
+            L"One or more terminals in this window still have running "
+            L"processes. They will be terminated." }));
+        dlg.PrimaryButtonText(L"Close");
+        dlg.CloseButtonText(L"Cancel");
+        dlg.DefaultButton(muxc::ContentDialogButton::Close);
+
+        auto op = dlg.ShowAsync();
+        auto weak = get_weak();
+        op.Completed([weak](auto&& sender, auto&& status) {
+            if (status != winrt::Windows::Foundation::AsyncStatus::Completed) return;
+            if (sender.GetResults() != muxc::ContentDialogResult::Primary) return;
+            if (auto self = weak.get()) self->RequestClose();
+        });
+    }
+
     void MainWindow::InitGhostty()
     {
         // m_ghosttyApp + m_ghosttyDispatcher are already set in the
@@ -2038,10 +2111,14 @@ namespace winrt::GhosttyWin32::implementation
     void MainWindow::OnCloseClick(winrt::Windows::Foundation::IInspectable const&,
                                   winrt::Microsoft::UI::Xaml::RoutedEventArgs const&)
     {
-        // Route through WM_CLOSE so any registered close hooks run; the
-        // window's own Close() shortcut would skip them.
-        if (m_hwnd) PostMessageW(m_hwnd, WM_CLOSE, 0, 0);
-        else this->Close();
+        // User-intent close → confirmation gate. TryClose walks the
+        // window's panes, shows a WinUI ContentDialog when any
+        // surface reports needs_confirm_quit, and only then calls
+        // through to RequestClose. Alt+F4 / OS-issued WM_CLOSE still
+        // bypasses this (would need a WndProc subclass), matching
+        // typical Windows-app behaviour where only the app's own
+        // close affordances confirm.
+        TryClose();
     }
 
     void MainWindow::UpdateMaximizeGlyph()

--- a/App/MainWindow.xaml.h
+++ b/App/MainWindow.xaml.h
@@ -78,6 +78,7 @@ namespace winrt::GhosttyWin32::implementation
         void Dispatch(std::function<void()> fn) override;
         void Tick() override;
         void RequestClose() override;
+        void TryClose() override;
 
         // Split-pane operations from IMainWindowView. Bodies are in
         // MainWindow.xaml.cpp; behaviour is unchanged from when these

--- a/Core/Ghostty/Actions/Actions.cpp
+++ b/Core/Ghostty/Actions/Actions.cpp
@@ -95,11 +95,11 @@ bool Actions::OnOpenUrl(ghostty_action_open_url_s ou) {
 
 bool Actions::OnCloseWindow() {
     // Close the window that owns the action's target and nothing
-    // else. This Actions instance is per-window (the runtime routed
-    // the action here from its target surface), so m_view is that
-    // window; siblings survive.
+    // else. Same intent as the X button — go through TryClose so
+    // needs_confirm_quit prompts the user before we tear anything
+    // down. Sibling windows survive either way.
     m_view.Dispatch([this]() {
-        m_view.RequestClose();
+        m_view.TryClose();
     });
     return true;
 }

--- a/Core/Ghostty/Surface.h
+++ b/Core/Ghostty/Surface.h
@@ -116,6 +116,15 @@ public:
         if (m_handle) ghostty_surface_set_content_scale(m_handle, x, y);
     }
 
+    // Ghostty's per-surface prompt-on-quit signal. Reflects the
+    // `confirm-close-surface` config and whether the surface actually
+    // has non-shell child processes running — hosts consult this on
+    // user-initiated close paths and only show a dialog when it
+    // reports true.
+    bool NeedsConfirmQuit() const noexcept {
+        return m_handle && ghostty_surface_needs_confirm_quit(m_handle);
+    }
+
     // ---- selection ----
     bool HasSelection() const noexcept {
         return m_handle && ghostty_surface_has_selection(m_handle);

--- a/Core/Host/IWindow.h
+++ b/Core/Host/IWindow.h
@@ -52,6 +52,15 @@ struct IWindow {
     // down, so handlers can call it unconditionally.
     virtual void RequestClose() = 0;
 
+    // User-intent close: same effect as RequestClose, but consults
+    // each surface's ghostty_surface_needs_confirm_quit first and
+    // shows a WinUI ContentDialog when any pane reports true. Only
+    // reachable from paths that represent explicit user intent (X
+    // button click, close_window keybind) — internal cleanup paths
+    // (tear-out empty shell, etc.) skip the confirmation and call
+    // RequestClose directly.
+    virtual void TryClose() = 0;
+
     // ----- split-pane operations -----
     // Surface-target split actions all share the same shape: find
     // the pane owning `surface` in its tab, mutate the tree, leave

--- a/Tests/MockMainWindowView.h
+++ b/Tests/MockMainWindowView.h
@@ -20,6 +20,7 @@ struct MockMainWindowView : core::host::IWindow {
     int dispatchCalls = 0;
     int tickCalls = 0;
     int requestCloseCalls = 0;
+    int tryCloseCalls = 0;
 
     HWND Hwnd() const noexcept override { return nullptr; }
     void Dispatch(std::function<void()> fn) override {
@@ -28,6 +29,7 @@ struct MockMainWindowView : core::host::IWindow {
     }
     void Tick() override { ++tickCalls; }
     void RequestClose() override { ++requestCloseCalls; }
+    void TryClose() override { ++tryCloseCalls; }
 
     // ----- split-pane -----
     int splitActivePaneCalls = 0;

--- a/Tests/test_ghostty_actions.cpp
+++ b/Tests/test_ghostty_actions.cpp
@@ -33,11 +33,16 @@ TEST(GhosttyActionsTest, OnRenderTicksTheView) {
     EXPECT_EQ(view.tickCalls, 1);
 }
 
-TEST(GhosttyActionsTest, OnCloseWindowAsksTheViewToClose) {
+TEST(GhosttyActionsTest, OnCloseWindowRoutesThroughTryClose) {
+    // TryClose is the confirmation-gated close path (issue #102);
+    // OnCloseWindow represents user intent, so it goes through
+    // TryClose rather than RequestClose to give
+    // needs_confirm_quit a chance to prompt.
     MockMainWindowView view;
     Actions actions(view);
     EXPECT_TRUE(actions.OnCloseWindow());
-    EXPECT_EQ(view.requestCloseCalls, 1);
+    EXPECT_EQ(view.tryCloseCalls, 1);
+    EXPECT_EQ(view.requestCloseCalls, 0);
 }
 
 TEST(GhosttyActionsTest, OnToggleFullscreenAsksTheViewToToggle) {


### PR DESCRIPTION
## Summary

libghostty already exposes `ghostty_surface_needs_confirm_quit` (factors in `confirm-close-surface` config + whether the surface has non-shell child processes running), but nothing on this port was consulting it — closing a window with `vim`, an `ssh` session, or a build in flight silently terminated everything. Add a `TryClose` path that checks each pane and shows a WinUI `ContentDialog` when any reports true, gating the actual `RequestClose` on Primary.

<details><summary>日本語</summary>

libghostty には `ghostty_surface_needs_confirm_quit` があり (`confirm-close-surface` config + シェル以外の子プロセスの有無を反映) 、この port からは誰も呼んでいなかった。`vim` / `ssh` / ビルド途中でウインドウを閉じるとサイレントに全プロセスが終了していた。`TryClose` 経路を追加し、各ペインをチェックしていずれかが true を返したら WinUI `ContentDialog` を出す。Primary ボタンで初めて実際の `RequestClose` が走る。

</details>

## How it works

- **`Surface::NeedsConfirmQuit()`** — thin wrapper over `ghostty_surface_needs_confirm_quit`.
- **`MainWindow::TryClose`** (new, on `IWindow`) — walks every leaf in every tab; if any surface says yes, shows a `ContentDialog` (`Title: "Close window?"`, body: `"One or more terminals in this window still have running processes. They will be terminated."`, Primary = `Close`, Close = `Cancel`, default = `Close`). Only Primary calls `RequestClose`.
- **`OnCloseClick`** (the X button in our custom title bar) — routes through `TryClose`.
- **`Actions::OnCloseWindow`** (the `close_window` keybind) — also routes through `TryClose`, so `Ctrl+Shift+W` with a running process prompts identically to clicking the X.
- **`RequestClose` stays unconditional** — internal cleanup paths (tear-out empty shells, deferred close-on-empty, `App::CloseAllWindows` sweep) still tear down without a prompt. Making those confirm would surprise users who deliberately dragged out the last tab or fired a quit-all keybind.
- **`Alt+F4` / OS-issued `WM_CLOSE`** still tears down without confirmation. Wiring the OS path too would need a `WndProc` subclass; typical Windows apps don't gate the OS close either. Follow-up if it turns out to bother anyone.

<details><summary>日本語</summary>

- **`Surface::NeedsConfirmQuit()`** — `ghostty_surface_needs_confirm_quit` の薄いラッパ。
- **`MainWindow::TryClose`** (新規、`IWindow` レベル) — 全 tab × 全 leaf を歩き、いずれかが true を返したら `ContentDialog` を出す (`Title: "Close window?"` / 本文: 「実行中プロセスがあります、終了されます」 / Primary = `Close`, Close = `Cancel`, default = `Close`)。Primary のみが `RequestClose` を呼ぶ。
- **`OnCloseClick`** (カスタムタイトルバーの X ボタン) — `TryClose` を経由する。
- **`Actions::OnCloseWindow`** (`close_window` キーバインド) — 同じく `TryClose` 経由。`Ctrl+Shift+W` でも X ボタンと同じダイアログが出る。
- **`RequestClose` は無条件のまま** — 内部クリーンアップ経路 (tear-out で空になったシェル、遅延 close-on-empty、`App::CloseAllWindows` の掃引) は今まで通りダイアログなし。ユーザーが意図的に最後のタブをドラッグ抜きした / quit-all を叩いた時にダイアログが出るのは想定外。
- **`Alt+F4` / OS 発の `WM_CLOSE`** も無確認のまま。フックには `WndProc` サブクラスが要り、Windows アプリの多くも OS 発 close は gate していないので follow-up 扱い。

</details>

## Tests

`Tests/test_ghostty_actions.cpp` — the existing `OnCloseWindowAsksTheViewToClose` test flips to `OnCloseWindowRoutesThroughTryClose` and now checks `view.tryCloseCalls == 1` / `view.requestCloseCalls == 0`. The mock gets a `tryCloseCalls` counter alongside `requestCloseCalls`.

## Verification

- [x] Open a tab, run `vim README.md`, click the X → dialog appears; **Cancel** keeps the window, **Close** exits `vim` and closes the window
- [ ] Same tab, `:q` in `vim` → shell prompt back → click X → **no dialog** (nothing to confirm)
- [ ] `close_window` keybind (e.g. `Ctrl+Shift+W`) with a running process — same dialog
- [ ] `confirm-close-surface = false` in config — no dialog even with running processes (libghostty short-circuits `needs_confirm_quit`)
- [ ] Two tabs, one with a running process, one idle → dialog fires; close the process, click X again → no dialog
- [x] Alt+F4 with a running process — closes without confirmation (documented behaviour)

Closes #102.

