### PR TITLE
Sync main into dev with -s ours after each release tag

### DIFF
--- a/.github/workflows/auto-tag-release-pr.yml
+++ b/.github/workflows/auto-tag-release-pr.yml
@@ -99,3 +99,35 @@ jobs:
           git tag -a "$VERSION" -m "Release $VERSION"
           git push origin "$VERSION"
           echo "Pushed tag $VERSION as ${APP_SLUG}[bot] → release.yml will fire."
+
+      # Record the just-tagged main commit as an ancestor of dev via
+      # a `-s ours` merge. Squash-merging the release PR into main
+      # produces a commit that ISN'T an ancestor of dev's history —
+      # dev still holds the individual PR commits that got squashed.
+      # Left as-is, every subsequent release PR's compare-base walks
+      # back to whichever commit was shared before the first squash,
+      # and the PR shows a 100+ file "diff" the reviewer has to scroll
+      # past + the notes generator lists every PR since v0.2.x. The
+      # `-s ours` strategy keeps dev's tree untouched (dev already has
+      # main's content, just split across PRs) but records main as
+      # merged, so the next release PR sees a sane merge-base.
+      #
+      # If the merge somehow conflicts (shouldn't — same content on
+      # both sides), warn and continue so the tag still triggers
+      # release.yml; the sync can be replayed manually.
+      - name: Record release in dev history
+        env:
+          VERSION: ${{ steps.ver.outputs.version }}
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+        run: |
+          set -euo pipefail
+          git fetch origin dev:dev
+          git checkout dev
+          if ! git merge -s ours --no-edit main \
+               -m "Record v${VERSION#v} release in dev history"; then
+            echo "::warning::main→dev sync failed; leaving dev untouched. Run 'git merge -s ours main' on dev manually."
+            git merge --abort || true
+            exit 0
+          fi
+          git push origin dev
+          echo "Synced main into dev with an ours-strategy merge; next release PR will compare cleanly."


### PR DESCRIPTION
## Summary

Sync `main` into `dev` with `-s ours` right after the release tag is pushed, so the next release PR and its generated notes both compare against a sane merge-base.

<details><summary>日本語</summary>

release tag を push した直後に `-s ours` で `main` を `dev` に merge する。次回以降の release PR 差分と自動生成 notes が正しい merge-base で比較されるようになる。

</details>

## Why

The release PR flow squash-merges `dev` into `main`. The resulting commit isn't an ancestor of `dev`'s history — `dev` still holds the individual PR commits that were squashed. Every subsequent release PR then compares against a merge-base back before `v0.4.0`, so the GitHub UI shows a 100+ file "diff" (the reviewer has to scroll past every pre-`v0.4.0` PR that touched the same files) and `generate-notes` lists every PR since `v0.2.x` regardless of what actually changed in this release.

v0.4.1 shipped with 100 files listed in the PR diff and 45 PRs in the release notes; v0.4.2 (a single-file submodule bump) hit the same trap.

<details><summary>日本語</summary>

release PR フローは `dev` を `main` に squash-merge する。生成された commit は `dev` の履歴の ancestor にならない — `dev` は squash 前の個別 PR commit を保持したまま。以降の release PR は `v0.4.0` の遥か前まで遡った merge-base で比較され、GitHub UI では 100+ files の "diff" (`v0.4.0` 以前で同じファイルを触った全 PR がスクロール対象になる) 、`generate-notes` はそのリリースで実際に変わったものと関係なく `v0.2.x` 以降の全 PR を列挙する状態だった。

v0.4.1 は PR diff 100 files / release notes 45 PRs で shipped、v0.4.2 (submodule bump 1 file) も同じ罠に落ちていた。

</details>

## Fix

Add a step to `auto-tag-release-pr.yml` after the tag push:

```yaml
- name: Record release in dev history
  run: |
    git fetch origin dev:dev
    git checkout dev
    git merge -s ours --no-edit main -m "Record v${VERSION#v} release in dev history"
    git push origin dev
```

`-s ours` keeps `dev`'s tree exactly as-is (`dev` already has `main`'s content, just split across the individual PRs) but records `main` as merged so it becomes an ancestor of `dev`. The next release PR then sees a sane merge-base, its diff shrinks to just the new PRs, and the notes generator anchors correctly.

Merge failures (shouldn't happen — same content on both sides) are warned but not fatal; the tag still fires `release.yml`, and the sync can be replayed manually.

<details><summary>日本語</summary>

`auto-tag-release-pr.yml` にタグ push 直後の step を追加:

```yaml
- name: Record release in dev history
  run: |
    git fetch origin dev:dev
    git checkout dev
    git merge -s ours --no-edit main -m "Record v${VERSION#v} release in dev history"
    git push origin dev
```

`-s ours` は `dev` の tree を完全に維持する (`dev` は既に個別 PR で `main` と同じ内容を持っている) が、`main` を merge 済みとして記録し `dev` の ancestor にする。以降の release PR は正しい merge-base で比較され、diff は新規 PR ぶんだけに縮み、notes generator も正しく anchor する。

merge conflict (両側同じ内容なので起きないはず) が起きた時は warning を出して続行、tag は `release.yml` を発火するし、sync は手動で replay できる。

</details>

## One-off initial sync

v0.4.0 と v0.4.1 の squash-merged 履歴で既に発生していた divergence は、この workflow がまだ ship していない時点でも解消しておく必要がある。以下を直接 push 済み:

- `dev` に `a52d0ee` (Record main squash-merges (v0.4.0, v0.4.1) as an ancestor of dev)
- `release/v0.4.2` に `ebf47f3` (Record v0.4.1 as an ancestor of release/v0.4.2)

PR #120 の diff が **100 files → 1 file** に縮小されたのはこの手動 sync のおかげ。

<details><summary>English</summary>

The already-diverged history from v0.4.0 and v0.4.1's squash-merges needed to be untangled before this workflow ships. Direct-pushed:

- `dev`: `a52d0ee` (Record main squash-merges (v0.4.0, v0.4.1) as an ancestor of dev)
- `release/v0.4.2`: `ebf47f3` (Record v0.4.1 as an ancestor of release/v0.4.2)

That's why PR #120's diff shrank from 100 files to 1 file.

</details>

## Verification

- [ ] Next release cycle: cut RC / open release PR, confirm the PR diff shows only the new PRs (not 100+ files) and the auto-generated notes anchor cleanly at the previous release
- [ ] `auto-tag-release-pr.yml` run after a release PR merge logs "Synced main into dev with an ours-strategy merge"
- [ ] `git log --oneline main..dev` after a release shows the `-s ours` merge commit at the top
