### PR TITLE
Refresh active tab on window activation to clear leftover emoji cell backgrounds

### DIFF
--- a/App/MainWindow.xaml.cpp
+++ b/App/MainWindow.xaml.cpp
@@ -268,6 +268,38 @@ namespace winrt::GhosttyWin32::implementation
                                         tc->Surface().SetFocus(true);
                                     }
                                 }
+                                // Emoji cells (double-width, colored)
+                                // sometimes come out of an alt-tab
+                                // cycle with black padding around the
+                                // glyph — the previously-presented
+                                // buffer's diff render doesn't fully
+                                // repaint the background half of the
+                                // cell to the terminal bg. They come
+                                // right after a natural redraw (I/O,
+                                // cursor blink) a beat later. Force a
+                                // full-frame refresh on every leaf in
+                                // the active tab so the correction
+                                // lands immediately instead of on the
+                                // next unrelated draw.
+                                if (auto* tab = self->ActiveTab()) {
+                                    if (auto* panelImpl =
+                                            winrt::get_self<implementation::SplitPanel>(tab->Panel())) {
+                                        struct RefreshLeaves {
+                                            void operator()(Pane* node) {
+                                                if (!node) return;
+                                                if (node->IsLeaf()) {
+                                                    if (auto* tc = Tab::LeafToTerminalControl(*node)) {
+                                                        tc->Surface().Refresh();
+                                                    }
+                                                    return;
+                                                }
+                                                (*this)(node->First());
+                                                (*this)(node->Second());
+                                            }
+                                        } refresh;
+                                        refresh(panelImpl->Root());
+                                    }
+                                }
                             } catch (winrt::hresult_error const&) {
                             }
                         });


### PR DESCRIPTION
## Summary

Emoji cells sometimes come out of an alt-tab cycle with a black rectangle around the glyph. The artifact clears on the next unrelated draw (typing, cursor blink, incoming output), so users see the wrong background for however long that next draw takes. Force a full-frame refresh on the active tab's leaves when the window's OS activation state goes back to Activated, so the correction lands right away.

<details><summary>日本語</summary>

alt-tab で Ghostty に戻ってくると、絵文字セルのグリフ周辺が黒い矩形として残ることがある。次の描画 (タイプ入力、カーソル点滅、シェル出力) が入るとその瞬間に消える = それまでの数秒間ユーザーには誤った背景色が見える状態。ウインドウの OS activation 状態が Deactivated → Activated に戻ったタイミングで active tab の全 leaf に refresh を fire して即座に補正させる。

</details>

## Root cause note

The wrong background is coming from libghostty's Windows DirectX renderer — the diffing logic doesn't fully repaint the background half of a double-width color-atlas cell after the swap chain's front buffer changed under it. Plumbing the fix upstream is the right long-term answer; this PR is the host-side workaround that gets the fresh redraw scheduled at the exact moment the user notices ("I just alt-tabbed back").

<details><summary>日本語</summary>

背景色ずれ自体の原因は libghostty (Windows DirectX renderer) 側の diff 描画ロジックで、ダブル幅カラーアトラスセルの背景側半分がスワップチェインのフロントバッファ変動後にちゃんと再描画されていない。根本修正は upstream で入れるのが本筋。本 PR はユーザーが気付いた瞬間 (「alt-tab で戻った瞬間」) にフレッシュな描画を投げるホスト側のワークアラウンド。

</details>

## Implementation

In the existing `Window.Activated` handler's restored-branch deferred lambda, after the existing `SetFocus(true)` (which puts libghostty back on the focused cadence), walk the active tab's `SplitPanel` tree and call `Surface().Refresh()` on every leaf. Inline recursion (rather than reusing `CollectLeaves` further down in the file) keeps the change confined to the activation path, matching the pattern used by the other tree walks in this file.

<details><summary>日本語</summary>

既存の `Window.Activated` ハンドラの restored-branch (deferred lambda) 内、`SetFocus(true)` (libghostty を focused cadence に戻す) の直後に、active tab の `SplitPanel` tree を歩いて各 leaf の `Surface().Refresh()` を叩く。ファイル末尾の `CollectLeaves` を借りるのではなくインライン再帰 — activation 経路に閉じたコードにするため、および同ファイル内の他のツリー走査と同パターンにするため。

</details>

## Verification

- [ ] `echo "🚀"` (or any double-width emoji), alt-tab to another app, alt-tab back — no lingering black rectangle around the emoji
- [ ] Same with several emoji on different lines
- [ ] Deactivate → activate the window quickly a few times in a row — no visible artifact between cycles
- [ ] Regular (non-emoji) cells unchanged: no flicker on alt-tab return
