### PR TITLE
Fix nvim render alignment: ceil physical pixels, debounce resize flicker

### DIFF
--- a/App/Display/PhysicalPixels.h
+++ b/App/Display/PhysicalPixels.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cmath>
 #include <cstdint>
 #include <utility>
 #include <winrt/Microsoft.UI.Xaml.h>
@@ -96,10 +97,18 @@ inline PhysicalSize ToPhysicalPixels(
     double widthDips,
     double heightDips)
 {
+    // Ceil (not truncate) so the swap chain is never one pixel
+    // narrower / shorter than the panel that composes it. A DIP
+    // width of 1919.6 at 1.5× scale is 2879.4 physical pixels; a
+    // truncating cast produced 2879 while DWM asked the panel to
+    // cover 2880, leaving a hairline gap on the far edge where the
+    // scaled swap-chain content didn't reach. Rounding up guarantees
+    // the swap chain fully covers the panel's physical rectangle;
+    // any subpixel overshoot is invisible (the composition clips).
     auto [sx, sy] = EffectiveScales(element);
     return {
-        static_cast<uint32_t>(widthDips  * sx),
-        static_cast<uint32_t>(heightDips * sy),
+        static_cast<uint32_t>(std::ceil(widthDips  * sx)),
+        static_cast<uint32_t>(std::ceil(heightDips * sy)),
     };
 }
 

--- a/App/TerminalControl.xaml.cpp
+++ b/App/TerminalControl.xaml.cpp
@@ -7,6 +7,7 @@
 #include "Input/TerminalKeyUp.h"
 #include "Display/PhysicalPixels.h"
 #include "Win32/Clipboard.h"
+#include <chrono>
 #include <dxgi1_3.h>
 #if __has_include("TerminalControl.g.cpp")
 #include "TerminalControl.g.cpp"
@@ -374,22 +375,47 @@ namespace winrt::GhosttyWin32::implementation
         // fires on a dead surface — but XAML can deliver a queued
         // SizeChanged after Detach during teardown, so we recheck
         // m_surface inside the handler under a strong lock.
+        //
+        // SizeChanged fires on every WM_SIZE during a drag-resize,
+        // and each SetSize triggers ghostty's renderer thread to
+        // reallocate the swap chain. Firing that reallocation many
+        // times per second is what produces the visible flicker
+        // during a drag: DWM composites intermediate frames at each
+        // in-flight buffer size while ghostty is midway through
+        // resizing again. Coalesce into a single SetSize per
+        // ~50 ms burst — for the fast-drag case the renderer only
+        // sees the last few sizes, and the panel's own composition
+        // engine (which stretches the current swap chain to the
+        // panel's DIP rectangle in the meantime) produces a smooth
+        // stretch instead of a flicker.
         auto weakSelf = get_weak();
-        m_sizeChangedToken = Panel().SizeChanged(
-            [weakSelf](Windows::Foundation::IInspectable const& sender,
-                       Microsoft::UI::Xaml::SizeChangedEventArgs const& args) {
+        auto dq = winrt::Microsoft::UI::Dispatching::DispatcherQueue::GetForCurrentThread();
+        m_pendingResizeTimer = dq ? dq.CreateTimer() : nullptr;
+        if (m_pendingResizeTimer) {
+            m_pendingResizeTimer.Interval(std::chrono::milliseconds{ 50 });
+            m_pendingResizeTimer.IsRepeating(false);
+            m_pendingResizeTimer.Tick([weakSelf](auto&&, auto&&) {
                 auto self = weakSelf.get();
                 if (!self || !self->m_surface) return;
-                // SizeChangedEventArgs.NewSize is in DIPs; ghostty's
-                // surface_set_size needs the swap-chain buffer
-                // resolution in physical pixels. display::ToPhysicalPixels
-                // does the multiplication and the CompositionScale=0
-                // fallback.
-                auto sz = args.NewSize();
-                auto panel = sender.as<Microsoft::UI::Xaml::Controls::SwapChainPanel>();
-                auto px = display::ToPhysicalPixels(panel, sz.Width, sz.Height);
-                if (px.width > 0 && px.height > 0) {
-                    self->m_surface.SetSize(px.width, px.height);
+                if (auto panel = self->Panel()) {
+                    auto px = display::MeasuredPhysical(panel);
+                    if (px.width > 0 && px.height > 0) {
+                        self->m_surface.SetSize(px.width, px.height);
+                    }
+                }
+            });
+        }
+        m_sizeChangedToken = Panel().SizeChanged(
+            [weakSelf](Windows::Foundation::IInspectable const&,
+                       Microsoft::UI::Xaml::SizeChangedEventArgs const&) {
+                auto self = weakSelf.get();
+                if (!self || !self->m_surface) return;
+                // Restart the debounce window; the timer's Tick will
+                // read the panel's current ActualWidth/Height and
+                // push the final size. Firing SetSize inline here
+                // would defeat the coalescing.
+                if (self->m_pendingResizeTimer) {
+                    self->m_pendingResizeTimer.Start();
                 }
             });
 
@@ -462,6 +488,15 @@ namespace winrt::GhosttyWin32::implementation
             // GC catches up.
             m_editContext.NotifyFocusLeave();
             m_editContext = nullptr;
+        }
+
+        // Stop the SizeChanged debounce timer first — its Tick reads
+        // m_surface, so letting it fire after we've dropped the
+        // handle below would AV. The weak_ref inside the callback
+        // guards the get() but stopping is cheap and clearer.
+        if (m_pendingResizeTimer) {
+            try { m_pendingResizeTimer.Stop(); }
+            catch (winrt::hresult_error const&) {}
         }
 
         if (auto panel = Panel()) {

--- a/App/TerminalControl.xaml.h
+++ b/App/TerminalControl.xaml.h
@@ -220,6 +220,14 @@ namespace winrt::GhosttyWin32::implementation
         // from input handlers.
         HWND m_hostHwnd{ nullptr };
         winrt::event_token m_sizeChangedToken{};
+        // Non-repeating 50 ms debounce for the SizeChanged handler.
+        // Started (and re-started) on every SizeChanged; its Tick reads
+        // the panel's current physical footprint and pushes the final
+        // size to ghostty. Coalescing avoids the drag-resize flicker
+        // caused by the renderer thread reallocating the swap chain
+        // once per WM_SIZE.
+        winrt::Microsoft::UI::Dispatching::DispatcherQueueTimer
+            m_pendingResizeTimer{ nullptr };
         // SwapChainPanel composition scale (DPI / per-monitor scale)
         // tracking. The panel's CompositionScale can lag behind the
         // window's DPI on RDP — initially the panel reports 1.0 even


### PR DESCRIPTION
## Summary

Two edits landed together because they show up as a single "the terminal doesn't quite fill the window" impression (reported specifically against nvim, but neither change is nvim-specific):

1. **Ceil the DIP → physical-pixel conversion.** `display::ToPhysicalPixels` was truncating. A DIP width of 1919.6 at 1.5× scale is 2879.4 physical pixels; the truncating cast produced 2879 while DWM asked the panel to cover 2880, leaving a hairline gap on the far edge where the scaled swap-chain content didn't reach. `std::ceil` guarantees the swap chain fully covers the panel's physical rectangle; any subpixel overshoot is invisible (composition clips).

2. **Debounce `Panel.SizeChanged` → `SetSize` at 50 ms.** SizeChanged was calling `m_surface.SetSize` on every `WM_SIZE`. During a drag-resize that fires many times per second, each triggering ghostty's renderer thread to reallocate the swap chain. DWM composites intermediate frames at each in-flight buffer size while ghostty is midway through resizing again — that's the visible "fast flicker" on window resize. Coalesce with a non-repeating `DispatcherQueueTimer` — every SizeChanged just `Start()`s it (restarting the countdown), and its Tick reads the panel's current physical footprint and pushes the final size. The panel's own composition engine stretches the current swap chain to the panel's DIP rectangle in the meantime, so the drag feels like a smooth stretch instead of a flicker.

<details><summary>日本語</summary>

nvim で報告された 2 症状 (「表示全体がずれてる (ウインドウとテーマの境目に余白/重なり)」と「リサイズ時に高速なちらつき」) が、実は根が別々の 2 修正で同時にケアできる話だったので 1 PR に:

1. **DIP → 物理ピクセル変換の丸めを truncate から ceil に。** `display::ToPhysicalPixels` は truncate していた。DIP 1919.6 × 1.5 スケール = 物理 2879.4 → truncate で 2879。DWM が panel に 2880 を要求 → 右端 1 px にスワップチェーンが届かず薄い隙間。`std::ceil` で必ず panel の物理矩形を覆う。subpixel の overshoot は composition が clip して不可視。

2. **`Panel.SizeChanged` → `SetSize` を 50 ms debounce。** SizeChanged が WM_SIZE ごとに `SetSize` を呼んでいた。drag-resize では毎秒何十回発火 → 毎回 ghostty のレンダースレッドがスワップチェーン再確保 → DWM は各中間 buffer サイズの frame を合成する → これが「リサイズ時のちらつき」の正体。非繰り返しの `DispatcherQueueTimer` で coalesce: SizeChanged はタイマーを `Start()` (カウントダウン再開) するだけ、Tick で最終サイズを push。debounce 中は panel の合成エンジンが現行スワップチェーンを DIP 矩形に stretch するので、ちらつきの代わりに滑らかな stretch に見える。

</details>

## Detach interaction

`Detach` now stops `m_pendingResizeTimer` before dropping the surface — the weak_ref inside the Tick already guards against firing after the control is gone, but Stopping explicitly is cheap and reads more obviously safe.

<details><summary>日本語</summary>

`Detach` で `m_pendingResizeTimer.Stop()` を追加。Tick 内の weak_ref 経由の get() は既に garbage guard として働くが、明示 Stop の方が読み手にとって意図が明確。

</details>

## Verification

- [ ] `nvim README.md` — visual: content fills the pane to the far edge, no hairline gap between the terminal cells and the window/theme border
- [ ] Drag-resize the window with `nvim` open (or `tmux`, `htop`) — no rapid flicker; content stretches smoothly then snaps to the correct rendered size after ~50 ms of stillness
- [ ] Multi-tab / split-pane resize behaviour unchanged (each pane's own timer coalesces independently)
- [ ] DPI change (drag to another monitor) still updates cell resolution correctly — `CompositionScaleChanged` path calls `SetSize` inline (not debounced), matching existing behaviour
