### PR TITLE
Refresh newly-active tab's surfaces on switch to clear ghost emoji frame

### DIFF
--- a/App/MainWindow.xaml.cpp
+++ b/App/MainWindow.xaml.cpp
@@ -632,6 +632,43 @@ namespace winrt::GhosttyWin32::implementation
                     // parented; the swap chain handle keeps its DComp
                     // binding across the switch.
                     self->UpdateActivePanelVisibility();
+                    // Ghost-frame guard for the tab we just brought
+                    // back: while its SplitPanel was Collapsed, DComp
+                    // stopped compositing but the SwapChainPanel's
+                    // last-presented buffer stayed put. When we flip
+                    // back to Visible the compositor shows that stale
+                    // buffer until the renderer thread produces a
+                    // fresh present — which for the "was unfocused,
+                    // now focused" surface takes at least one hybrid-
+                    // cadence tick, long enough for the eye to catch
+                    // (most obviously with emoji glyphs). Refresh
+                    // every leaf in the newly-active tab so ghostty's
+                    // renderer produces a full frame right away and
+                    // the stale content never gets a chance to show.
+                    if (auto* tab = self->ActiveTab()) {
+                        if (auto* panelImpl =
+                                winrt::get_self<implementation::SplitPanel>(tab->Panel())) {
+                            // Inline recursion (rather than reusing
+                            // CollectLeaves defined further down in
+                            // this file) so this can sit close to the
+                            // SelectionChanged handler where the rest
+                            // of the tab-switch bookkeeping lives.
+                            struct RefreshLeaves {
+                                void operator()(Pane* node) {
+                                    if (!node) return;
+                                    if (node->IsLeaf()) {
+                                        if (auto* tc = Tab::LeafToTerminalControl(*node)) {
+                                            tc->Surface().Refresh();
+                                        }
+                                        return;
+                                    }
+                                    (*this)(node->First());
+                                    (*this)(node->Second());
+                                }
+                            } refresh;
+                            refresh(panelImpl->Root());
+                        }
+                    }
                     // Defer Focus to the next dispatcher tick. The
                     // synchronous Focus call races XAML's own focus
                     // migration when the previously-active panel just


### PR DESCRIPTION
## Summary

Switching tabs left emoji (and any other content) from the target tab's previous state visible for a beat on the way back. Fix by refreshing every leaf in the newly-active tab from the `SelectionChanged` handler so the renderer produces a fresh present immediately.

<details><summary>日本語</summary>

タブを切り替えたとき、戻り先タブの前回状態の絵文字 (や他の内容) が一瞬残って見える現象があった。`SelectionChanged` のハンドラで新アクティブタブの全 leaf の surface を `Refresh` して、レンダラーに即時再描画させることで解消する。

</details>

## Why the ghost

While a tab's `SplitPanel` is `Collapsed`, DComp stops compositing it but the `SwapChainPanel`'s last-presented buffer stays put. When we flip back to `Visible` the compositor shows that stale buffer until the renderer thread produces a fresh present — and for a surface that just transitioned from unfocused to focused, that takes at least one hybrid-cadence tick. The eye catches the delay, most obviously with emoji glyphs where the color-atlas contrast makes the residual pixels stand out.

Calling `ghostty_surface_refresh` on the tab-switch path forces libghostty to schedule a full frame straight away; by the time DComp gets around to compositing the newly-visible panel, the buffer has the current terminal state instead of the pre-hide snapshot.

<details><summary>日本語</summary>

タブの `SplitPanel` が `Collapsed` の間、DComp は合成を止めるが `SwapChainPanel` の最終 present バッファはそのまま残る。再び `Visible` になった瞬間、compositor はまずその古いバッファを composite し、レンダラースレッドが新規 present を出すまで表示され続ける。unfocused → focused 遷移直後の surface は hybrid-cadence の 1 tick 遅れが入るため、目に見えるほど長く残る — 特に絵文字はカラーアトラスのコントラストで残像がはっきり見える。

タブ切替パスで `ghostty_surface_refresh` を叩けば libghostty が即座にフル frame を予約する → DComp が新パネルを composite する頃には現在のターミナル状態が入っている、という寸法。

</details>

## Implementation

- `SelectionChanged` handler in `MainWindow.xaml.cpp` — after `UpdateActivePanelVisibility` (Collapsed→Visible flip) and before the deferred `Focus`, walk the newly-active tab's `SplitPanel` tree and call `Surface().Refresh()` on every leaf's `TerminalControl`.
- Inline recursion (rather than reusing `CollectLeaves` defined further down in the same file) keeps the change local to the tab-switch bookkeeping and sidesteps the forward-reference tangle that would otherwise need a declaration higher in the file — same pattern used by the `TryClose` walk from #112.

<details><summary>日本語</summary>

- `MainWindow.xaml.cpp` の `SelectionChanged` ハンドラ、`UpdateActivePanelVisibility` (Collapsed→Visible フリップ) の直後、Focus の defer より前に、新アクティブタブの `SplitPanel` tree を歩き、各 leaf の `TerminalControl` の `Surface().Refresh()` を呼ぶ。
- ファイル末尾の `CollectLeaves` を借りるのではなくインライン再帰にしたのは、変更をタブ切替周りに閉じるため、および forward-reference の面倒を避けるため (#112 の `TryClose` と同パターン)。

</details>

## Verification

- [ ] `echo "🚀"` in tab A, switch to tab B, switch back — no residual emoji visible in the moment before the fresh frame arrives
- [ ] Same with multi-line emoji output; no residual in the previously-shown region
- [ ] Tab switch feels the same latency-wise (Refresh is a scheduling hint, no synchronous work)
- [ ] Split-pane tab: every pane in the newly-active tab refreshes (not just the focused one)
