### PR TITLE
Model window close as a state-machine (WindowCloseGate) + expand confirmation to every close path

### DIFF
--- a/App/App.vcxproj
+++ b/App/App.vcxproj
@@ -170,6 +170,7 @@
     <ClInclude Include="TerminalControl.xaml.h">
       <DependentUpon>TerminalControl.xaml</DependentUpon>
     </ClInclude>
+    <ClInclude Include="WindowCloseGate.h" />
   </ItemGroup>
   <ItemGroup>
     <ApplicationDefinition Include="App.xaml" />

--- a/App/MainWindow.xaml.cpp
+++ b/App/MainWindow.xaml.cpp
@@ -39,6 +39,19 @@ namespace muxc = Microsoft::UI::Xaml::Controls;
 namespace winrt::GhosttyWin32::implementation
 {
     MainWindow::MainWindow()
+        // Wire the close-flow state machine. Ops capture `this` — the
+        // gate is a member of this MainWindow, so the captured pointer
+        // outlives every callback fired through it. Callbacks are
+        // never invoked before the ctor body finishes (RequestClose is
+        // triggered by UI events, not construction).
+        : m_closeGate(WindowCloseGate::Ops{
+            [this](CloseScope const& s) { return NeedsConfirmForScope(s); },
+            [this](CloseScope const& s,
+                   std::function<void(bool)> onDecision) {
+                ShowCloseDialog(s, std::move(onDecision));
+            },
+            [this](CloseScope const& s) { ExecuteClose(s); },
+          })
     {
         // Adopt the App-scope ghostty wrapper as a class invariant.
         // App::OnLaunched created ghostty before make<MainWindow>()
@@ -91,6 +104,13 @@ namespace winrt::GhosttyWin32::implementation
             if (App::g_app) App::g_app->Windows().Register(this);
             auto windowNative = this->try_as<::IWindowNative>();
             if (windowNative) windowNative->get_WindowHandle(&m_hwnd);
+            // Install the WM_CLOSE intercept as soon as the HWND
+            // exists so Alt+F4 / OS-issued close routes through
+            // m_closeGate the same way the custom title-bar X does.
+            // Safe before the tab tree is built — the gate's Ops
+            // handle an empty m_tabs correctly (no tabs → no confirm
+            // needed → immediate execute).
+            HookCloseSignal();
             // The pre-first-frame hide avoids flashing an empty window
             // before ghostty presents. A drop host receives a tab that
             // is already presenting, so it has frames to show from the
@@ -557,55 +577,14 @@ namespace winrt::GhosttyWin32::implementation
                 walk(tv);
             });
 
-            tv.TabCloseRequested([this](muxc::TabView const& sender, muxc::TabViewTabCloseRequestedEventArgs const& args) {
-                auto item = args.Tab();
-                // Detach the control BEFORE removing it from TabView.
-                // Detach calls ISwapChainPanelNative2::SetSwapChainHandle(nullptr)
-                // on the inner panel, and that call AVs at +0x1F8 inside
-                // microsoft.ui.xaml.dll if the panel has already been
-                // unparented from the live visual tree (reproducer:
-                // Ctrl+Shift+W long-press across multiple tabs, where
-                // XAML hasn't finished processing the previous RemoveAt
-                // when the next Detach kicks in). Doing it pre-RemoveAt
-                // keeps the panel in the live tree for the duration of
-                // SetSwapChainHandle. Detach is idempotent, so the
-                // ~Tab → ~TerminalControl path runs it again as a no-op.
-                if (auto* t = m_tabs.FindByItem(item)) {
-                    // Detach every pane in the tab, not just the active
-                    // one — multi-pane tabs have multiple swap chains
-                    // and each needs SetSwapChainHandle(nullptr) before
-                    // the panel is unparented.
-                    t->DetachAll();
-                }
-                uint32_t idx = 0;
-                if (sender.TabItems().IndexOf(item, idx)) {
-                    sender.TabItems().RemoveAt(idx);
-                }
-                DwmFlush();              // wait for compositor to release
-                if (sender.TabItems().Size() == 0) {
-                    // Last tab: defer Tab object destruction to
-                    // ~MainWindow's m_tabs.Clear. Tearing down the
-                    // focused control synchronously here leaves XAML's
-                    // focus subsystem holding a stale pointer that AVs
-                    // at +0x1F8 once mw->Close() kicks off window
-                    // teardown — same path as a normal title-bar X
-                    // close, which works fine precisely because XAML
-                    // finishes its own focus cleanup before our
-                    // destructors run. The orphan SplitPanel under
-                    // AppContent comes down with the window, no
-                    // explicit Remove needed.
-                    this->Close();
-                } else {
-                    // Unparent the panel from AppContent before
-                    // destroying the Tab. ~Tab doesn't touch the
-                    // visual tree (Tab doesn't know about AppContent),
-                    // so without this the panel would leak as an
-                    // orphan child of AppContent.
-                    if (auto* t = m_tabs.FindByItem(item)) {
-                        RemoveTabPanelFromAppContent(*t);
-                    }
-                    m_tabs.Remove(item);
-                }
+            tv.TabCloseRequested([this](muxc::TabView const&,
+                                         muxc::TabViewTabCloseRequestedEventArgs const& args) {
+                // Route through the gate so tab-header X gets the same
+                // confirmation gate as the window X, keybind, and Alt+F4.
+                // The gate's execute callback for Tab scope forwards to
+                // PerformTabClose which owns the DetachAll / RemoveAt /
+                // last-tab-triggers-window-close sequence.
+                m_closeGate.RequestClose(CloseScope::Tab(args.Tab()));
             });
 
             // Whenever the selected tab changes — explicit click on a
@@ -768,6 +747,34 @@ namespace winrt::GhosttyWin32::implementation
             }
             return DefSubclassProc(hwnd, msg, wp, lp);
         }
+
+        // Distinct slot from SizeLimit (id=1) and SystemTheme (id=2)
+        // so all three subclasses coexist on the same HWND.
+        constexpr UINT_PTR kCloseConfirmSubclassId = 3;
+
+        LRESULT CALLBACK CloseConfirmSubclassProc(
+            HWND hwnd, UINT msg, WPARAM wp, LPARAM lp,
+            UINT_PTR /*id*/, DWORD_PTR ref) noexcept
+        {
+            if (msg == WM_CLOSE) {
+                // Alt+F4 / OS-issued close comes through here. If the
+                // gate is already progressing a Window-scope close
+                // (execute() was reached — Close() has been called and
+                // this is the follow-up WM_CLOSE the framework posts),
+                // let the default handler destroy the window. Otherwise
+                // route to the gate, which shows the confirmation
+                // dialog and only calls execute (which posts another
+                // WM_CLOSE) on approve.
+                if (auto* self = reinterpret_cast<MainWindow*>(ref)) {
+                    auto& gate = self->CloseGate();
+                    if (!gate.WindowCloseInProgress()) {
+                        gate.RequestClose(CloseScope::Window());
+                        return 0;  // swallow: gate owns the follow-up
+                    }
+                }
+            }
+            return DefSubclassProc(hwnd, msg, wp, lp);
+        }
     }
 
     void MainWindow::HookSystemThemeSignal() noexcept
@@ -775,6 +782,14 @@ namespace winrt::GhosttyWin32::implementation
         if (!m_hwnd) return;
         SetWindowSubclass(m_hwnd, &SystemThemeSubclassProc,
                           kSystemThemeSubclassId,
+                          reinterpret_cast<DWORD_PTR>(this));
+    }
+
+    void MainWindow::HookCloseSignal() noexcept
+    {
+        if (!m_hwnd) return;
+        SetWindowSubclass(m_hwnd, &CloseConfirmSubclassProc,
+                          kCloseConfirmSubclassId,
                           reinterpret_cast<DWORD_PTR>(this));
     }
 
@@ -996,75 +1011,135 @@ namespace winrt::GhosttyWin32::implementation
 
     void MainWindow::TryClose()
     {
-        // Walk every leaf in every tab: if any surface reports
-        // needs_confirm_quit=true, gate the close on a
-        // WinUI ContentDialog. Otherwise close straight through.
-        //
-        // ghostty_surface_needs_confirm_quit already factors in the
-        // `confirm-close-surface` config, so users who set it false
-        // sail through without a dialog on every close.
-        //
-        // Inline recursion (rather than reusing CollectLeaves defined
-        // later in this file) so this can sit close to RequestClose
-        // where the surrounding close-path handlers already live.
-        struct Check {
-            bool any = false;
-            void operator()(Pane* node) {
-                if (any || !node) return;
-                if (node->IsLeaf()) {
-                    if (auto* tc = Tab::LeafToTerminalControl(*node)) {
-                        if (tc->Surface().NeedsConfirmQuit()) any = true;
-                    }
-                    return;
-                }
-                (*this)(node->First());
-                (*this)(node->Second());
+        // Thin adapter: the IWindow-level "confirm the whole window
+        // close" call funnels into the same gate every other entry
+        // point uses. The gate consults NeedsConfirmForScope, renders
+        // the dialog via ShowCloseDialog, and executes through
+        // ExecuteClose — all methods on this class, wired up in the
+        // constructor's Ops.
+        m_closeGate.RequestClose(CloseScope::Window());
+    }
+
+    bool MainWindow::NeedsConfirmForScope(CloseScope const& scope)
+    {
+        // Predicate for WindowCloseGate.Ops.needsConfirm. Window scope
+        // walks every tab (any tab with a running-process surface
+        // triggers the prompt); Tab scope defers to Tab's own
+        // NeedsConfirmClose — the tab owns its pane tree so it's the
+        // right home for that query. ghostty_surface_needs_confirm_quit
+        // already respects the `confirm-close-surface` config, so users
+        // who set it false sail through without a dialog on every close.
+        if (scope.kind() == CloseScope::Kind::Window) {
+            for (auto& tab : m_tabs) {
+                if (tab && tab->NeedsConfirmClose()) return true;
             }
-        };
-        Check check;
-        for (auto& tab : m_tabs) {
-            if (!tab) continue;
-            auto* panelImpl =
-                winrt::get_self<implementation::SplitPanel>(tab->Panel());
-            if (!panelImpl) continue;
-            check(panelImpl->Root());
-            if (check.any) break;
+            return false;
         }
-        bool anyNeedsConfirm = check.any;
+        auto* tab = m_tabs.FindByItem(scope.tabItem());
+        return tab && tab->NeedsConfirmClose();
+    }
 
-        if (!anyNeedsConfirm) {
-            RequestClose();
-            return;
-        }
-
-        // XamlRoot is required for a ContentDialog to know which
-        // Window / island to overlay. Fall back to a plain close
-        // if the tree isn't realised yet (shouldn't happen — a
-        // close reaching TryClose means the window has been shown).
+    void MainWindow::ShowCloseDialog(CloseScope const& scope,
+                                     std::function<void(bool)> onDecision)
+    {
+        // XamlRoot is required for ContentDialog to know which Window
+        // / island to overlay. If the tree isn't realised (shouldn't
+        // reach here in practice — the gate only calls showDialog for
+        // an in-flight window that has surfaces), treat as approved
+        // rather than hanging: the alternative is a silent no-op that
+        // looks like the app ignored the close.
         auto content = Content();
         auto xamlRoot = content ? content.XamlRoot() : nullptr;
         if (!xamlRoot) {
-            RequestClose();
+            onDecision(true);
             return;
         }
 
+        // Body text is scope-specific — a window-close warning reads
+        // differently from a single-tab warning even if both come from
+        // the same "still has running processes" condition.
+        winrt::hstring body{ scope.kind() == CloseScope::Kind::Window
+            ? L"One or more terminals in this window still have running "
+              L"processes. They will be terminated."
+            : L"This tab has a terminal with a running process. "
+              L"It will be terminated." };
+
         muxc::ContentDialog dlg;
         dlg.XamlRoot(xamlRoot);
-        dlg.Title(winrt::box_value(winrt::hstring{ L"Close window?" }));
-        dlg.Content(winrt::box_value(winrt::hstring{
-            L"One or more terminals in this window still have running "
-            L"processes. They will be terminated." }));
+        dlg.Title(winrt::box_value(winrt::hstring{ L"Close?" }));
+        dlg.Content(winrt::box_value(body));
         dlg.PrimaryButtonText(L"Close");
         dlg.CloseButtonText(L"Cancel");
         dlg.DefaultButton(muxc::ContentDialogButton::Close);
 
         auto op = dlg.ShowAsync();
-        auto weak = get_weak();
-        op.Completed([weak](auto&& sender, auto&& status) {
-            if (status != winrt::Windows::Foundation::AsyncStatus::Completed) return;
-            if (sender.GetResults() != muxc::ContentDialogResult::Primary) return;
-            if (auto self = weak.get()) self->RequestClose();
+        op.Completed([onDecision = std::move(onDecision)]
+                     (auto&& sender, auto&& status) {
+            bool approved =
+                status == winrt::Windows::Foundation::AsyncStatus::Completed &&
+                sender.GetResults() == muxc::ContentDialogResult::Primary;
+            onDecision(approved);
         });
+    }
+
+    void MainWindow::ExecuteClose(CloseScope const& scope)
+    {
+        if (scope.kind() == CloseScope::Kind::Window) {
+            // Drop the whole window. RequestClose calls Window::Close,
+            // which posts WM_CLOSE; the subclass sees
+            // m_closeGate.WindowCloseInProgress() and lets the default
+            // handler proceed (no re-prompt).
+            RequestClose();
+            return;
+        }
+        PerformTabClose(scope.tabItem());
+    }
+
+    void MainWindow::PerformTabClose(
+        winrt::Microsoft::UI::Xaml::Controls::TabViewItem const& item)
+    {
+        // Mechanics of closing a single tab. No confirmation here —
+        // the gate has already vetted this call. Sequence matters:
+        //
+        //   1. Detach every pane's TerminalControl. Detach calls
+        //      ISwapChainPanelNative2::SetSwapChainHandle(nullptr) on
+        //      the inner panel; that call AVs at +0x1F8 inside
+        //      microsoft.ui.xaml.dll if the panel has already been
+        //      unparented from the live visual tree (reproducer:
+        //      Ctrl+Shift+W long-press across multiple tabs, where
+        //      XAML hasn't finished processing the previous RemoveAt
+        //      when the next Detach kicks in). Doing it pre-RemoveAt
+        //      keeps the panel in the live tree for the duration of
+        //      SetSwapChainHandle. Detach is idempotent, so ~Tab →
+        //      ~TerminalControl runs it again as a no-op.
+        //   2. RemoveAt from TabView, then DwmFlush so the compositor
+        //      finishes releasing before we touch anything else.
+        //   3a. Last tab: fall through to a whole-window close via
+        //       RequestClose. The Tab object itself is destroyed by
+        //       ~MainWindow's m_tabs.Clear — tearing it down
+        //       synchronously here leaves XAML's focus subsystem
+        //       holding a stale pointer that AVs at +0x1F8 once
+        //       Close() kicks off window teardown.
+        //   3b. Otherwise unparent the SplitPanel from AppContent
+        //       before destroying the Tab (~Tab doesn't touch the
+        //       visual tree, so without this the panel would leak as
+        //       an orphan child).
+        auto* t = m_tabs.FindByItem(item);
+        if (t) t->DetachAll();
+        auto tv = TabView();
+        uint32_t idx = 0;
+        if (tv.TabItems().IndexOf(item, idx)) {
+            tv.TabItems().RemoveAt(idx);
+        }
+        DwmFlush();
+        if (tv.TabItems().Size() == 0) {
+            RequestClose();
+            return;
+        }
+        if (t) {
+            RemoveTabPanelFromAppContent(*t);
+            m_tabs.Remove(item);
+        }
     }
 
     void MainWindow::InitGhostty()
@@ -1290,31 +1365,12 @@ namespace winrt::GhosttyWin32::implementation
 
     void MainWindow::CloseTabBySurface(ghostty_surface_t surface)
     {
-        // Mirror the TabCloseRequested handler — see there for why
-        // Detach runs before RemoveAt and why the last tab's Tab
-        // destruction is deferred to ~MainWindow.
+        // CLOSE_SURFACE / CLOSE_TAB keybind path (Ctrl+Shift+W). Route
+        // through the gate so this affordance gets the same
+        // confirmation as the tab-header X and the custom title-bar X.
         auto* t = m_tabs.FindBySurface(surface);
         if (!t) return;
-        auto item = t->Item();
-        // CLOSE_TAB closes the whole tab regardless of pane count —
-        // detach every leaf so each swap chain handle is cleared
-        // before unparent.
-        t->DetachAll();
-        auto tv = TabView();
-        uint32_t idx = 0;
-        if (tv.TabItems().IndexOf(item, idx)) {
-            tv.TabItems().RemoveAt(idx);
-        }
-        DwmFlush();
-        if (tv.TabItems().Size() == 0) {
-            RequestClose();
-        } else {
-            // Mirror the TabCloseRequested handler: unparent the
-            // SplitPanel from AppContent before destroying the Tab so
-            // it doesn't leak as an orphan child.
-            RemoveTabPanelFromAppContent(*t);
-            m_tabs.Remove(item);
-        }
+        m_closeGate.RequestClose(CloseScope::Tab(t->Item()));
     }
 
     void MainWindow::GoToTab(int requested)
@@ -2354,13 +2410,13 @@ namespace winrt::GhosttyWin32::implementation
     void MainWindow::OnCloseClick(winrt::Windows::Foundation::IInspectable const&,
                                   winrt::Microsoft::UI::Xaml::RoutedEventArgs const&)
     {
-        // User-intent close → confirmation gate. TryClose walks the
-        // window's panes, shows a WinUI ContentDialog when any
-        // surface reports needs_confirm_quit, and only then calls
-        // through to RequestClose. Alt+F4 / OS-issued WM_CLOSE still
-        // bypasses this (would need a WndProc subclass), matching
-        // typical Windows-app behaviour where only the app's own
-        // close affordances confirm.
+        // User-intent close → confirmation gate. TryClose funnels into
+        // m_closeGate.RequestClose(Window scope); the gate walks all
+        // tabs, shows the ContentDialog when any surface reports
+        // needs_confirm_quit, and only executes on approve. Alt+F4 /
+        // OS-issued WM_CLOSE reaches the same gate through the
+        // CloseConfirmSubclassProc installed in HookCloseSignal, so
+        // the custom X and Alt+F4 now share the same prompt.
         TryClose();
     }
 

--- a/App/MainWindow.xaml.h
+++ b/App/MainWindow.xaml.h
@@ -14,6 +14,7 @@
 #include "Tabs/Tab.h"
 #include "Tabs/TabFactory.h"
 #include "Tabs/Tabs.h"
+#include "WindowCloseGate.h"
 
 namespace winrt::GhosttyWin32::implementation
 {
@@ -79,6 +80,12 @@ namespace winrt::GhosttyWin32::implementation
         void Tick() override;
         void RequestClose() override;
         void TryClose() override;
+        // Public accessor for the close-flow state machine so file-local
+        // helpers (the WM_CLOSE subclass proc, for one) can consult its
+        // invariants and enqueue close requests without befriending
+        // MainWindow. The gate itself is safe to expose — it protects
+        // its own invariants regardless of caller.
+        WindowCloseGate& CloseGate() noexcept { return m_closeGate; }
 
         // Split-pane operations from IMainWindowView. Bodies are in
         // MainWindow.xaml.cpp; behaviour is unchanged from when these
@@ -206,6 +213,32 @@ namespace winrt::GhosttyWin32::implementation
         // Tear down the pane carrying `id` and update the tree / tab
         // list. Dispatched from close_surface_cb. UI thread only.
         void CloseSurfaceByPaneId(PaneId id);
+
+        // ----- WindowCloseGate ops -----
+        // Predicates and effects the gate calls back into. Ordered here
+        // so the initializer for m_closeGate can reference them by
+        // address without needing full definitions inline. All three
+        // run on the UI thread — the gate itself has no threading of
+        // its own; showDialog just returns and the decision callback
+        // fires later on the dispatcher.
+        bool NeedsConfirmForScope(CloseScope const& scope);
+        void ShowCloseDialog(CloseScope const& scope,
+                             std::function<void(bool)> onDecision);
+        void ExecuteClose(CloseScope const& scope);
+        // Mechanics of closing a single tab (detach panes, remove from
+        // TabView, unparent panel, drop the Tab object; or trigger a
+        // full window close when it was the last tab). Callable without
+        // going through the gate — the gate's Tab-scope execute is a
+        // one-liner that forwards here.
+        void PerformTabClose(
+            Microsoft::UI::Xaml::Controls::TabViewItem const& item);
+
+        // Install a WM_CLOSE subclass so Alt+F4 / OS-issued close routes
+        // through m_closeGate the same way the custom title-bar X does.
+        // Idempotent; subclass is auto-removed when the HWND is
+        // destroyed. Called from the one-shot Activated after m_hwnd is
+        // captured.
+        void HookCloseSignal() noexcept;
 
         // The TerminalControl hosting the pane carrying `id`, or null
         // when no tab in this window owns it (already closed, or it
@@ -342,6 +375,16 @@ namespace winrt::GhosttyWin32::implementation
         // One tick of the poll. Body is inline in the .cpp; walks
         // m_tabs and updates the header where appropriate.
         void UpdateForegroundNames() noexcept;
+
+        // Close-flow state machine. Every user-facing close (custom X,
+        // tab-header X, close_surface keybind, WM_CLOSE subclass) funnels
+        // through here so the confirmation dialog invariants live in one
+        // named value rather than as scattered MainWindow fields. Declared
+        // last because the initializer references other members (m_tabs,
+        // TabView(), Content(), RequestClose) and member init runs in
+        // declaration order — the gate must be built after everything it
+        // will call into is already set up.
+        WindowCloseGate m_closeGate;
     };
 }
 

--- a/App/Tabs/Tab.h
+++ b/App/Tabs/Tab.h
@@ -121,6 +121,18 @@ public:
     winrt::GhosttyWin32::SplitPanel const& Panel() const noexcept { return m_panel; }
     Pane* ActiveLeaf() const noexcept { return m_activeLeaf; }
 
+    // Per-tab confirmation predicate: does any surface in this tab's
+    // pane tree currently report ghostty_surface_needs_confirm_quit?
+    // Owns the pane-tree walk here because Tab already owns the tree —
+    // callers (WindowCloseGate.Ops.needsConfirm for a Tab scope,
+    // MainWindow.TryClose iterating tabs for the window scope) get a
+    // straight bool rather than pulling the tree out and walking it
+    // themselves.
+    bool NeedsConfirmClose() const {
+        auto* panelImpl = winrt::get_self<implementation::SplitPanel>(m_panel);
+        return panelImpl && SubtreeNeedsConfirmClose(panelImpl->Root());
+    }
+
     // Retarget the active leaf — used by NEW_SPLIT (focus shifts to
     // the freshly-created pane), GOTO_SPLIT (direction-based pane
     // nav), and the pointer-focus path (a click on a non-active pane).
@@ -220,6 +232,19 @@ private:
         }
         DetachAllLeaves(node->First());
         DetachAllLeaves(node->Second());
+    }
+
+    // Depth-first test: any surface in this subtree currently reports
+    // needs_confirm_quit? Short-circuits at the first true — walks no
+    // further once the caller's answer is settled.
+    static bool SubtreeNeedsConfirmClose(Pane const* node) {
+        if (!node) return false;
+        if (node->IsLeaf()) {
+            auto const* tc = LeafToTerminalControl(*node);
+            return tc && tc->Surface().NeedsConfirmQuit();
+        }
+        return SubtreeNeedsConfirmClose(node->First()) ||
+               SubtreeNeedsConfirmClose(node->Second());
     }
 
     // SplitPanel owns the Pane tree (via its own m_root). The host

--- a/App/WindowCloseGate.h
+++ b/App/WindowCloseGate.h
@@ -1,0 +1,146 @@
+#pragma once
+
+#include <winrt/Microsoft.UI.Xaml.Controls.h>
+#include <functional>
+#include <utility>
+
+namespace winrt::GhosttyWin32::implementation {
+
+// Value type describing what a user wants closed. Passed through the
+// gate as a single argument so entry points (custom X button, tab-header
+// X, close_surface keybind, WM_CLOSE subclass) fund into the same
+// RequestClose signature — they just build a different scope.
+//
+// Two constructors, two kinds:
+//   * Window: the whole top-level MainWindow (all tabs, all panes).
+//   * Tab(item): one tab identified by its TabViewItem. That item is the
+//     stable identity the TabView already uses for lookups; passing it
+//     through avoids re-resolving the target inside the gate's Ops.
+class CloseScope {
+public:
+    enum class Kind { Window, Tab };
+
+    static CloseScope Window() noexcept {
+        return CloseScope{Kind::Window, nullptr};
+    }
+    static CloseScope Tab(
+        Microsoft::UI::Xaml::Controls::TabViewItem item) noexcept
+    {
+        return CloseScope{Kind::Tab, std::move(item)};
+    }
+
+    Kind kind() const noexcept { return m_kind; }
+    Microsoft::UI::Xaml::Controls::TabViewItem const& tabItem() const noexcept {
+        return m_item;
+    }
+
+private:
+    CloseScope(Kind k,
+               Microsoft::UI::Xaml::Controls::TabViewItem item) noexcept
+        : m_kind(k), m_item(std::move(item)) {}
+
+    Kind m_kind;
+    Microsoft::UI::Xaml::Controls::TabViewItem m_item{ nullptr };
+};
+
+// State machine gating window-close flow. Owns the "dialog in flight" and
+// "window close in progress" invariants so every close entry point routes
+// through one place instead of scattering fields across MainWindow.
+//
+// Injected Ops thin the class down to state transitions + policy
+// delegation: MainWindow supplies how to check "does this scope need
+// confirmation?", how to render the dialog, and how to execute the
+// actual close. The state machine itself is pure — a std::function
+// fake for Ops exercises every transition (approve, cancel, in-flight
+// guard, re-entrance from close-triggered WM_CLOSE) without WinUI /
+// Win32.
+//
+// Invariants protected:
+//
+//   1. At most one confirmation dialog is on screen at a time. Rapid
+//      Alt+F4 / X clicks land in Prompting and are ignored until the
+//      current dialog resolves.
+//   2. Close only proceeds after confirmation OR when confirmation
+//      isn't required (needsConfirm returns false).
+//   3. Cancel returns cleanly to Idle — no half-torn state.
+//   4. Once a Window-scope close has been approved, WindowCloseInProgress
+//      stays true so the WM_CLOSE subclass can distinguish "internal
+//      close following approval" (default-proceed) from "user's fresh
+//      Alt+F4" (re-enter the gate).
+class WindowCloseGate {
+public:
+    struct Ops {
+        // Synchronous predicate: given a scope, does any surface inside
+        // need confirmation right now? Called on every RequestClose.
+        std::function<bool(CloseScope const&)> needsConfirm;
+
+        // Async dialog. Gate hands over a decision callback that must
+        // fire exactly once with `true` (user approved) or `false`
+        // (cancelled / dismissed). The callback may fire on a later
+        // dispatcher turn — the gate is safe against that.
+        std::function<void(CloseScope const&,
+                           std::function<void(bool)> onDecision)> showDialog;
+
+        // Perform the actual close. For Window scope, take the top-level
+        // window down (typically Window::Close). For Tab scope, remove
+        // that tab from the TabView and clean up its panes.
+        std::function<void(CloseScope const&)> execute;
+    };
+
+    explicit WindowCloseGate(Ops ops) noexcept : m_ops(std::move(ops)) {}
+
+    // Entry point. Every user-facing close signal (X, keybind, WM_CLOSE)
+    // reaches the gate through here. Guarantees the four invariants
+    // documented on the class.
+    void RequestClose(CloseScope scope) {
+        // Invariant 1: dialog already up, second signal is noise.
+        if (m_state == State::Prompting) return;
+
+        // Invariant 4: after a Window close is approved, the window is
+        // tearing down. Further requests during that teardown flow are
+        // internal (the Close() call re-enters WM_CLOSE) and shouldn't
+        // re-prompt.
+        if (m_windowCloseInProgress) return;
+
+        // Fresh request. Consult policy.
+        if (!m_ops.needsConfirm(scope)) {
+            markInProgressIfWindow(scope);
+            m_ops.execute(scope);
+            return;
+        }
+
+        // Confirmation required. Hand off to async dialog; decision
+        // callback drives back to Idle (cancel) or Approved+execute
+        // (Primary).
+        m_state = State::Prompting;
+        m_ops.showDialog(scope,
+            [this, scope](bool approved) mutable {
+                m_state = State::Idle;
+                if (!approved) return;
+                markInProgressIfWindow(scope);
+                m_ops.execute(scope);
+            });
+    }
+
+    // Read by the WM_CLOSE subclass: is a Window-scope close currently
+    // executing? True after approve (or after no-confirm-needed) for a
+    // Window scope, stays true — the window is dying, nothing else in
+    // this gate ever runs again.
+    bool WindowCloseInProgress() const noexcept {
+        return m_windowCloseInProgress;
+    }
+
+private:
+    void markInProgressIfWindow(CloseScope const& scope) noexcept {
+        if (scope.kind() == CloseScope::Kind::Window) {
+            m_windowCloseInProgress = true;
+        }
+    }
+
+    enum class State { Idle, Prompting };
+    State m_state{ State::Idle };
+    bool  m_windowCloseInProgress{ false };
+    Ops   m_ops;
+};
+
+}  // namespace winrt::GhosttyWin32::implementation


### PR DESCRIPTION
Closes #126.

## Why

Follow-up to #112, per [that PR's post-merge note](https://github.com/i999rri/GhosttyWin32/pull/112#issuecomment-5302537786). #112 landed the initial ContentDialog wired to the custom title-bar X only; every other close path (tab-header X, `CLOSE_SURFACE` / `CLOSE_TAB` keybind = `Ctrl+Shift+W`, Alt+F4 / OS-issued `WM_CLOSE`) still bypassed the prompt and silently killed running processes. The internal shape was also Orchestrator-flavoured: `TryClose` walked the tree inline, a local `Check` functor with a role-verb name did the work, and any expansion would grow more MainWindow fields.

## What

Model the close flow as a `WindowCloseGate` value that protects three invariants and expose it to every close entry point.

**Invariants the gate protects**

1. At most one confirmation dialog is visible at a time. Rapid Alt+F4 / X clicks land in `Prompting` and are ignored until the current dialog resolves.
2. Close only proceeds after confirmation OR when confirmation isn't required (`needsConfirm` returns false).
3. Cancel returns cleanly to Idle — no half-torn state.
4. Once a Window-scope close has been approved, `WindowCloseInProgress()` stays true so the `WM_CLOSE` subclass can distinguish "internal close following approval" (default-proceed) from "user's fresh Alt+F4" (re-enter the gate).

**Where responsibilities land**

- **`WindowCloseGate`** (new, `App/WindowCloseGate.h`) — state machine + injected `Ops`. State transitions are pure; a `std::function` fake for `Ops` exercises every transition (approve, cancel, in-flight guard, re-entrance) without WinUI / Win32.
- **`CloseScope`** (new, same header) — value type describing what to close (`Window` or `Tab(item)`). Passed through the gate so all entry points share `RequestClose`'s signature and differ only in the scope they build.
- **`Tab::NeedsConfirmClose()`** (new) — per-tab predicate. Tab owns its pane tree; the confirmation walk belongs on Tab. Both window-scope (walks all tabs) and tab-scope (this one tab) predicates go through it.
- **`MainWindow`** holds one gate. `TryClose` becomes a one-line `RequestClose(Window)`. `TabView::TabCloseRequested`, `CloseTabBySurface`, and the new `WM_CLOSE` subclass all funnel into the gate too — one dialog implementation, one confirmation policy, one state machine.

**Close paths covered**

| Path | Before | After |
|---|---|---|
| Custom title-bar X | Dialog (via `TryClose`) | Dialog via gate |
| Tab-header X | **Silent close** | Dialog via gate |
| `Ctrl+Shift+W` (`CLOSE_SURFACE` / `CLOSE_TAB`) | **Silent close** | Dialog via gate |
| Alt+F4 / OS `WM_CLOSE` | **Silent close** | Dialog via gate |

**Removed / superseded**

- The local `struct Check` functor in `TryClose` (#123 was tracking its role-verb name — instance now gone; issue keeps tracking other walkers).
- `TryCloseTab` from the earlier abandoned #125 was Orchestrator-flavoured on `MainWindow`; the equivalent responsibility now lives inside the gate + `PerformTabClose` primitive.

## Test plan

With `confirm-close-surface = always` (unconditional prompt) and any tab with a running process:

- [ ] Custom title-bar X → dialog appears; **Cancel** keeps the window, **Close** exits and closes
- [ ] Tab-header X → dialog appears; **Cancel** keeps tab, **Close** closes only that tab
- [ ] `Ctrl+Shift+W` → dialog appears; **Cancel** keeps tab, **Close** closes only that tab
- [ ] Alt+F4 → dialog appears; **Cancel** keeps window, **Close** closes window
- [ ] Rapid Alt+F4 spam → single dialog on screen, no stacking
- [ ] Closing the last tab via any path → window comes down without a second prompt

With `confirm-close-surface = false` (or a shell prompt with no running process) — every path closes without a dialog (existing behaviour preserved).

## Naming note

`Gate` isn't an established C++ pattern name — it's borrowed from feature-gate / access-control usage where the metaphor is "keeps things out unless invariants are met". Rename is out of scope for this PR; if a better name surfaces we swap it in a follow-up.

<details>
<summary>日本語</summary>

## 目的

#112 の [merge 後コメント](https://github.com/i999rri/GhosttyWin32/pull/112#issuecomment-5302537786) の追い作業。#112 は custom title-bar X 経由だけ ContentDialog を出す中間実装で、他の close 経路 (タブの X、`Ctrl+Shift+W` の `CLOSE_SURFACE`/`CLOSE_TAB`、Alt+F4/OS 発の `WM_CLOSE`) は素通りで走ってるプロセスを黙って kill してた。内部構造も Orchestrator 的 (`TryClose` が inline で pane 木を歩く、`Check` 役割動詞名の局所 functor) で、経路を増やす度に MainWindow の field が増える構造だった。

## 何をした

close flow を **`WindowCloseGate`** value class の状態機械にまとめた。3つの不変条件を守る:

1. 同時に dialog は 1枚だけ (Alt+F4/X 連打で stack しない)
2. 確認が要る場合は承認前に close は走らない
3. cancel は Idle に戻る (中途半端な状態を残さない)
4. Window scope の close が承認された後は `WindowCloseInProgress()` が true のまま — WM_CLOSE subclass が「承認後の内部 close」(default-proceed) と「user の新しい Alt+F4」(gate に再入) を区別できる

**責務の割り振り**

- **`WindowCloseGate`** (新規): 状態機械 + Ops 注入。遷移は pure で fake の Ops で全遷移テスト可能
- **`CloseScope`** (同じ header): 「何を閉じるか」の value 型 (Window / Tab(item))
- **`Tab::NeedsConfirmClose()`** (新規): tab 内の pane 木を歩く述語。Tab が pane 木の owner なので Tab に住むのが自然
- **`MainWindow`** は Gate 1個を保持。各 close 経路 (custom X、tab X、Ctrl+Shift+W、WM_CLOSE subclass) は全部 `m_closeGate.RequestClose(scope)` に流すだけ

**カバーされる close 経路**は上の表参照。**削除**したもの: `TryClose` 内の局所 `Check` functor (#123 のパターン実例、これで 1個消化)、#125 で試した Orchestrator 的な `TryCloseTab` (責務は Gate + PerformTabClose primitive に分離)。

## 命名メモ

`Gate` は C++ の確立 pattern 名じゃない — feature-gate / アクセス制御の「不変条件を満たさないと通さない」メタファーからの造語。rename は別 PR 扱い、いい名前が出たら差し替え。

</details>