### PR TITLE
Split the Composite Pane class into a sum type: Pane + Split + Branch + Tree

### DIFF
--- a/App/App.vcxproj
+++ b/App/App.vcxproj
@@ -157,9 +157,11 @@
     </ClInclude>
     <ClInclude Include="MainWindows.h" />
     <ClInclude Include="SplitPanel.h" />
+    <ClInclude Include="Tabs\Panes\Branch.h" />
     <ClInclude Include="Tabs\Panes\Pane.h" />
     <ClInclude Include="Tabs\Panes\PaneId.h" />
     <ClInclude Include="Tabs\Panes\PaneIdAllocator.h" />
+    <ClInclude Include="Tabs\Panes\Split.h" />
     <ClInclude Include="Tabs\Tab.h" />
     <ClInclude Include="Tabs\TabFactory.h" />
     <ClInclude Include="Tabs\Tabs.h" />

--- a/App/App.vcxproj
+++ b/App/App.vcxproj
@@ -162,6 +162,7 @@
     <ClInclude Include="Tabs\Panes\PaneId.h" />
     <ClInclude Include="Tabs\Panes\PaneIdAllocator.h" />
     <ClInclude Include="Tabs\Panes\Split.h" />
+    <ClInclude Include="Tabs\Panes\Tree.h" />
     <ClInclude Include="Tabs\Tab.h" />
     <ClInclude Include="Tabs\TabFactory.h" />
     <ClInclude Include="Tabs\Tabs.h" />

--- a/App/App.vcxproj.filters
+++ b/App/App.vcxproj.filters
@@ -46,6 +46,9 @@
     <ClInclude Include="Tabs\TabFactory.h">
       <Filter>Tabs</Filter>
     </ClInclude>
+    <ClInclude Include="Tabs\Panes\Branch.h">
+      <Filter>Tabs\Panes</Filter>
+    </ClInclude>
     <ClInclude Include="Tabs\Panes\Pane.h">
       <Filter>Tabs\Panes</Filter>
     </ClInclude>
@@ -53,6 +56,9 @@
       <Filter>Tabs\Panes</Filter>
     </ClInclude>
     <ClInclude Include="Tabs\Panes\PaneIdAllocator.h">
+      <Filter>Tabs\Panes</Filter>
+    </ClInclude>
+    <ClInclude Include="Tabs\Panes\Split.h">
       <Filter>Tabs\Panes</Filter>
     </ClInclude>
     <ClInclude Include="Display\PhysicalPixels.h">

--- a/App/App.vcxproj.filters
+++ b/App/App.vcxproj.filters
@@ -61,6 +61,9 @@
     <ClInclude Include="Tabs\Panes\Split.h">
       <Filter>Tabs\Panes</Filter>
     </ClInclude>
+    <ClInclude Include="Tabs\Panes\Tree.h">
+      <Filter>Tabs\Panes</Filter>
+    </ClInclude>
     <ClInclude Include="Display\PhysicalPixels.h">
       <Filter>Display</Filter>
     </ClInclude>

--- a/App/MainWindow.xaml.cpp
+++ b/App/MainWindow.xaml.cpp
@@ -1710,9 +1710,6 @@ namespace winrt::GhosttyWin32::implementation
     }
 
     namespace {
-        // Locate the Pane hosting `surface` in the given SplitPanel's
-        // tree. Delegates to Tree::FindPane with the surface-ownership
-        // predicate; the tree is small (a handful of panes at most).
         Pane* FindPaneForSurface(implementation::SplitPanel* panelImpl,
                                  ghostty_surface_t surface)
         {
@@ -1723,16 +1720,12 @@ namespace winrt::GhosttyWin32::implementation
             });
         }
 
-        // Push every pane under `branch` into `out` in depth-first
-        // order — left subtree before right. PREVIOUS / NEXT pane
-        // navigation iterates this list to find neighbours of the
-        // currently active pane.
         void CollectPanes(Branch& branch, std::vector<Pane*>& out) {
             branch.ForEachPane([&out](Pane& p) { out.push_back(&p); });
         }
 
-        // The Branch wrapping `pane` in this tree, needed for
-        // arrangedRect lookup (rects live on Branch, not Pane).
+        // arrangedRect lives on Branch, not Pane — layout callers
+        // resolve the pane back to its wrapping Branch through this.
         Branch* BranchOfPane(implementation::SplitPanel* panelImpl,
                              Pane const* pane)
         {
@@ -1741,16 +1734,11 @@ namespace winrt::GhosttyWin32::implementation
             return root ? root->FindBranchOfPane(*pane) : nullptr;
         }
 
-        // Pick the pane whose arranged rect is adjacent to `active`
-        // in the requested cardinal direction. Filters to panes
-        // strictly on the requested side, then scores them by primary
-        // distance (along the axis) plus a perpendicular penalty so
-        // an aligned neighbour beats a far-off-axis one.
-        //
-        // Returns nullptr if no candidate qualifies — caller's job
-        // to decide whether to fall back (today: just ignore the
-        // input, matching how Windows Terminal handles "no neighbour
-        // in this direction").
+        // Score = primary distance + 2 * perpendicular. The 2x
+        // penalty keeps focus moves predictable when an off-axis
+        // pane is technically closer in straight-line distance than
+        // the aligned neighbour. Returns nullptr when no pane sits
+        // on the requested side.
         Pane* FindAdjacentPane(implementation::SplitPanel* panelImpl,
                                Pane* active,
                                std::vector<Pane*> const& panes,
@@ -1781,8 +1769,7 @@ namespace winrt::GhosttyWin32::implementation
                 bool valid = false;
                 switch (dir) {
                 case GHOSTTY_GOTO_SPLIT_LEFT:
-                    // Candidate must end at or before active starts —
-                    // allow a tiny overlap to absorb float rounding.
+                    // 1px slack absorbs float rounding on the boundary.
                     if (cx2 > a.X + 1.0f) break;
                     primary = a.X - cx2;
                     perpendicular = std::abs(cCenterY - aCenterY);
@@ -1810,10 +1797,6 @@ namespace winrt::GhosttyWin32::implementation
                     return nullptr;  // PREVIOUS / NEXT handled elsewhere
                 }
                 if (!valid) continue;
-                // Weight perpendicular gap twice as heavily as primary
-                // distance — keeps focus moves predictable when there
-                // are off-axis panes that are technically closer in
-                // straight-line distance.
                 double score = primary + 2.0 * perpendicular;
                 if (score < bestScore) {
                     bestScore = score;
@@ -1851,17 +1834,14 @@ namespace winrt::GhosttyWin32::implementation
         Pane* sourcePane = FindPaneForSurface(panelImpl, surface);
         if (!sourcePane) return;
 
-        // The source pane's UIElement + PaneId get moved into a fresh
-        // wrapper Pane inside the split subtree we build below.
-        // Capturing them here means the wrapper has its own reference
-        // to the underlying TerminalControl before the ReplacePane call
-        // destroys the original Branch.
+        // Copy out before ReplacePane destroys the original Branch —
+        // the wrapper below needs its own reference to the underlying
+        // TerminalControl and id.
         auto sourceContent = sourcePane->content;
         PaneId sourcePaneId = sourcePane->id;
 
-        // ghostty's split-direction maps to (direction, which-side-
-        // does-the-new-pane-take). RIGHT/DOWN put the new pane after
-        // the source on the layout axis; LEFT/UP put it before.
+        // RIGHT/DOWN put the new pane after the source on the layout
+        // axis; LEFT/UP put it before.
         Split::Direction splitDir;
         bool newFirst;
         switch (direction) {
@@ -1922,17 +1902,13 @@ namespace winrt::GhosttyWin32::implementation
         }
         auto newBranch = std::move(ctx.result);
         if (!newBranch) return;
-        // Capture a stable pointer to the new Pane before newBranch
-        // moves into the subtree; get_if on the variant is only
-        // valid while the branch is still around.
+        // Cache before newBranch is moved into the subtree — get_if
+        // on the variant is only valid while the branch is around.
         Pane* newPanePtr = newBranch->TryGet<Pane>();
         auto newControl = newBranch->TryGet<Pane>()
             ? newBranch->TryGet<Pane>()->content.try_as<winrt::GhosttyWin32::TerminalControl>()
             : nullptr;
 
-        // Build the replacement subtree: a Split branch whose left/right
-        // are (a) a wrapper around the original source content and
-        // (b) the new pane branch, ordered per `newFirst`.
         auto sourceWrapper = MakePaneBranch(sourceContent, sourcePaneId);
         auto subtree = newFirst
             ? MakeSplitBranch(splitDir, 0.5, std::move(newBranch), std::move(sourceWrapper))
@@ -1986,10 +1962,8 @@ namespace winrt::GhosttyWin32::implementation
 
         Pane* pane = FindPaneForSurface(panelImpl, surface);
         if (!pane) return;
-        // Single-pane tabs skip the zoom — there's nothing to expand
-        // against, and the visual state would be identical to the
-        // normal layout. Detect by asking whether the root Branch is
-        // itself the wrapping Branch for this pane.
+        // Single-pane tab has nothing to expand against; visual state
+        // would be identical to the normal layout.
         auto* root = panelImpl->Tree().Root();
         if (root && root->TryGet<Pane>() == pane) return;
 
@@ -2066,17 +2040,13 @@ namespace winrt::GhosttyWin32::implementation
             ? Split::Direction::Horizontal
             : Split::Direction::Vertical;
 
-        // Walk up from the pane's wrapping Branch to the nearest
-        // ancestor Split with the matching axis. Branch::parent
-        // points at the enclosing Branch (which will be a Split
-        // variant); we keep walking until we find a Split whose
-        // direction matches, or run out of parents.
+        // Walk to the nearest ancestor Split whose axis matches.
         Branch* node = BranchOfPane(panelImpl, pane);
         while (node && node->parent) {
             Branch* parent = node->parent;
             auto* parentSplit = parent ? parent->TryGet<Split>() : nullptr;
             if (parentSplit && parentSplit->direction == needDir) {
-                node = parent;  // target: this Split branch
+                node = parent;
                 break;
             }
             node = parent;
@@ -2244,12 +2214,9 @@ namespace winrt::GhosttyWin32::implementation
         auto* panelImpl = winrt::get_self<implementation::SplitPanel>(tab->Panel());
         if (!panelImpl) return;
 
-        // Identify a sibling pane BEFORE the removal so we can
-        // retarget the active pane into it (the pane pointer is about
-        // to be invalidated). The sibling here means "the pane on the
-        // other side of the immediate Split ancestor" — under the new
-        // sum-type, we find it by walking to the wrapping Branch and
-        // taking the opposite child, then picking its first pane.
+        // Pick a sibling pane before removal invalidates the pointer.
+        // "Sibling" == the first pane on the other child of the
+        // immediate Split ancestor.
         Pane* siblingPane = nullptr;
         bool closingActive = (tab->ActivePane() == pane);
         if (auto* wrapping = BranchOfPane(panelImpl, pane)) {

--- a/App/MainWindow.xaml.cpp
+++ b/App/MainWindow.xaml.cpp
@@ -1925,9 +1925,9 @@ namespace winrt::GhosttyWin32::implementation
         // Capture a stable pointer to the new Pane before newBranch
         // moves into the subtree; get_if on the variant is only
         // valid while the branch is still around.
-        Pane* newPanePtr = newBranch->AsPane();
-        auto newControl = newBranch->AsPane()
-            ? newBranch->AsPane()->content.try_as<winrt::GhosttyWin32::TerminalControl>()
+        Pane* newPanePtr = newBranch->TryGet<Pane>();
+        auto newControl = newBranch->TryGet<Pane>()
+            ? newBranch->TryGet<Pane>()->content.try_as<winrt::GhosttyWin32::TerminalControl>()
             : nullptr;
 
         // Build the replacement subtree: a Split branch whose left/right
@@ -1991,7 +1991,7 @@ namespace winrt::GhosttyWin32::implementation
         // normal layout. Detect by asking whether the root Branch is
         // itself the wrapping Branch for this pane.
         auto* root = panelImpl->Tree().Root();
-        if (root && root->AsPane() == pane) return;
+        if (root && root->TryGet<Pane>() == pane) return;
 
         panelImpl->SetZoomed(pane);
         tab->SetActivePane(pane);
@@ -2074,7 +2074,7 @@ namespace winrt::GhosttyWin32::implementation
         Branch* node = BranchOfPane(panelImpl, pane);
         while (node && node->parent) {
             Branch* parent = node->parent;
-            auto* parentSplit = parent ? parent->AsSplit() : nullptr;
+            auto* parentSplit = parent ? parent->TryGet<Split>() : nullptr;
             if (parentSplit && parentSplit->direction == needDir) {
                 node = parent;  // target: this Split branch
                 break;
@@ -2082,7 +2082,7 @@ namespace winrt::GhosttyWin32::implementation
             node = parent;
         }
         if (!node) return;
-        auto* targetSplit = node->AsSplit();
+        auto* targetSplit = node->TryGet<Split>();
         if (!targetSplit || targetSplit->direction != needDir) return;
 
         auto rect = node->arrangedRect;
@@ -2254,7 +2254,7 @@ namespace winrt::GhosttyWin32::implementation
         bool closingActive = (tab->ActivePane() == pane);
         if (auto* wrapping = BranchOfPane(panelImpl, pane)) {
             if (auto* parent = wrapping->parent) {
-                if (auto* parentSplit = parent->AsSplit()) {
+                if (auto* parentSplit = parent->TryGet<Split>()) {
                     Branch* siblingBranch =
                         (parentSplit->left.get() == wrapping)
                             ? parentSplit->right.get()

--- a/App/MainWindow.xaml.cpp
+++ b/App/MainWindow.xaml.cpp
@@ -789,27 +789,16 @@ namespace winrt::GhosttyWin32::implementation
         // old variant and the surface's palette doesn't change until
         // it's recreated. Push the new scheme into each existing
         // surface too so the flip lands immediately.
-        struct Push {
-            ghostty_color_scheme_e scheme;
-            void operator()(Pane* node) const {
-                if (!node) return;
-                if (node->IsLeaf()) {
-                    if (auto* tc = Tab::LeafToTerminalControl(*node)) {
-                        tc->Surface().SetColorScheme(scheme);
-                    }
-                    return;
-                }
-                (*this)(node->First());
-                (*this)(node->Second());
-            }
-        };
-        Push push{ scheme };
         for (auto& tab : m_tabs) {
             if (!tab) continue;
             auto* panelImpl =
                 winrt::get_self<implementation::SplitPanel>(tab->Panel());
             if (!panelImpl) continue;
-            push(panelImpl->Root());
+            panelImpl->Tree().ForEachPane([scheme](Pane& p) {
+                if (auto* tc = Tab::PaneToTerminalControl(p)) {
+                    tc->Surface().SetColorScheme(scheme);
+                }
+            });
         }
         // Mirror the OS preference into the WinUI shell so titlebar,
         // TabView chrome, menus, and any XamlControlsResources-derived
@@ -853,7 +842,7 @@ namespace winrt::GhosttyWin32::implementation
         // Collapsed elements stay parented (no Unloaded fires) so the
         // SwapChainPanel's DComp surface binding survives the switch.
         // No focus-visual pre-apply is needed — UnfocusedDim is owned
-        // by Tab.SetActiveLeaf and is independent of XAML focus, so
+        // by Tab.SetActivePane and is independent of XAML focus, so
         // tab switches don't disturb it.
         auto* tab = ActiveTab();
         winrt::GhosttyWin32::SplitPanel activePanel{ nullptr };
@@ -943,19 +932,19 @@ namespace winrt::GhosttyWin32::implementation
     {
         m_activeSurface = surface;
         // Route the focus event back into the owning Tab so it can
-        // update its per-tab dim invariant. SetActiveLeaf is idempotent
+        // update its per-tab dim invariant. SetActivePane is idempotent
         // when `leaf` is already the tab's active leaf, so the deferred
         // Focus call we issue after tab switches (which re-focuses the
         // same TerminalControl that was already active in the
         // newly-selected tab) doesn't repaint anything. The case that
         // matters is a pointer click on a non-active pane inside a
-        // split — GotFocus fires, we land here, SetActiveLeaf swaps
+        // split — GotFocus fires, we land here, SetActivePane swaps
         // the dim across the panes.
         if (!surface) return;
         try {
-            auto lookup = m_tabs.FindLeafBySurface(surface);
-            if (lookup.tab && lookup.leaf && lookup.tab->ActiveLeaf() != lookup.leaf) {
-                lookup.tab->SetActiveLeaf(lookup.leaf);
+            auto lookup = m_tabs.FindPaneBySurface(surface);
+            if (lookup.tab && lookup.pane && lookup.tab->ActivePane() != lookup.pane) {
+                lookup.tab->SetActivePane(lookup.pane);
             }
         } catch (...) {
             // Defensive: dim update is a UX nicety, never crash the
@@ -996,41 +985,16 @@ namespace winrt::GhosttyWin32::implementation
 
     void MainWindow::TryClose()
     {
-        // Walk every leaf in every tab: if any surface reports
-        // needs_confirm_quit=true, gate the close on a
-        // WinUI ContentDialog. Otherwise close straight through.
-        //
+        // Ask each Tab whether any of its panes need confirmation.
+        // Tab::NeedsConfirmClose owns the pane-tree walk (Tab owns
+        // the tree, so the query belongs there); the surface-level
         // ghostty_surface_needs_confirm_quit already factors in the
         // `confirm-close-surface` config, so users who set it false
         // sail through without a dialog on every close.
-        //
-        // Inline recursion (rather than reusing CollectLeaves defined
-        // later in this file) so this can sit close to RequestClose
-        // where the surrounding close-path handlers already live.
-        struct Check {
-            bool any = false;
-            void operator()(Pane* node) {
-                if (any || !node) return;
-                if (node->IsLeaf()) {
-                    if (auto* tc = Tab::LeafToTerminalControl(*node)) {
-                        if (tc->Surface().NeedsConfirmQuit()) any = true;
-                    }
-                    return;
-                }
-                (*this)(node->First());
-                (*this)(node->Second());
-            }
-        };
-        Check check;
+        bool anyNeedsConfirm = false;
         for (auto& tab : m_tabs) {
-            if (!tab) continue;
-            auto* panelImpl =
-                winrt::get_self<implementation::SplitPanel>(tab->Panel());
-            if (!panelImpl) continue;
-            check(panelImpl->Root());
-            if (check.any) break;
+            if (tab && tab->NeedsConfirmClose()) { anyNeedsConfirm = true; break; }
         }
-        bool anyNeedsConfirm = check.any;
 
         if (!anyNeedsConfirm) {
             RequestClose();
@@ -1590,12 +1554,12 @@ namespace winrt::GhosttyWin32::implementation
         // the tab's active leaf. MOUSE_SHAPE carries the originating
         // surface, and with split panes the pointer can be over a
         // non-active pane — using ActiveControl() landed the shape on
-        // the wrong pane (#65). FindLeafBySurface walks the pane tree
+        // the wrong pane (#65). FindPaneBySurface walks the pane tree
         // and returns the owning leaf; in the single-pane case it
         // resolves to the same control ActiveControl() would.
-        auto lookup = m_tabs.FindLeafBySurface(surface);
-        if (!lookup.leaf) return;
-        if (auto* tc = Tab::LeafToTerminalControl(*lookup.leaf)) {
+        auto lookup = m_tabs.FindPaneBySurface(surface);
+        if (!lookup.pane) return;
+        if (auto* tc = Tab::PaneToTerminalControl(*lookup.pane)) {
             tc->SetCursorShape(shape);
         }
     }
@@ -1665,10 +1629,10 @@ namespace winrt::GhosttyWin32::implementation
             // so a later click routes back to the right pane via
             // PresentNotification. Encoded as semicolon-separated
             // key=value pairs to leave room for future fields.
-            if (auto lookup = m_tabs.FindLeafBySurface(surface);
-                lookup.leaf && lookup.leaf->Id())
+            if (auto lookup = m_tabs.FindPaneBySurface(surface);
+                lookup.pane && lookup.pane->id)
             {
-                auto idStr = std::to_wstring(lookup.leaf->Id().value);
+                auto idStr = std::to_wstring(lookup.pane->id.value);
                 builder.AddArgument(L"action", L"present");
                 builder.AddArgument(L"surfaceId", winrt::hstring(idStr));
             }
@@ -1693,8 +1657,8 @@ namespace winrt::GhosttyWin32::implementation
                 if (tabView) {
                     tabView.SelectedItem(lookup.tab->Item());
                 }
-                if (lookup.leaf) {
-                    lookup.tab->SetActiveLeaf(lookup.leaf);
+                if (lookup.pane) {
+                    lookup.tab->SetActivePane(lookup.pane);
                 }
                 lookup.tab->Focus();
             }
@@ -1746,42 +1710,39 @@ namespace winrt::GhosttyWin32::implementation
     }
 
     namespace {
-        // Depth-first search for the leaf hosting `surface`. The pane
-        // tree is small (a handful of leaves at most) so a flat walk
-        // is strictly cheaper than maintaining a side index.
-        Pane* FindLeafForSurface(Pane* node, ghostty_surface_t surface) {
-            if (!node) return nullptr;
-            if (node->IsLeaf()) {
-                auto* tc = Tab::LeafToTerminalControl(*node);
-                return (tc && tc->Surface().Owns(surface)) ? node : nullptr;
-            }
-            if (auto* p = FindLeafForSurface(node->First(), surface)) return p;
-            return FindLeafForSurface(node->Second(), surface);
+        // Locate the Pane hosting `surface` in the given SplitPanel's
+        // tree. Delegates to Tree::FindPane with the surface-ownership
+        // predicate; the tree is small (a handful of panes at most).
+        Pane* FindPaneForSurface(implementation::SplitPanel* panelImpl,
+                                 ghostty_surface_t surface)
+        {
+            if (!panelImpl) return nullptr;
+            return panelImpl->Tree().FindPane([surface](Pane const& p) {
+                auto const* tc = Tab::PaneToTerminalControl(p);
+                return tc && tc->Surface().Owns(surface);
+            });
         }
 
-        // Returns the first leaf reached by depth-first descent — used
-        // to pick a focus target after a split collapses and the
-        // previously-active leaf is gone.
-        Pane* FirstLeafIn(Pane* node) {
-            if (!node) return nullptr;
-            if (node->IsLeaf()) return node;
-            if (auto* p = FirstLeafIn(node->First())) return p;
-            return FirstLeafIn(node->Second());
-        }
-
-        // Push every leaf under `node` into `out` in depth-first
+        // Push every pane under `branch` into `out` in depth-first
         // order — left subtree before right. PREVIOUS / NEXT pane
         // navigation iterates this list to find neighbours of the
-        // currently active leaf.
-        void CollectLeaves(Pane* node, std::vector<Pane*>& out) {
-            if (!node) return;
-            if (node->IsLeaf()) { out.push_back(node); return; }
-            CollectLeaves(node->First(), out);
-            CollectLeaves(node->Second(), out);
+        // currently active pane.
+        void CollectPanes(Branch& branch, std::vector<Pane*>& out) {
+            branch.ForEachPane([&out](Pane& p) { out.push_back(&p); });
         }
 
-        // Pick the leaf whose arranged rect is adjacent to `active`
-        // in the requested cardinal direction. Filters to leaves
+        // The Branch wrapping `pane` in this tree, needed for
+        // arrangedRect lookup (rects live on Branch, not Pane).
+        Branch* BranchOfPane(implementation::SplitPanel* panelImpl,
+                             Pane const* pane)
+        {
+            if (!panelImpl || !pane) return nullptr;
+            auto* root = panelImpl->Tree().Root();
+            return root ? root->FindBranchOfPane(pane) : nullptr;
+        }
+
+        // Pick the pane whose arranged rect is adjacent to `active`
+        // in the requested cardinal direction. Filters to panes
         // strictly on the requested side, then scores them by primary
         // distance (along the axis) plus a perpendicular penalty so
         // an aligned neighbour beats a far-off-axis one.
@@ -1790,12 +1751,15 @@ namespace winrt::GhosttyWin32::implementation
         // to decide whether to fall back (today: just ignore the
         // input, matching how Windows Terminal handles "no neighbour
         // in this direction").
-        Pane* FindAdjacentLeaf(Pane* active,
-                               std::vector<Pane*> const& leaves,
+        Pane* FindAdjacentPane(implementation::SplitPanel* panelImpl,
+                               Pane* active,
+                               std::vector<Pane*> const& panes,
                                ghostty_action_goto_split_e dir)
         {
-            if (!active) return nullptr;
-            auto a = active->ArrangedRect();
+            if (!active || !panelImpl) return nullptr;
+            auto* activeBranch = BranchOfPane(panelImpl, active);
+            if (!activeBranch) return nullptr;
+            auto a = activeBranch->arrangedRect;
             float ax2 = a.X + a.Width;
             float ay2 = a.Y + a.Height;
             float aCenterX = a.X + a.Width  * 0.5f;
@@ -1803,9 +1767,11 @@ namespace winrt::GhosttyWin32::implementation
 
             Pane* best = nullptr;
             double bestScore = std::numeric_limits<double>::max();
-            for (auto* leaf : leaves) {
-                if (leaf == active) continue;
-                auto c = leaf->ArrangedRect();
+            for (auto* candidate : panes) {
+                if (candidate == active) continue;
+                auto* candBranch = BranchOfPane(panelImpl, candidate);
+                if (!candBranch) continue;
+                auto c = candBranch->arrangedRect;
                 float cx2 = c.X + c.Width;
                 float cy2 = c.Y + c.Height;
                 float cCenterX = c.X + c.Width  * 0.5f;
@@ -1851,7 +1817,7 @@ namespace winrt::GhosttyWin32::implementation
                 double score = primary + 2.0 * perpendicular;
                 if (score < bestScore) {
                     bestScore = score;
-                    best = leaf;
+                    best = candidate;
                 }
             }
             return best;
@@ -1865,13 +1831,11 @@ namespace winrt::GhosttyWin32::implementation
             auto* panelImpl =
                 winrt::get_self<implementation::SplitPanel>(tab->Panel());
             if (!panelImpl) continue;
-            std::vector<Pane*> leaves;
-            CollectLeaves(panelImpl->Root(), leaves);
-            for (auto* leaf : leaves) {
-                if (auto* tc = Tab::LeafToTerminalControl(*leaf)) {
+            panelImpl->Tree().ForEachPane([visible](Pane& p) {
+                if (auto* tc = Tab::PaneToTerminalControl(p)) {
                     tc->Surface().SetOcclusion(visible);
                 }
-            }
+            });
         }
     }
 
@@ -1884,27 +1848,27 @@ namespace winrt::GhosttyWin32::implementation
         auto* panelImpl = winrt::get_self<implementation::SplitPanel>(sourceTab->Panel());
         if (!panelImpl) return;
 
-        Pane* sourceLeaf = FindLeafForSurface(panelImpl->Root(), surface);
-        if (!sourceLeaf || !sourceLeaf->IsLeaf()) return;
+        Pane* sourcePane = FindPaneForSurface(panelImpl, surface);
+        if (!sourcePane) return;
 
-        // The source leaf's UIElement + PaneId are about to be moved
-        // into a new wrapper leaf inside the split subtree we build
-        // below. Capturing them here means the wrapper has its own
-        // reference to the underlying TerminalControl before the
-        // ReplaceLeaf call destroys the original Pane node.
-        auto sourceContent = sourceLeaf->Content();
-        PaneId sourcePaneId = sourceLeaf->Id();
+        // The source pane's UIElement + PaneId get moved into a fresh
+        // wrapper Pane inside the split subtree we build below.
+        // Capturing them here means the wrapper has its own reference
+        // to the underlying TerminalControl before the ReplacePane call
+        // destroys the original Branch.
+        auto sourceContent = sourcePane->content;
+        PaneId sourcePaneId = sourcePane->id;
 
-        // ghostty's split-direction maps to (orientation, which-side-
+        // ghostty's split-direction maps to (direction, which-side-
         // does-the-new-pane-take). RIGHT/DOWN put the new pane after
         // the source on the layout axis; LEFT/UP put it before.
-        SplitOrientation orient;
+        Split::Direction splitDir;
         bool newFirst;
         switch (direction) {
-            case GHOSTTY_SPLIT_DIRECTION_RIGHT: orient = SplitOrientation::Horizontal; newFirst = false; break;
-            case GHOSTTY_SPLIT_DIRECTION_LEFT:  orient = SplitOrientation::Horizontal; newFirst = true;  break;
-            case GHOSTTY_SPLIT_DIRECTION_DOWN:  orient = SplitOrientation::Vertical;   newFirst = false; break;
-            case GHOSTTY_SPLIT_DIRECTION_UP:    orient = SplitOrientation::Vertical;   newFirst = true;  break;
+            case GHOSTTY_SPLIT_DIRECTION_RIGHT: splitDir = Split::Direction::Horizontal; newFirst = false; break;
+            case GHOSTTY_SPLIT_DIRECTION_LEFT:  splitDir = Split::Direction::Horizontal; newFirst = true;  break;
+            case GHOSTTY_SPLIT_DIRECTION_DOWN:  splitDir = Split::Direction::Vertical;   newFirst = false; break;
+            case GHOSTTY_SPLIT_DIRECTION_UP:    splitDir = Split::Direction::Vertical;   newFirst = true;  break;
             default: return;
         }
 
@@ -1913,15 +1877,15 @@ namespace winrt::GhosttyWin32::implementation
         // expressed in PHYSICAL pixels (see display::MeasuredPhysical
         // for why the conversion matters).
         uint32_t srcW = 0, srcH = 0;
-        if (auto* srcTc = Tab::LeafToTerminalControl(*sourceLeaf)) {
+        if (auto* srcTc = Tab::PaneToTerminalControl(*sourcePane)) {
             auto sz = display::MeasuredPhysical(srcTc->InnerPanel());
             srcW = sz.width;
             srcH = sz.height;
         }
-        uint32_t newW = (orient == SplitOrientation::Horizontal) ? srcW / 2 : srcW;
-        uint32_t newH = (orient == SplitOrientation::Vertical)   ? srcH / 2 : srcH;
+        uint32_t newW = (splitDir == Split::Direction::Horizontal) ? srcW / 2 : srcW;
+        uint32_t newH = (splitDir == Split::Direction::Vertical)   ? srcH / 2 : srcH;
 
-        // Wrap MakeLeaf in an SEH guard for the same reason CreateTab
+        // Wrap MakePane in an SEH guard for the same reason CreateTab
         // does — ghostty_surface_new calls into dx_create_texture
         // where NVIDIA drivers have historically thrown hardware
         // exceptions. Without the guard, a driver AV here takes down
@@ -1933,12 +1897,12 @@ namespace winrt::GhosttyWin32::implementation
             TabFactory* factory;
             uint32_t initialWidth;
             uint32_t initialHeight;
-            std::unique_ptr<Pane> result;
+            std::unique_ptr<Branch> result;
         };
         SplitCtx ctx{ m_tabFactory.get(), newW, newH, nullptr };
         int ok = RunSEHGuarded([](void* arg) noexcept {
             auto* c = static_cast<SplitCtx*>(arg);
-            c->result = c->factory->MakeLeaf(c->initialWidth, c->initialHeight);
+            c->result = c->factory->MakePane(c->initialWidth, c->initialHeight);
         }, &ctx);
         if (!ok) {
             // Driver-side hardware exception. Process state is
@@ -1956,20 +1920,25 @@ namespace winrt::GhosttyWin32::implementation
             if (m_hwnd) PostMessageW(m_hwnd, WM_CLOSE, 0, 0);
             return;
         }
-        auto newLeaf = std::move(ctx.result);
-        if (!newLeaf) return;
-        Pane* newLeafPtr = newLeaf.get();
-        auto newControl = newLeaf->Content().try_as<winrt::GhosttyWin32::TerminalControl>();
+        auto newBranch = std::move(ctx.result);
+        if (!newBranch) return;
+        // Capture a stable pointer to the new Pane before newBranch
+        // moves into the subtree; get_if on the variant is only
+        // valid while the branch is still around.
+        Pane* newPanePtr = newBranch->AsPane();
+        auto newControl = newBranch->AsPane()
+            ? newBranch->AsPane()->content.try_as<winrt::GhosttyWin32::TerminalControl>()
+            : nullptr;
 
-        // Build the replacement subtree: a split node whose children
+        // Build the replacement subtree: a Split branch whose left/right
         // are (a) a wrapper around the original source content and
-        // (b) the new leaf, ordered per `newFirst`.
-        auto sourceWrapper = Pane::MakeLeaf(sourceContent, sourcePaneId);
+        // (b) the new pane branch, ordered per `newFirst`.
+        auto sourceWrapper = MakePaneBranch(sourceContent, sourcePaneId);
         auto subtree = newFirst
-            ? Pane::MakeSplit(orient, 0.5, std::move(newLeaf), std::move(sourceWrapper))
-            : Pane::MakeSplit(orient, 0.5, std::move(sourceWrapper), std::move(newLeaf));
+            ? MakeSplitBranch(splitDir, 0.5, std::move(newBranch), std::move(sourceWrapper))
+            : MakeSplitBranch(splitDir, 0.5, std::move(sourceWrapper), std::move(newBranch));
 
-        if (!panelImpl->ReplaceLeaf(sourceLeaf, std::move(subtree))) {
+        if (!panelImpl->ReplacePane(sourcePane, std::move(subtree))) {
             // Tree mutation failed after the new surface was already
             // attached — detach so it doesn't leak.
             if (newControl) {
@@ -1983,7 +1952,7 @@ namespace winrt::GhosttyWin32::implementation
         // Focus shifts to the freshly-created pane: matches the
         // expectation set by every other terminal (a `:vsplit` lands
         // the cursor in the new pane).
-        sourceTab->SetActiveLeaf(newLeafPtr);
+        sourceTab->SetActivePane(newPanePtr);
         if (newControl) {
             newControl.Focus(Microsoft::UI::Xaml::FocusState::Programmatic);
         }
@@ -2010,23 +1979,25 @@ namespace winrt::GhosttyWin32::implementation
         // Already zoomed → unzoom regardless of which pane fired the
         // action. Matches how Windows Terminal / iTerm exit zoom mode:
         // a second press anywhere collapses it back.
-        if (panelImpl->ZoomedLeaf()) {
+        if (panelImpl->Zoomed()) {
             panelImpl->SetZoomed(nullptr);
             return;
         }
 
-        Pane* leaf = FindLeafForSurface(panelImpl->Root(), surface);
-        if (!leaf) return;
-        // Single-leaf tabs skip the zoom — there's nothing to expand
+        Pane* pane = FindPaneForSurface(panelImpl, surface);
+        if (!pane) return;
+        // Single-pane tabs skip the zoom — there's nothing to expand
         // against, and the visual state would be identical to the
-        // normal layout.
-        if (leaf == panelImpl->Root()) return;
+        // normal layout. Detect by asking whether the root Branch is
+        // itself the wrapping Branch for this pane.
+        auto* root = panelImpl->Tree().Root();
+        if (root && root->AsPane() == pane) return;
 
-        panelImpl->SetZoomed(leaf);
-        tab->SetActiveLeaf(leaf);
+        panelImpl->SetZoomed(pane);
+        tab->SetActivePane(pane);
         // Re-focus so the zoomed pane keeps input even when zoom was
         // toggled from a non-active pane via a remapped binding.
-        if (auto control = leaf->Content().try_as<winrt::GhosttyWin32::TerminalControl>()) {
+        if (auto control = pane->content.try_as<winrt::GhosttyWin32::TerminalControl>()) {
             control.Focus(Microsoft::UI::Xaml::FocusState::Programmatic);
         }
     }
@@ -2040,35 +2011,35 @@ namespace winrt::GhosttyWin32::implementation
         auto* panelImpl = winrt::get_self<implementation::SplitPanel>(tab->Panel());
         if (!panelImpl) return;
 
-        Pane* active = FindLeafForSurface(panelImpl->Root(), surface);
+        Pane* active = FindPaneForSurface(panelImpl, surface);
         if (!active) return;
 
-        std::vector<Pane*> leaves;
-        CollectLeaves(panelImpl->Root(), leaves);
-        if (leaves.size() <= 1) return;  // nothing to navigate to
+        std::vector<Pane*> panes;
+        if (auto* root = panelImpl->Tree().Root()) CollectPanes(*root, panes);
+        if (panes.size() <= 1) return;  // nothing to navigate to
 
         Pane* target = nullptr;
         if (direction == GHOSTTY_GOTO_SPLIT_PREVIOUS
             || direction == GHOSTTY_GOTO_SPLIT_NEXT) {
             // Cycle through DFS order. wrap-around so the last pane's
             // NEXT lands on the first and vice versa.
-            auto it = std::find(leaves.begin(), leaves.end(), active);
-            if (it == leaves.end()) return;
-            size_t idx = static_cast<size_t>(std::distance(leaves.begin(), it));
+            auto it = std::find(panes.begin(), panes.end(), active);
+            if (it == panes.end()) return;
+            size_t idx = static_cast<size_t>(std::distance(panes.begin(), it));
             size_t newIdx;
             if (direction == GHOSTTY_GOTO_SPLIT_NEXT) {
-                newIdx = (idx + 1) % leaves.size();
+                newIdx = (idx + 1) % panes.size();
             } else {
-                newIdx = (idx == 0) ? leaves.size() - 1 : idx - 1;
+                newIdx = (idx == 0) ? panes.size() - 1 : idx - 1;
             }
-            target = leaves[newIdx];
+            target = panes[newIdx];
         } else {
-            target = FindAdjacentLeaf(active, leaves, direction);
+            target = FindAdjacentPane(panelImpl, active, panes, direction);
         }
         if (!target || target == active) return;
 
-        tab->SetActiveLeaf(target);
-        if (auto element = target->Content()) {
+        tab->SetActivePane(target);
+        if (auto element = target->content) {
             if (auto control = element.try_as<winrt::GhosttyWin32::TerminalControl>()) {
                 control.Focus(Microsoft::UI::Xaml::FocusState::Programmatic);
             }
@@ -2084,37 +2055,38 @@ namespace winrt::GhosttyWin32::implementation
         auto* panelImpl = winrt::get_self<implementation::SplitPanel>(tab->Panel());
         if (!panelImpl) return;
 
-        Pane* leaf = FindLeafForSurface(panelImpl->Root(), surface);
-        if (!leaf) return;
+        Pane* pane = FindPaneForSurface(panelImpl, surface);
+        if (!pane) return;
 
         // The split axis we're resizing matches the direction axis:
         // LEFT/RIGHT → Horizontal split, UP/DOWN → Vertical split.
-        SplitOrientation needOrient =
+        Split::Direction needDir =
             (resize.direction == GHOSTTY_RESIZE_SPLIT_LEFT
              || resize.direction == GHOSTTY_RESIZE_SPLIT_RIGHT)
-            ? SplitOrientation::Horizontal
-            : SplitOrientation::Vertical;
+            ? Split::Direction::Horizontal
+            : Split::Direction::Vertical;
 
-        // Walk up to the nearest ancestor split with the right axis.
-        // `child` is the descendant of that ancestor that contains the
-        // active leaf — used to figure out whether the leaf is on the
-        // first/second side of the split so the direction sign is
-        // applied correctly.
-        Pane* node = leaf;
-        Pane* child = nullptr;
-        while (node && node->Parent()) {
-            auto* parent = node->Parent();
-            if (parent->Orientation() == needOrient) {
-                child = node;
-                node = parent;
+        // Walk up from the pane's wrapping Branch to the nearest
+        // ancestor Split with the matching axis. Branch::parent
+        // points at the enclosing Branch (which will be a Split
+        // variant); we keep walking until we find a Split whose
+        // direction matches, or run out of parents.
+        Branch* node = BranchOfPane(panelImpl, pane);
+        while (node && node->parent) {
+            Branch* parent = node->parent;
+            auto* parentSplit = parent ? parent->AsSplit() : nullptr;
+            if (parentSplit && parentSplit->direction == needDir) {
+                node = parent;  // target: this Split branch
                 break;
             }
             node = parent;
         }
-        if (!child || !node || node->IsLeaf()) return;
+        if (!node) return;
+        auto* targetSplit = node->AsSplit();
+        if (!targetSplit || targetSplit->direction != needDir) return;
 
-        auto rect = node->ArrangedRect();
-        float extent = (needOrient == SplitOrientation::Horizontal) ? rect.Width : rect.Height;
+        auto rect = node->arrangedRect;
+        float extent = (needDir == Split::Direction::Horizontal) ? rect.Width : rect.Height;
         float useable = std::max(1.0f,
             extent - static_cast<float>(implementation::SplitPanel::kSplitterThickness));
         double deltaRatio = static_cast<double>(resize.amount) / useable;
@@ -2124,15 +2096,11 @@ namespace winrt::GhosttyWin32::implementation
         //   * RIGHT / DOWN move the boundary toward +axis → ratio
         //     grows (first child gets larger).
         //   * LEFT / UP move the boundary toward -axis → ratio shrinks.
-        // The previous "flip the sign when the active pane is the
-        // second child" logic was a tmux-style "grow the active pane
-        // in the arrow direction" rule that surprised the user when
-        // pressing LEFT from the right-hand pane moved the boundary
-        // right instead of left.
         bool increase = (resize.direction == GHOSTTY_RESIZE_SPLIT_RIGHT
                       || resize.direction == GHOSTTY_RESIZE_SPLIT_DOWN);
 
-        node->SetRatio(node->Ratio() + (increase ? deltaRatio : -deltaRatio));
+        targetSplit->ratio = ClampSplitRatio(
+            targetSplit->ratio + (increase ? deltaRatio : -deltaRatio));
         panelImpl->InvalidateMeasure();
         panelImpl->InvalidateArrange();
     }
@@ -2140,8 +2108,8 @@ namespace winrt::GhosttyWin32::implementation
     TerminalControl* MainWindow::ControlByPaneId(PaneId id) noexcept
     {
         auto lookup = m_tabs.FindByPaneId(id);
-        if (!lookup.leaf) return nullptr;
-        return Tab::LeafToTerminalControl(*lookup.leaf);
+        if (!lookup.pane) return nullptr;
+        return Tab::PaneToTerminalControl(*lookup.pane);
     }
 
     std::unique_ptr<Tab> MainWindow::ReleaseTornOutTab(
@@ -2157,14 +2125,11 @@ namespace winrt::GhosttyWin32::implementation
         if (m_activeSurface) {
             if (auto* panelImpl =
                     winrt::get_self<implementation::SplitPanel>(t->Panel())) {
-                std::vector<Pane*> leaves;
-                CollectLeaves(panelImpl->Root(), leaves);
-                for (auto* leaf : leaves) {
-                    auto* tc = Tab::LeafToTerminalControl(*leaf);
-                    if (tc && tc->Surface().Owns(m_activeSurface)) {
-                        m_activeSurface = nullptr;
-                        break;
-                    }
+                if (panelImpl->Tree().FindPane([this](Pane const& p) {
+                        auto const* tc = Tab::PaneToTerminalControl(p);
+                        return tc && tc->Surface().Owns(m_activeSurface);
+                    })) {
+                    m_activeSurface = nullptr;
                 }
             }
         }
@@ -2211,15 +2176,13 @@ namespace winrt::GhosttyWin32::implementation
         // onLeafFocused — MainWindow outlives every control it hosts.
         if (auto* panelImpl =
                 winrt::get_self<implementation::SplitPanel>(tab->Panel())) {
-            std::vector<Pane*> leaves;
-            CollectLeaves(panelImpl->Root(), leaves);
-            for (auto* leaf : leaves) {
-                if (auto* tc = Tab::LeafToTerminalControl(*leaf)) {
+            panelImpl->Tree().ForEachPane([this](Pane& p) {
+                if (auto* tc = Tab::PaneToTerminalControl(p)) {
                     tc->Rehost(m_hwnd, [this](ghostty_surface_t s) noexcept {
                         NotifySurfaceFocused(s);
                     });
                 }
-            }
+            });
         }
 
         // Same shape as CreateTab's post-Make sequence: parent the
@@ -2261,14 +2224,14 @@ namespace winrt::GhosttyWin32::implementation
     void MainWindow::CloseSurfaceByPaneId(PaneId id)
     {
         auto lookup = m_tabs.FindByPaneId(id);
-        if (!lookup.tab || !lookup.leaf) return;
+        if (!lookup.tab || !lookup.pane) return;
         auto* tab = lookup.tab;
-        auto* leaf = lookup.leaf;
+        auto* pane = lookup.pane;
 
         // Detach first so the surface / DComp handle are released
-        // synchronously, before the Pane node holding the
-        // TerminalControl is destroyed.
-        if (auto* tc = Tab::LeafToTerminalControl(*leaf)) {
+        // synchronously, before the Branch holding the TerminalControl
+        // is destroyed.
+        if (auto* tc = Tab::PaneToTerminalControl(*pane)) {
             // Clear m_activeSurface if it pointed at the surface we're
             // about to free — the focused-surface cache must never
             // outlive the underlying ghostty_surface_t. The next
@@ -2281,31 +2244,41 @@ namespace winrt::GhosttyWin32::implementation
         auto* panelImpl = winrt::get_self<implementation::SplitPanel>(tab->Panel());
         if (!panelImpl) return;
 
-        // Identify the sibling subtree BEFORE the removal so we can
-        // retarget the active leaf into it (the leaf pointer is about
-        // to be invalidated).
-        Pane* sibling = nullptr;
-        bool closingActive = (tab->ActiveLeaf() == leaf);
-        if (auto* parent = leaf->Parent()) {
-            sibling = (parent->First() == leaf) ? parent->Second() : parent->First();
-        }
-        // Clear the active-leaf pointer up front: regardless of which
-        // branch runs below, leaving it pointing at the doomed leaf
-        // would dangle until the SetActiveLeaf calls overwrite it.
-        if (closingActive) tab->SetActiveLeaf(nullptr);
-
-        auto result = panelImpl->RemoveLeaf(leaf);
-        if (result == implementation::SplitPanel::RemovalResult::Collapsed) {
-            // Tab survives; retarget focus to the surviving subtree.
-            if (closingActive && sibling) {
-                if (auto* newActive = FirstLeafIn(sibling)) {
-                    tab->SetActiveLeaf(newActive);
-                    if (auto* tc = Tab::LeafToTerminalControl(*newActive)) {
-                        auto element = newActive->Content();
-                        if (auto control = element.try_as<winrt::GhosttyWin32::TerminalControl>()) {
-                            control.Focus(Microsoft::UI::Xaml::FocusState::Programmatic);
-                        }
+        // Identify a sibling pane BEFORE the removal so we can
+        // retarget the active pane into it (the pane pointer is about
+        // to be invalidated). The sibling here means "the pane on the
+        // other side of the immediate Split ancestor" — under the new
+        // sum-type, we find it by walking to the wrapping Branch and
+        // taking the opposite child, then picking its first pane.
+        Pane* siblingPane = nullptr;
+        bool closingActive = (tab->ActivePane() == pane);
+        if (auto* wrapping = BranchOfPane(panelImpl, pane)) {
+            if (auto* parent = wrapping->parent) {
+                if (auto* parentSplit = parent->AsSplit()) {
+                    Branch* siblingBranch =
+                        (parentSplit->left.get() == wrapping)
+                            ? parentSplit->right.get()
+                            : parentSplit->left.get();
+                    if (siblingBranch) {
+                        siblingPane = siblingBranch->FindPane(
+                            [](Pane const&) { return true; });
                     }
+                }
+            }
+        }
+        // Clear the active-pane pointer up front: regardless of which
+        // branch runs below, leaving it pointing at the doomed pane
+        // would dangle until the SetActivePane calls overwrite it.
+        if (closingActive) tab->SetActivePane(nullptr);
+
+        auto result = panelImpl->RemovePane(pane);
+        if (result == Tree::RemoveResult::Collapsed) {
+            // Tab survives; retarget focus to the surviving subtree.
+            if (closingActive && siblingPane) {
+                tab->SetActivePane(siblingPane);
+                auto element = siblingPane->content;
+                if (auto control = element.try_as<winrt::GhosttyWin32::TerminalControl>()) {
+                    control.Focus(Microsoft::UI::Xaml::FocusState::Programmatic);
                 }
             }
             return;

--- a/App/MainWindow.xaml.cpp
+++ b/App/MainWindow.xaml.cpp
@@ -1938,7 +1938,7 @@ namespace winrt::GhosttyWin32::implementation
             ? MakeSplitBranch(splitDir, 0.5, std::move(newBranch), std::move(sourceWrapper))
             : MakeSplitBranch(splitDir, 0.5, std::move(sourceWrapper), std::move(newBranch));
 
-        if (!panelImpl->ReplacePane(sourcePane, std::move(subtree))) {
+        if (!panelImpl->ReplacePane(*sourcePane, std::move(subtree))) {
             // Tree mutation failed after the new surface was already
             // attached — detach so it doesn't leak.
             if (newControl) {
@@ -2271,7 +2271,7 @@ namespace winrt::GhosttyWin32::implementation
         // would dangle until the SetActivePane calls overwrite it.
         if (closingActive) tab->SetActivePane(nullptr);
 
-        auto result = panelImpl->RemovePane(pane);
+        auto result = panelImpl->RemovePane(*pane);
         if (result == Tree::RemoveResult::Collapsed) {
             // Tab survives; retarget focus to the surviving subtree.
             if (closingActive && siblingPane) {

--- a/App/MainWindow.xaml.cpp
+++ b/App/MainWindow.xaml.cpp
@@ -1738,7 +1738,7 @@ namespace winrt::GhosttyWin32::implementation
         {
             if (!panelImpl || !pane) return nullptr;
             auto* root = panelImpl->Tree().Root();
-            return root ? root->FindBranchOfPane(pane) : nullptr;
+            return root ? root->FindBranchOfPane(*pane) : nullptr;
         }
 
         // Pick the pane whose arranged rect is adjacent to `active`

--- a/App/MainWindow.xaml.cpp
+++ b/App/MainWindow.xaml.cpp
@@ -2239,7 +2239,7 @@ namespace winrt::GhosttyWin32::implementation
         if (closingActive) tab->SetActivePane(nullptr);
 
         auto result = panelImpl->RemovePane(*pane);
-        if (result == Tree::RemoveResult::Collapsed) {
+        if (result.IsCollapsed()) {
             // Tab survives; retarget focus to the surviving subtree.
             if (closingActive && siblingPane) {
                 tab->SetActivePane(siblingPane);

--- a/App/MainWindow.xaml.cpp
+++ b/App/MainWindow.xaml.cpp
@@ -1717,7 +1717,7 @@ namespace winrt::GhosttyWin32::implementation
                                  ghostty_surface_t surface)
         {
             if (!panelImpl) return nullptr;
-            return panelImpl->Tree().FindPane([surface](Pane const& p) {
+            return panelImpl->Tree().FindPaneBy([surface](Pane const& p) {
                 auto const* tc = Tab::PaneToTerminalControl(p);
                 return tc && tc->Surface().Owns(surface);
             });
@@ -2125,7 +2125,7 @@ namespace winrt::GhosttyWin32::implementation
         if (m_activeSurface) {
             if (auto* panelImpl =
                     winrt::get_self<implementation::SplitPanel>(t->Panel())) {
-                if (panelImpl->Tree().FindPane([this](Pane const& p) {
+                if (panelImpl->Tree().FindPaneBy([this](Pane const& p) {
                         auto const* tc = Tab::PaneToTerminalControl(p);
                         return tc && tc->Surface().Owns(m_activeSurface);
                     })) {
@@ -2260,7 +2260,7 @@ namespace winrt::GhosttyWin32::implementation
                             ? parentSplit->right.get()
                             : parentSplit->left.get();
                     if (siblingBranch) {
-                        siblingPane = siblingBranch->FindPane(
+                        siblingPane = siblingBranch->FindPaneBy(
                             [](Pane const&) { return true; });
                     }
                 }

--- a/App/SplitPanel.cpp
+++ b/App/SplitPanel.cpp
@@ -235,7 +235,7 @@ Windows::Foundation::Size SplitPanel::ArrangeOverride(Windows::Foundation::Size 
         // Zoom: only the zoomed pane is arranged. Cache the rect on
         // its wrapping Branch so downstream code (drag-resize,
         // GOTO_SPLIT direction navigation) can still recover it.
-        if (auto* zoomedBranch = root->FindBranchOfPane(zoomed)) {
+        if (auto* zoomedBranch = root->FindBranchOfPane(*zoomed)) {
             zoomedBranch->arrangedRect = fullRect;
         }
         if (auto element = zoomed->content) {

--- a/App/SplitPanel.cpp
+++ b/App/SplitPanel.cpp
@@ -78,7 +78,7 @@ void SplitPanel::EqualizeAll() {
     if (m_splitters.empty()) return;
     for (auto const& entry : m_splitters) {
         if (entry.branch) {
-            if (auto* split = entry.branch->AsSplit()) {
+            if (auto* split = entry.branch->TryGet<Split>()) {
                 split->ratio = 0.5;
             }
         }
@@ -100,13 +100,13 @@ void SplitPanel::SyncChildrenFromTree() {
 }
 
 void SplitPanel::AppendBranchToChildren(Branch& branch) {
-    if (auto* pane = branch.AsPane()) {
+    if (auto* pane = branch.TryGet<Pane>()) {
         if (auto element = pane->content) {
             Children().Append(element);
         }
         return;
     }
-    auto* split = branch.AsSplit();
+    auto* split = branch.TryGet<Split>();
     if (!split) return;
     // Walk left → splitter → right. Placing the splitter between the
     // children in Children() means it paints on top of the junction so
@@ -189,7 +189,7 @@ Windows::Foundation::Size SplitPanel::MeasureOverride(Windows::Foundation::Size 
 }
 
 Windows::Foundation::Size SplitPanel::MeasureBranch(Branch& branch, Windows::Foundation::Size available) {
-    if (auto* pane = branch.AsPane()) {
+    if (auto* pane = branch.TryGet<Pane>()) {
         if (auto element = pane->content) {
             element.Measure(available);
             return element.DesiredSize();
@@ -197,7 +197,7 @@ Windows::Foundation::Size SplitPanel::MeasureBranch(Branch& branch, Windows::Fou
         return { 0, 0 };
     }
 
-    auto* split = branch.AsSplit();
+    auto* split = branch.TryGet<Split>();
     if (!split) return { 0, 0 };
     auto* first  = split->left.get();
     auto* second = split->right.get();
@@ -250,14 +250,14 @@ Windows::Foundation::Size SplitPanel::ArrangeOverride(Windows::Foundation::Size 
 void SplitPanel::ArrangeBranch(Branch& branch, Windows::Foundation::Rect rect) {
     branch.arrangedRect = rect;
 
-    if (auto* pane = branch.AsPane()) {
+    if (auto* pane = branch.TryGet<Pane>()) {
         if (auto element = pane->content) {
             element.Arrange(rect);
         }
         return;
     }
 
-    auto* split = branch.AsSplit();
+    auto* split = branch.TryGet<Split>();
     if (!split) return;
     auto* first  = split->left.get();
     auto* second = split->right.get();
@@ -304,7 +304,7 @@ void SplitPanel::OnSplitterPointerMoved(Branch* splitBranch,
                                         Microsoft::UI::Xaml::Input::PointerRoutedEventArgs const& args)
 {
     if (!m_draggingBranch || m_draggingBranch != splitBranch) return;
-    auto* split = splitBranch ? splitBranch->AsSplit() : nullptr;
+    auto* split = splitBranch ? splitBranch->TryGet<Split>() : nullptr;
     if (!split) return;
 
     auto self = get_strong().as<winrt::Microsoft::UI::Xaml::UIElement>();

--- a/App/SplitPanel.cpp
+++ b/App/SplitPanel.cpp
@@ -208,7 +208,7 @@ Windows::Foundation::Size SplitPanel::MeasureBranch(Branch& branch, Windows::Fou
     auto firstAvail  = available;
     auto secondAvail = available;
     float thickness  = static_cast<float>(kSplitterThickness);
-    if (split->direction == Split::Direction::Horizontal) {
+    if (split->IsHorizontal()) {
         float useable = std::max(0.0f, available.Width - thickness);
         firstAvail.Width  = static_cast<float>(useable * split->ratio);
         secondAvail.Width = static_cast<float>(useable * (1.0 - split->ratio));
@@ -221,7 +221,7 @@ Windows::Foundation::Size SplitPanel::MeasureBranch(Branch& branch, Windows::Fou
     auto a = MeasureBranch(*first, firstAvail);
     auto b = MeasureBranch(*second, secondAvail);
 
-    if (split->direction == Split::Direction::Horizontal) {
+    if (split->IsHorizontal()) {
         return { a.Width + b.Width + thickness, std::max(a.Height, b.Height) };
     }
     return { std::max(a.Width, b.Width), a.Height + b.Height + thickness };
@@ -267,7 +267,7 @@ void SplitPanel::ArrangeBranch(Branch& branch, Windows::Foundation::Rect rect) {
 
     float thickness = static_cast<float>(kSplitterThickness);
 
-    if (split->direction == Split::Direction::Horizontal) {
+    if (split->IsHorizontal()) {
         float useable = std::max(0.0f, rect.Width - thickness);
         float firstW  = useable * static_cast<float>(split->ratio);
         float secondW = useable - firstW;
@@ -314,7 +314,7 @@ void SplitPanel::OnSplitterPointerMoved(Branch* splitBranch,
     double newRatio = split->ratio;
     float thickness = static_cast<float>(kSplitterThickness);
 
-    if (split->direction == Split::Direction::Horizontal) {
+    if (split->IsHorizontal()) {
         float useable = std::max(1.0f, rect.Width - thickness);
         newRatio = (point.X - rect.X) / useable;
     } else {

--- a/App/SplitPanel.cpp
+++ b/App/SplitPanel.cpp
@@ -23,7 +23,7 @@ bool SplitPanel::ReplacePane(Pane const& pane, std::unique_ptr<Branch> newSubtre
 
 Tree::RemoveResult SplitPanel::RemovePane(Pane const& pane) {
     auto result = m_tree.RemovePane(pane);
-    if (result != Tree::RemoveResult::NotFound) {
+    if (!result.IsNotFound()) {
         SyncChildrenFromTree();
         InvalidateMeasure();
         InvalidateArrange();

--- a/App/SplitPanel.cpp
+++ b/App/SplitPanel.cpp
@@ -6,77 +6,33 @@
 
 namespace winrt::GhosttyWin32::implementation {
 
-void SplitPanel::SetRoot(std::unique_ptr<Pane> root) {
-    m_root = std::move(root);
+void SplitPanel::SetRoot(std::unique_ptr<Branch> root) {
+    m_tree.SetRoot(std::move(root));
     SyncChildrenFromTree();
     InvalidateMeasure();
     InvalidateArrange();
 }
 
-bool SplitPanel::ReplaceLeaf(Pane* leaf, std::unique_ptr<Pane> newSubtree) {
-    if (!leaf || !newSubtree || !m_root) return false;
-
-    // Root replacement: defer to SetRoot so the same children-sync /
-    // invalidate path runs.
-    if (m_root.get() == leaf) {
-        SetRoot(std::move(newSubtree));
-        return true;
-    }
-
-    // Non-root: parent owns leaf via unique_ptr; rewrite that pointer.
-    auto* parent = leaf->Parent();
-    if (!parent) return false;
-    if (!parent->ReplaceChild(leaf, std::move(newSubtree))) return false;
-
+bool SplitPanel::ReplacePane(Pane const* pane, std::unique_ptr<Branch> newSubtree) {
+    if (!m_tree.ReplacePane(pane, std::move(newSubtree))) return false;
     SyncChildrenFromTree();
     InvalidateMeasure();
     InvalidateArrange();
     return true;
 }
 
-SplitPanel::RemovalResult SplitPanel::RemoveLeaf(Pane* leaf) {
-    if (!leaf || !m_root) return RemovalResult::NotFound;
-
-    if (m_root.get() == leaf) {
-        // Root removal — tree becomes empty. Caller decides the
-        // surrounding-tab action.
-        SetRoot(nullptr);
-        return RemovalResult::RemovedRoot;
-    }
-
-    auto* parent = leaf->Parent();
-    if (!parent) return RemovalResult::NotFound;
-
-    // Identify the surviving sibling (the parent's other child) and
-    // detach it from the parent so its unique_ptr survives the parent
-    // destruction triggered below.
-    Pane* siblingRaw = (parent->First() == leaf) ? parent->Second()
-                                                  : parent->First();
-    if (!siblingRaw) return RemovalResult::NotFound;
-    auto sibling = parent->DetachChild(siblingRaw);
-    if (!sibling) return RemovalResult::NotFound;
-
-    // Replace `parent` in its slot with the sibling subtree. The
-    // parent's unique_ptr is overwritten, which destroys the parent
-    // node and (transitively) the doomed leaf. The sibling subtree's
-    // contents are unaffected because we already detached it.
-    auto* grandparent = parent->Parent();
-    if (!grandparent) {
-        // parent was root.
-        SetRoot(std::move(sibling));
-    } else {
-        if (!grandparent->ReplaceChild(parent, std::move(sibling))) {
-            return RemovalResult::NotFound;  // shouldn't happen, but fail closed
-        }
+Tree::RemoveResult SplitPanel::RemovePane(Pane const* pane) {
+    auto result = m_tree.RemovePane(pane);
+    if (result != Tree::RemoveResult::NotFound) {
         SyncChildrenFromTree();
         InvalidateMeasure();
         InvalidateArrange();
     }
-    return RemovalResult::Collapsed;
+    return result;
 }
 
-void SplitPanel::SetZoomed(Pane* leaf) {
-    m_zoomedLeaf = leaf;
+void SplitPanel::SetZoomed(Pane const* pane) {
+    m_tree.SetZoomed(pane);
     UpdateChildVisibility();
     InvalidateMeasure();
     InvalidateArrange();
@@ -84,10 +40,11 @@ void SplitPanel::SetZoomed(Pane* leaf) {
 
 void SplitPanel::UpdateChildVisibility() {
     using namespace winrt::Microsoft::UI::Xaml;
-    // No zoom in effect — every child stays visible. Walk Children()
-    // directly so this also recovers visibility for elements that
-    // were previously hidden by an earlier zoom.
-    if (!m_zoomedLeaf) {
+    auto const* zoomed = m_tree.Zoomed();
+    // No zoom — every child stays visible. Walk Children() directly so
+    // this also recovers visibility for elements previously hidden by
+    // an earlier zoom.
+    if (!zoomed) {
         for (auto&& child : Children()) {
             if (auto el = child.try_as<UIElement>()) {
                 el.Visibility(Visibility::Visible);
@@ -95,10 +52,8 @@ void SplitPanel::UpdateChildVisibility() {
         }
         return;
     }
-    // Zoom active — only the zoomed leaf's content stays visible.
-    // Comparing UIElement projections by identity works because each
-    // element appears at most once in Children().
-    auto zoomElement = m_zoomedLeaf->Content();
+    // Zoom active — only the zoomed pane's content stays visible.
+    auto zoomElement = zoomed->content;
     for (auto&& child : Children()) {
         if (auto el = child.try_as<UIElement>()) {
             el.Visibility(el == zoomElement ? Visibility::Visible : Visibility::Collapsed);
@@ -110,10 +65,6 @@ void SplitPanel::SetDividerColor(winrt::Windows::UI::Color color) noexcept {
     using namespace winrt::Microsoft::UI::Xaml::Controls;
     using namespace winrt::Microsoft::UI::Xaml::Media;
     m_dividerBrush = SolidColorBrush(color);
-    // Repaint every existing splitter so a reload-driven colour
-    // change shows up without waiting for a tree rebuild. New
-    // splitters created after this point pick the brush up via
-    // MakeSplitter's check on m_dividerBrush.
     for (auto const& entry : m_splitters) {
         if (auto border = entry.element.try_as<Border>()) {
             border.Background(m_dividerBrush);
@@ -122,13 +73,15 @@ void SplitPanel::SetDividerColor(winrt::Windows::UI::Color color) noexcept {
 }
 
 void SplitPanel::EqualizeAll() {
-    // m_splitters already holds one entry per internal node, so reuse
-    // it instead of re-walking the tree. The vector is rebuilt on
-    // every SyncChildrenFromTree, so it's always in sync with the
-    // current tree shape.
+    // m_splitters already holds one entry per Split node — reuse
+    // instead of re-walking the tree.
     if (m_splitters.empty()) return;
     for (auto const& entry : m_splitters) {
-        if (entry.node) entry.node->SetRatio(0.5);
+        if (entry.branch) {
+            if (auto* split = entry.branch->AsSplit()) {
+                split->ratio = 0.5;
+            }
+        }
     }
     InvalidateMeasure();
     InvalidateArrange();
@@ -137,83 +90,56 @@ void SplitPanel::EqualizeAll() {
 void SplitPanel::SyncChildrenFromTree() {
     Children().Clear();
     m_splitters.clear();
-    m_draggingNode = nullptr;
-    // Any tree shape change invalidates a previously-stored zoom
-    // pointer (the leaf may have moved, been wrapped in a split, or
-    // gone away entirely). Clearing here is safer than auditing every
-    // call site for whether the zoomed leaf survived.
-    m_zoomedLeaf = nullptr;
-    if (m_root) AppendNodeToChildren(*m_root);
-    // Re-evaluate Visibility across the rebuilt Children collection:
-    // a previous zoom would have left some leaves with
-    // Visibility=Collapsed, and that state survives a Clear() +
-    // re-Append because Visibility is a property of the UIElement
-    // itself, not its parent-child relationship. With m_zoomedLeaf
-    // reset above, UpdateChildVisibility sets every child to Visible.
+    m_draggingBranch = nullptr;
+    // Any tree shape change invalidates a stored zoom pointer.
+    m_tree.ClearZoomed();
+    if (auto* root = m_tree.Root()) AppendBranchToChildren(*root);
+    // Re-evaluate Visibility after rebuilding Children (previous zoom
+    // could have left Visibility=Collapsed on now-unrelated elements).
     UpdateChildVisibility();
 }
 
-void SplitPanel::AppendNodeToChildren(Pane& node) {
-    if (node.IsLeaf()) {
-        if (auto element = node.Content()) {
+void SplitPanel::AppendBranchToChildren(Branch& branch) {
+    if (auto* pane = branch.AsPane()) {
+        if (auto element = pane->content) {
             Children().Append(element);
         }
         return;
     }
-    // Walk first → splitter → second. The visual order matches the
-    // layout order, and putting the splitter between the children in
-    // the Children() collection means it gets painted on top of the
-    // junction so the dragable strip is always reachable for input.
-    if (auto* f = node.First()) AppendNodeToChildren(*f);
-    auto splitter = MakeSplitter(&node);
+    auto* split = branch.AsSplit();
+    if (!split) return;
+    // Walk left → splitter → right. Placing the splitter between the
+    // children in Children() means it paints on top of the junction so
+    // the drag strip is always reachable for input.
+    if (split->left)  AppendBranchToChildren(*split->left);
+    auto splitter = MakeSplitter(&branch);
     Children().Append(splitter);
-    m_splitters.push_back({ splitter, &node });
-    if (auto* s = node.Second()) AppendNodeToChildren(*s);
+    m_splitters.push_back({ splitter, &branch });
+    if (split->right) AppendBranchToChildren(*split->right);
 }
 
-Microsoft::UI::Xaml::Controls::Border SplitPanel::MakeSplitter(Pane* node) {
+Microsoft::UI::Xaml::Controls::Border SplitPanel::MakeSplitter(Branch* splitBranch) {
     using namespace winrt::Microsoft::UI::Xaml;
     using namespace winrt::Microsoft::UI::Xaml::Controls;
     using namespace winrt::Microsoft::UI::Xaml::Input;
     using namespace winrt::Microsoft::UI::Xaml::Media;
 
     Border border{};
-    // Prefer the SetDividerColor-supplied brush (TabFactory resolves
-    // it from ghostty config) over the built-in fallback. Fallback
-    // is a semi-transparent gray, visible on both light- and dark-
-    // themed terminal backgrounds without dominating — used only
-    // when the factory hasn't called SetDividerColor yet.
     if (m_dividerBrush) {
         border.Background(m_dividerBrush);
     } else {
         border.Background(SolidColorBrush(winrt::Windows::UI::Color{ 96, 128, 128, 128 }));
     }
 
-    // No resize cursor for now — ProtectedCursor is protected on
-    // UIElement and Border is sealed, so we can't set the per-element
-    // cursor from outside without subclassing. A follow-up can swap
-    // this Border for a custom UserControl-based splitter that
-    // exposes the cursor setup; until then the strip is visible
-    // enough to grab without the cursor hint.
-
-    // Wire pointer events. `node` is captured by raw pointer; this is
-    // safe because Borders are recreated on every SyncChildrenFromTree,
-    // so a stale `node` would only exist on a stale Border that's
-    // already been removed from Children() (and whose events therefore
-    // can't fire).
-    //
-    // `this` is also captured raw — the SplitPanel owns the Border via
-    // Children(), so the impl lives at least as long as any event the
-    // Border can fire.
-    border.PointerPressed([this, node](winrt::Windows::Foundation::IInspectable const& sender,
-                                       PointerRoutedEventArgs const& args) {
+    border.PointerPressed([this, splitBranch](winrt::Windows::Foundation::IInspectable const& sender,
+                                              PointerRoutedEventArgs const& args) {
         if (auto el = sender.try_as<UIElement>()) {
-            OnSplitterPointerPressed(el, node, args);
+            OnSplitterPointerPressed(el, splitBranch, args);
         }
     });
-    border.PointerMoved([this, node](winrt::Windows::Foundation::IInspectable const&,
-                                     PointerRoutedEventArgs const& args) {
-        OnSplitterPointerMoved(node, args);
+    border.PointerMoved([this, splitBranch](winrt::Windows::Foundation::IInspectable const&,
+                                            PointerRoutedEventArgs const& args) {
+        OnSplitterPointerMoved(splitBranch, args);
     });
     border.PointerReleased([this](winrt::Windows::Foundation::IInspectable const& sender,
                                   PointerRoutedEventArgs const& args) {
@@ -231,30 +157,28 @@ Microsoft::UI::Xaml::Controls::Border SplitPanel::MakeSplitter(Pane* node) {
     return border;
 }
 
-Microsoft::UI::Xaml::Controls::Border SplitPanel::SplitterForNode(Pane const* node) const {
+Microsoft::UI::Xaml::Controls::Border SplitPanel::SplitterForBranch(Branch const* splitBranch) const {
     for (auto const& entry : m_splitters) {
-        if (entry.node == node) return entry.element;
+        if (entry.branch == splitBranch) return entry.element;
     }
     return nullptr;
 }
 
 Windows::Foundation::Size SplitPanel::MeasureOverride(Windows::Foundation::Size availableSize) {
-    if (!m_root) return { 0, 0 };
-    // Zoom path: only the zoomed leaf participates in layout. The
-    // others are Visibility=Collapsed so Panel's base class skips
-    // them entirely — we don't need to Measure them.
-    if (m_zoomedLeaf && m_zoomedLeaf->IsLeaf()) {
-        if (auto element = m_zoomedLeaf->Content()) {
+    auto* root = m_tree.Root();
+    if (!root) return { 0, 0 };
+    // Zoom path: only the zoomed pane participates in layout. Others
+    // are Visibility=Collapsed so Panel's base class skips them.
+    if (auto const* zoomed = m_tree.Zoomed()) {
+        if (auto element = zoomed->content) {
             element.Measure(availableSize);
             return element.DesiredSize();
         }
         return { 0, 0 };
     }
-    auto result = MeasureNode(*m_root, availableSize);
-    // Every Splitter must also be measured before Arrange — XAML's
-    // contract is "every child gets Measure before Arrange or the
-    // framework panics". They don't influence the panel's desired
-    // size, just have to be visited.
+    auto result = MeasureBranch(*root, availableSize);
+    // Every splitter must be measured before Arrange — XAML's contract
+    // is "every child gets Measure or the framework panics".
     for (auto const& entry : m_splitters) {
         if (entry.element) {
             entry.element.Measure({ static_cast<float>(kSplitterThickness),
@@ -264,148 +188,140 @@ Windows::Foundation::Size SplitPanel::MeasureOverride(Windows::Foundation::Size 
     return result;
 }
 
-Windows::Foundation::Size SplitPanel::MeasureNode(Pane& node, Windows::Foundation::Size available) {
-    if (node.IsLeaf()) {
-        if (auto element = node.Content()) {
+Windows::Foundation::Size SplitPanel::MeasureBranch(Branch& branch, Windows::Foundation::Size available) {
+    if (auto* pane = branch.AsPane()) {
+        if (auto element = pane->content) {
             element.Measure(available);
             return element.DesiredSize();
         }
         return { 0, 0 };
     }
 
-    auto* first = node.First();
-    auto* second = node.Second();
+    auto* split = branch.AsSplit();
+    if (!split) return { 0, 0 };
+    auto* first  = split->left.get();
+    auto* second = split->right.get();
     if (!first && !second) return { 0, 0 };
-    if (!first)  return MeasureNode(*second, available);
-    if (!second) return MeasureNode(*first, available);
+    if (!first)  return MeasureBranch(*second, available);
+    if (!second) return MeasureBranch(*first, available);
 
-    // Reserve room for the splitter strip on the split axis so the
-    // children don't ask for space the splitter will end up taking.
     auto firstAvail  = available;
     auto secondAvail = available;
     float thickness  = static_cast<float>(kSplitterThickness);
-    if (node.Orientation() == SplitOrientation::Horizontal) {
+    if (split->direction == Split::Direction::Horizontal) {
         float useable = std::max(0.0f, available.Width - thickness);
-        firstAvail.Width  = static_cast<float>(useable * node.Ratio());
-        secondAvail.Width = static_cast<float>(useable * (1.0 - node.Ratio()));
+        firstAvail.Width  = static_cast<float>(useable * split->ratio);
+        secondAvail.Width = static_cast<float>(useable * (1.0 - split->ratio));
     } else {
         float useable = std::max(0.0f, available.Height - thickness);
-        firstAvail.Height  = static_cast<float>(useable * node.Ratio());
-        secondAvail.Height = static_cast<float>(useable * (1.0 - node.Ratio()));
+        firstAvail.Height  = static_cast<float>(useable * split->ratio);
+        secondAvail.Height = static_cast<float>(useable * (1.0 - split->ratio));
     }
 
-    auto a = MeasureNode(*first, firstAvail);
-    auto b = MeasureNode(*second, secondAvail);
+    auto a = MeasureBranch(*first, firstAvail);
+    auto b = MeasureBranch(*second, secondAvail);
 
-    if (node.Orientation() == SplitOrientation::Horizontal) {
+    if (split->direction == Split::Direction::Horizontal) {
         return { a.Width + b.Width + thickness, std::max(a.Height, b.Height) };
     }
     return { std::max(a.Width, b.Width), a.Height + b.Height + thickness };
 }
 
 Windows::Foundation::Size SplitPanel::ArrangeOverride(Windows::Foundation::Size finalSize) {
-    if (!m_root) return finalSize;
+    auto* root = m_tree.Root();
+    if (!root) return finalSize;
     Windows::Foundation::Rect fullRect{ 0, 0, finalSize.Width, finalSize.Height };
-    // Zoom: only the zoomed leaf is arranged. Others are Collapsed so
-    // their ActualSize / SizeChanged don't fire; the SwapChainPanel
-    // they own keeps whatever swap chain it had bound and resumes
-    // when unzoomed.
-    if (m_zoomedLeaf && m_zoomedLeaf->IsLeaf()) {
-        m_zoomedLeaf->SetArrangedRect(fullRect);
-        if (auto element = m_zoomedLeaf->Content()) {
+    if (auto const* zoomed = m_tree.Zoomed()) {
+        // Zoom: only the zoomed pane is arranged. Cache the rect on
+        // its wrapping Branch so downstream code (drag-resize,
+        // GOTO_SPLIT direction navigation) can still recover it.
+        if (auto* zoomedBranch = root->FindBranchOfPane(zoomed)) {
+            zoomedBranch->arrangedRect = fullRect;
+        }
+        if (auto element = zoomed->content) {
             element.Arrange(fullRect);
         }
         return finalSize;
     }
-    ArrangeNode(*m_root, fullRect);
+    ArrangeBranch(*root, fullRect);
     return finalSize;
 }
 
-void SplitPanel::ArrangeNode(Pane& node, Windows::Foundation::Rect rect) {
-    // Cache the arranged rect on the node so drag-resize and
-    // direction-based pane navigation can recover it without walking
-    // the tree from the root each time.
-    node.SetArrangedRect(rect);
+void SplitPanel::ArrangeBranch(Branch& branch, Windows::Foundation::Rect rect) {
+    branch.arrangedRect = rect;
 
-    if (node.IsLeaf()) {
-        if (auto element = node.Content()) {
+    if (auto* pane = branch.AsPane()) {
+        if (auto element = pane->content) {
             element.Arrange(rect);
         }
         return;
     }
 
-    auto* first = node.First();
-    auto* second = node.Second();
+    auto* split = branch.AsSplit();
+    if (!split) return;
+    auto* first  = split->left.get();
+    auto* second = split->right.get();
     if (!first && !second) return;
-    if (!first)  { ArrangeNode(*second, rect); return; }
-    if (!second) { ArrangeNode(*first, rect); return; }
+    if (!first)  { ArrangeBranch(*second, rect); return; }
+    if (!second) { ArrangeBranch(*first, rect); return; }
 
     float thickness = static_cast<float>(kSplitterThickness);
 
-    if (node.Orientation() == SplitOrientation::Horizontal) {
+    if (split->direction == Split::Direction::Horizontal) {
         float useable = std::max(0.0f, rect.Width - thickness);
-        float firstW  = useable * static_cast<float>(node.Ratio());
+        float firstW  = useable * static_cast<float>(split->ratio);
         float secondW = useable - firstW;
         Windows::Foundation::Rect firstRect{ rect.X, rect.Y, firstW, rect.Height };
         Windows::Foundation::Rect splitRect{ rect.X + firstW, rect.Y, thickness, rect.Height };
         Windows::Foundation::Rect secondRect{ rect.X + firstW + thickness, rect.Y, secondW, rect.Height };
-        ArrangeNode(*first, firstRect);
-        if (auto sp = SplitterForNode(&node)) sp.Arrange(splitRect);
-        ArrangeNode(*second, secondRect);
+        ArrangeBranch(*first, firstRect);
+        if (auto sp = SplitterForBranch(&branch)) sp.Arrange(splitRect);
+        ArrangeBranch(*second, secondRect);
     } else {
         float useable = std::max(0.0f, rect.Height - thickness);
-        float firstH  = useable * static_cast<float>(node.Ratio());
+        float firstH  = useable * static_cast<float>(split->ratio);
         float secondH = useable - firstH;
         Windows::Foundation::Rect firstRect{ rect.X, rect.Y, rect.Width, firstH };
         Windows::Foundation::Rect splitRect{ rect.X, rect.Y + firstH, rect.Width, thickness };
         Windows::Foundation::Rect secondRect{ rect.X, rect.Y + firstH + thickness, rect.Width, secondH };
-        ArrangeNode(*first, firstRect);
-        if (auto sp = SplitterForNode(&node)) sp.Arrange(splitRect);
-        ArrangeNode(*second, secondRect);
+        ArrangeBranch(*first, firstRect);
+        if (auto sp = SplitterForBranch(&branch)) sp.Arrange(splitRect);
+        ArrangeBranch(*second, secondRect);
     }
 }
 
 void SplitPanel::OnSplitterPointerPressed(Microsoft::UI::Xaml::UIElement const& splitter,
-                                          Pane* node,
+                                          Branch* splitBranch,
                                           Microsoft::UI::Xaml::Input::PointerRoutedEventArgs const& args)
 {
-    if (!node) return;
+    if (!splitBranch) return;
     if (!splitter.CapturePointer(args.Pointer())) return;
-    m_draggingNode = node;
+    m_draggingBranch = splitBranch;
     args.Handled(true);
 }
 
-void SplitPanel::OnSplitterPointerMoved(Pane* node,
+void SplitPanel::OnSplitterPointerMoved(Branch* splitBranch,
                                         Microsoft::UI::Xaml::Input::PointerRoutedEventArgs const& args)
 {
-    // Only consume moves that belong to the active drag — without
-    // this check, a stray PointerMoved on a non-pressed splitter
-    // (e.g. hover) would mutate the ratio.
-    if (!m_draggingNode || m_draggingNode != node) return;
+    if (!m_draggingBranch || m_draggingBranch != splitBranch) return;
+    auto* split = splitBranch ? splitBranch->AsSplit() : nullptr;
+    if (!split) return;
 
-    // Position in SplitPanel local coordinates so it can be compared
-    // against the parent split's arranged rect (also expressed in
-    // SplitPanel coordinates). get_strong() returns the projected
-    // SplitPanel; .as<UIElement>() narrows it to the UIElement
-    // projection GetCurrentPoint expects without the multi-step
-    // implicit conversion `*this` would need.
     auto self = get_strong().as<winrt::Microsoft::UI::Xaml::UIElement>();
     auto point = args.GetCurrentPoint(self).Position();
 
-    // The parent split occupies the same rect ArrangeNode last
-    // assigned to it, cached on the Pane itself.
-    auto rect = node->ArrangedRect();
-    double newRatio = node->Ratio();
+    auto rect = splitBranch->arrangedRect;
+    double newRatio = split->ratio;
     float thickness = static_cast<float>(kSplitterThickness);
 
-    if (node->Orientation() == SplitOrientation::Horizontal) {
+    if (split->direction == Split::Direction::Horizontal) {
         float useable = std::max(1.0f, rect.Width - thickness);
         newRatio = (point.X - rect.X) / useable;
     } else {
         float useable = std::max(1.0f, rect.Height - thickness);
         newRatio = (point.Y - rect.Y) / useable;
     }
-    node->SetRatio(newRatio);  // clamped to [0.05, 0.95] inside Pane
+    split->ratio = ClampSplitRatio(newRatio);
     InvalidateMeasure();
     InvalidateArrange();
     args.Handled(true);
@@ -415,7 +331,7 @@ void SplitPanel::OnSplitterPointerReleased(Microsoft::UI::Xaml::UIElement const&
                                            Microsoft::UI::Xaml::Input::PointerRoutedEventArgs const& args)
 {
     splitter.ReleasePointerCapture(args.Pointer());
-    m_draggingNode = nullptr;
+    m_draggingBranch = nullptr;
     args.Handled(true);
 }
 

--- a/App/SplitPanel.cpp
+++ b/App/SplitPanel.cpp
@@ -13,7 +13,7 @@ void SplitPanel::SetRoot(std::unique_ptr<Branch> root) {
     InvalidateArrange();
 }
 
-bool SplitPanel::ReplacePane(Pane const* pane, std::unique_ptr<Branch> newSubtree) {
+bool SplitPanel::ReplacePane(Pane const& pane, std::unique_ptr<Branch> newSubtree) {
     if (!m_tree.ReplacePane(pane, std::move(newSubtree))) return false;
     SyncChildrenFromTree();
     InvalidateMeasure();
@@ -21,7 +21,7 @@ bool SplitPanel::ReplacePane(Pane const* pane, std::unique_ptr<Branch> newSubtre
     return true;
 }
 
-Tree::RemoveResult SplitPanel::RemovePane(Pane const* pane) {
+Tree::RemoveResult SplitPanel::RemovePane(Pane const& pane) {
     auto result = m_tree.RemovePane(pane);
     if (result != Tree::RemoveResult::NotFound) {
         SyncChildrenFromTree();

--- a/App/SplitPanel.h
+++ b/App/SplitPanel.h
@@ -40,14 +40,15 @@ struct SplitPanel : SplitPanelT<SplitPanel> {
     void SetRoot(std::unique_ptr<Branch> root);
 
     // Replace the Branch wrapping `pane` with `newSubtree`. Returns
-    // true on success; false if the pane isn't in this tree or either
-    // pointer is null.
+    // true on success; false if the pane isn't in this tree or
+    // `newSubtree` is null. `pane` is by reference — non-null at the
+    // type level.
     //
     // Used by NEW_SPLIT: the caller builds a split subtree whose left
     // is a new Branch wrapping the existing pane's content (preserving
     // its PaneId so close_surface_cb still routes correctly) plus a
     // fresh Branch for the new pane, then calls this to swap it in.
-    bool ReplacePane(Pane const* pane, std::unique_ptr<Branch> newSubtree);
+    bool ReplacePane(Pane const& pane, std::unique_ptr<Branch> newSubtree);
 
     // Remove `pane` from the tree and collapse its enclosing split by
     // promoting the surviving sibling. Returns the kind of removal so
@@ -60,7 +61,7 @@ struct SplitPanel : SplitPanelT<SplitPanel> {
     // The pane's TerminalControl is NOT detached here; the caller is
     // expected to do that before invoking RemovePane so the surface
     // and DComp handle are released synchronously.
-    Tree::RemoveResult RemovePane(Pane const* pane);
+    Tree::RemoveResult RemovePane(Pane const& pane);
 
     // Reset every Split node's ratio to 0.5 so each split divides
     // its area evenly. Matches EQUALIZE_SPLITS; no-op on a single-pane

--- a/App/SplitPanel.h
+++ b/App/SplitPanel.h
@@ -1,181 +1,156 @@
 #pragma once
 
 #include "SplitPanel.g.h"
-#include "Tabs/Panes/Pane.h"
+#include "Tabs/Panes/Tree.h"
 #include <memory>
 #include <vector>
 
 namespace winrt::GhosttyWin32::implementation {
 
-// Custom Panel that lays out a Pane tree.
+// Custom Panel that lays out a pane tree.
 //
-// The Pane tree is the source of truth for geometry: each internal
-// node holds an orientation + ratio, each leaf wraps a UIElement.
-// SplitPanel owns the root (`m_root`); MeasureOverride / ArrangeOverride
-// recurse the tree and split the available rectangle accordingly.
+// Owns the tree (via `Tree m_tree`) and renders it — MeasureOverride /
+// ArrangeOverride walk each Branch and split the available rectangle
+// according to the Split direction and ratio at each internal node.
+// Leaves' UIElements are appended to the underlying Panel's Children()
+// collection so framework input routing, hit-testing, and measure /
+// arrange work end-to-end; the XAML shape stays flat (no nested
+// Panels, no GridSplitter).
 //
-// Children registration with the underlying Panel is handled by
-// SetRoot(): every leaf's `Content()` UIElement is appended to
-// `Children()` so the framework's measure / arrange machinery and
-// hit-testing see them. The XAML tree shape is intentionally flat —
-// no nested Panels, no GridSplitter — so leaves don't pay for
-// transform stacks they don't need, and a future "swap two leaves"
-// operation reduces to swapping unique_ptrs in the tree without
-// touching XAML beyond a Measure invalidation.
+// This class straddles the model-view boundary:
+//   * The tree data + walker + structural mutations live on `m_tree`
+//     (pure C++, no WinUI, unit-testable in isolation).
+//   * The XAML side of things — Children collection, MeasureOverride,
+//     ArrangeOverride, splitter Borders, pointer-drag handling —
+//     lives here on SplitPanel.
+//
+// SetRoot / ReplacePane / RemovePane are adapter methods: they call
+// through to Tree's mutations, then refresh Children() and invalidate
+// layout. Callers who only want to READ the tree go through Tree()
+// directly (`splitPanel->Tree().AnyPaneMatches(...)`), skipping the
+// XAML-side sync entirely.
 struct SplitPanel : SplitPanelT<SplitPanel> {
     SplitPanel() = default;
 
-    // Replaces the current Pane tree with `root` and refreshes the
-    // Panel's children to contain exactly the leaf UIElements (in
-    // depth-first traversal order). Safe to call repeatedly; the old
-    // tree is destroyed, the new one takes effect on the next layout
-    // pass.
-    //
-    // Passing `nullptr` clears the panel: tree gone, no children.
-    void SetRoot(std::unique_ptr<Pane> root);
+    // Replaces the current tree with `root` and refreshes the Panel's
+    // Children to contain exactly the leaf UIElements in depth-first
+    // order. Safe to call repeatedly; the old tree is destroyed, the
+    // new one takes effect on the next layout pass. Passing nullptr
+    // clears the panel.
+    void SetRoot(std::unique_ptr<Branch> root);
 
-    // Replace `leaf` (which must currently be reachable from m_root)
-    // with the subtree `newSubtree`. Returns true on success — false
-    // if `leaf` isn't in this tree, or if either pointer is null.
+    // Replace the Branch wrapping `pane` with `newSubtree`. Returns
+    // true on success; false if the pane isn't in this tree or either
+    // pointer is null.
     //
-    // Used by NEW_SPLIT: the caller builds a split subtree whose
-    // first/second is a new leaf wrapping the existing leaf's content
-    // (preserving its PaneId so close_surface_cb still routes
-    // correctly) plus a fresh leaf for the new pane, then calls this
-    // to swap it in. The framework's Children() collection is
-    // refreshed and a layout pass is requested.
-    bool ReplaceLeaf(Pane* leaf, std::unique_ptr<Pane> newSubtree);
+    // Used by NEW_SPLIT: the caller builds a split subtree whose left
+    // is a new Branch wrapping the existing pane's content (preserving
+    // its PaneId so close_surface_cb still routes correctly) plus a
+    // fresh Branch for the new pane, then calls this to swap it in.
+    bool ReplacePane(Pane const* pane, std::unique_ptr<Branch> newSubtree);
 
-    // Remove `leaf` from the tree and collapse its enclosing split
-    // node, promoting the surviving sibling into the slot the parent
-    // occupied. Returns the kind of removal that happened so the
-    // caller can take additional UI action:
-    //   * RemovedRoot — leaf was the root; tree is now empty (the
-    //     caller is expected to close the surrounding tab).
-    //   * Collapsed   — leaf had a sibling; parent split node was
-    //     replaced with that sibling, tab continues to render.
-    //   * NotFound    — leaf wasn't reachable from m_root, or one of
-    //     the back-pointer invariants was broken; no mutation
-    //     happened.
+    // Remove `pane` from the tree and collapse its enclosing split by
+    // promoting the surviving sibling. Returns the kind of removal so
+    // the caller can decide follow-up UI:
+    //   * RemovedRoot — pane was the root; tree is now empty (caller
+    //     is expected to close the surrounding tab).
+    //   * Collapsed   — split collapsed onto sibling; tab continues.
+    //   * NotFound    — pane wasn't in this tree; no mutation.
     //
-    // The leaf's TerminalControl is NOT detached here; the caller is
-    // expected to do that before invoking RemoveLeaf so the surface
+    // The pane's TerminalControl is NOT detached here; the caller is
+    // expected to do that before invoking RemovePane so the surface
     // and DComp handle are released synchronously.
-    enum class RemovalResult {
-        NotFound,
-        RemovedRoot,
-        Collapsed,
-    };
-    RemovalResult RemoveLeaf(Pane* leaf);
+    Tree::RemoveResult RemovePane(Pane const* pane);
 
-    // Reset every internal node's ratio to 0.5 (so each split divides
-    // its area evenly) and trigger a layout pass. Matches what the
-    // ghostty EQUALIZE_SPLITS action expects — no-op on a single-leaf
+    // Reset every Split node's ratio to 0.5 so each split divides
+    // its area evenly. Matches EQUALIZE_SPLITS; no-op on a single-pane
     // tree.
     void EqualizeAll();
 
-    // Zoom one leaf to fill the entire SplitPanel — every other leaf
-    // and every splitter is hidden via Visibility=Collapsed, and
-    // MeasureOverride / ArrangeOverride lay out only the zoomed leaf
-    // at the full size. Pass nullptr to unzoom.
-    //
-    // `leaf` must be currently reachable from m_root; on any tree
-    // mutation (SetRoot / ReplaceLeaf / RemoveLeaf) the zoom is
-    // automatically cleared because SyncChildrenFromTree resets the
-    // state — the previously-stored pointer can no longer be trusted
-    // after the tree shape changes.
-    void SetZoomed(Pane* leaf);
-    Pane* ZoomedLeaf() const noexcept { return m_zoomedLeaf; }
+    // Zoom one pane to fill the entire SplitPanel — every other pane
+    // and every splitter is hidden via Visibility=Collapsed. Pass
+    // nullptr to unzoom. `pane` must be currently reachable from the
+    // tree; on any tree mutation the zoom is automatically cleared
+    // because the stored pointer can no longer be trusted.
+    void SetZoomed(Pane const* pane);
+    Pane const* Zoomed() const noexcept { return m_tree.Zoomed(); }
 
-    // Read-only access for the host (Tab will need this to walk for
-    // active-leaf focusing, but Phase 1 only uses it for diagnostics).
-    Pane* Root() const noexcept { return m_root.get(); }
+    // Read-only access to the underlying tree — walker calls go through
+    // here (`splitPanel->Tree().AnyPaneMatches(...)`).
+    class Tree&       Tree()       noexcept { return m_tree; }
+    class Tree const& Tree() const noexcept { return m_tree; }
 
     // Panel overrides.
-    Windows::Foundation::Size MeasureOverride(Windows::Foundation::Size availableSize);
-    Windows::Foundation::Size ArrangeOverride(Windows::Foundation::Size finalSize);
+    winrt::Windows::Foundation::Size MeasureOverride(winrt::Windows::Foundation::Size availableSize);
+    winrt::Windows::Foundation::Size ArrangeOverride(winrt::Windows::Foundation::Size finalSize);
 
     // Width of the splitter strip in DIPs. Doubles as the click
-    // hit-target for drag-resize — at 1 DIP the click area is
-    // small but precise; bump if drag becomes too finicky in
-    // practice.
+    // hit-target for drag-resize.
     static constexpr double kSplitterThickness = 1.0;
 
-    // Set the brush used to paint the splitter strip. Called once
-    // by the factory right after the SplitPanel is constructed
-    // (before any tree exists), and re-callable later if a config
-    // reload changes split-divider-color. Refreshes the Background
-    // of any already-laid-out splitter Borders so the change shows
-    // up without rebuilding the tree.
+    // Set the brush used to paint the splitter strip. Called once by
+    // TabFactory (config-derived colour) and re-callable if a config
+    // reload changes split-divider-color.
     void SetDividerColor(winrt::Windows::UI::Color color) noexcept;
 
 private:
     // Recursive measure — caps each subtree at its share of `available`
-    // along the split axis. Called by MeasureOverride.
-    Windows::Foundation::Size MeasureNode(Pane& node, Windows::Foundation::Size available);
+    // along the split axis.
+    winrt::Windows::Foundation::Size MeasureBranch(Branch& branch, winrt::Windows::Foundation::Size available);
 
-    // Recursive arrange — `rect` is the area assigned to `node` in
-    // SplitPanel coordinates, before any nested splits apply.
-    void ArrangeNode(Pane& node, Windows::Foundation::Rect rect);
+    // Recursive arrange — `rect` is the area assigned to `branch` in
+    // SplitPanel coordinates, before any nested splits apply. Caches
+    // the arranged rect on the Branch itself for later use (drag-resize,
+    // direction-based GOTO_SPLIT).
+    void ArrangeBranch(Branch& branch, winrt::Windows::Foundation::Rect rect);
 
-    // Repopulates `Children()` (and the parallel `m_splitters` list)
-    // to match the current tree. Called by SetRoot / ReplaceLeaf /
-    // RemoveLeaf after a tree mutation.
+    // Repopulates Children() and m_splitters to match the current tree.
+    // Called after every SetRoot / ReplacePane / RemovePane.
     void SyncChildrenFromTree();
 
-    // Append a depth-first traversal of `node` to `Children()`: every
-    // leaf's content, and one fresh Splitter Border per internal node
-    // (recorded in m_splitters so MeasureNode / ArrangeNode can reach
-    // it from the corresponding Pane*).
-    void AppendNodeToChildren(Pane& node);
+    // Append a depth-first traversal of `branch` to Children(): every
+    // leaf's content, and one fresh Splitter Border per Split node
+    // (recorded in m_splitters so measure/arrange can find it).
+    void AppendBranchToChildren(Branch& branch);
 
-    // Build a Border for the drag-handle of an internal node and wire
+    // Build a Border for the drag-handle of a Split branch and wire
     // its pointer events. Borders are recreated on every
-    // SyncChildrenFromTree, so the captured node pointer is always
-    // current at the time the lambda runs.
-    Microsoft::UI::Xaml::Controls::Border MakeSplitter(Pane* node);
+    // SyncChildrenFromTree, so the captured Branch* is current at the
+    // time the lambda runs.
+    winrt::Microsoft::UI::Xaml::Controls::Border MakeSplitter(Branch* splitBranch);
 
-    // Find the Border previously created for `node`, or nullptr if
-    // none. Used during measure/arrange to position the strip.
-    Microsoft::UI::Xaml::Controls::Border SplitterForNode(Pane const* node) const;
+    // Find the Border previously created for `splitBranch`, or nullptr.
+    winrt::Microsoft::UI::Xaml::Controls::Border SplitterForBranch(Branch const* splitBranch) const;
 
-    // Pointer event handlers. Called from the lambdas wired up in
-    // MakeSplitter. `splitter` is the Border that owns the event;
-    // `node` is the internal Pane the splitter is for.
-    void OnSplitterPointerPressed(Microsoft::UI::Xaml::UIElement const& splitter,
-                                  Pane* node,
-                                  Microsoft::UI::Xaml::Input::PointerRoutedEventArgs const& args);
-    void OnSplitterPointerMoved(Pane* node,
-                                Microsoft::UI::Xaml::Input::PointerRoutedEventArgs const& args);
-    void OnSplitterPointerReleased(Microsoft::UI::Xaml::UIElement const& splitter,
-                                   Microsoft::UI::Xaml::Input::PointerRoutedEventArgs const& args);
+    // Pointer event handlers. `splitBranch` is the Branch (holding a
+    // Split) whose splitter is being manipulated.
+    void OnSplitterPointerPressed(winrt::Microsoft::UI::Xaml::UIElement const& splitter,
+                                  Branch* splitBranch,
+                                  winrt::Microsoft::UI::Xaml::Input::PointerRoutedEventArgs const& args);
+    void OnSplitterPointerMoved(Branch* splitBranch,
+                                winrt::Microsoft::UI::Xaml::Input::PointerRoutedEventArgs const& args);
+    void OnSplitterPointerReleased(winrt::Microsoft::UI::Xaml::UIElement const& splitter,
+                                   winrt::Microsoft::UI::Xaml::Input::PointerRoutedEventArgs const& args);
 
     struct SplitterEntry {
-        Microsoft::UI::Xaml::Controls::Border element{ nullptr };
-        Pane* node{ nullptr };
+        winrt::Microsoft::UI::Xaml::Controls::Border element{ nullptr };
+        Branch* branch{ nullptr };  // always a Branch holding a Split
     };
 
     // Refresh Visibility on every child so the zoom state matches
-    // m_zoomedLeaf. Called from SetZoomed and from SyncChildrenFromTree
-    // (after rebuilding Children() but before the next layout pass).
+    // Tree().Zoomed().
     void UpdateChildVisibility();
 
-    std::unique_ptr<Pane> m_root;
+    class Tree m_tree;
     std::vector<SplitterEntry> m_splitters;
-    // Cached brush handed to every splitter Border. Set by
-    // SetDividerColor; if null, MakeSplitter falls back to a
-    // neutral semi-transparent gray so brand-new SplitPanels are
-    // still visible before the factory hooks up the config-derived
-    // colour.
+    // Cached brush handed to every splitter Border. Null before
+    // TabFactory calls SetDividerColor — MakeSplitter then falls
+    // back to a neutral semi-transparent gray so brand-new
+    // SplitPanels are still visible.
     winrt::Microsoft::UI::Xaml::Media::SolidColorBrush m_dividerBrush{ nullptr };
-    // Set while a splitter drag is in progress (PointerPressed →
-    // PointerReleased / CaptureLost). Identifies which internal node's
-    // ratio is being updated by PointerMoved.
-    Pane* m_draggingNode{ nullptr };
-    // Set by SetZoomed — the leaf that should fill the entire panel
-    // while other leaves / splitters are hidden. Cleared by tree
-    // mutations because the stored pointer can no longer be trusted.
-    Pane* m_zoomedLeaf{ nullptr };
+    // Set while a splitter drag is in progress. Identifies which Split
+    // branch's ratio is being updated by PointerMoved.
+    Branch* m_draggingBranch{ nullptr };
 };
 
 }  // namespace winrt::GhosttyWin32::implementation

--- a/App/Tabs/Panes/Branch.h
+++ b/App/Tabs/Panes/Branch.h
@@ -104,8 +104,9 @@ inline bool Branch::AnyPaneMatches(
 {
     if (auto* p = TryGet<Pane>()) return pred(*p);
     if (auto* s = TryGet<Split>()) {
-        return (s->left  && s->left ->AnyPaneMatches(pred))
-            || (s->right && s->right->AnyPaneMatches(pred));
+        return s->AnyOfChildren([&](Branch const& c) {
+            return c.AnyPaneMatches(pred);
+        });
     }
     return false;
 }
@@ -113,16 +114,14 @@ inline bool Branch::AnyPaneMatches(
 inline void Branch::ForEachPane(std::function<void(Pane&)> const& visitor) {
     if (auto* p = TryGet<Pane>()) { visitor(*p); return; }
     if (auto* s = TryGet<Split>()) {
-        if (s->left)  s->left ->ForEachPane(visitor);
-        if (s->right) s->right->ForEachPane(visitor);
+        s->ForEachChild([&](Branch& c) { c.ForEachPane(visitor); });
     }
 }
 
 inline void Branch::ForEachPane(std::function<void(Pane const&)> const& visitor) const {
     if (auto* p = TryGet<Pane>()) { visitor(*p); return; }
     if (auto* s = TryGet<Split>()) {
-        if (s->left)  s->left ->ForEachPane(visitor);
-        if (s->right) s->right->ForEachPane(visitor);
+        s->ForEachChild([&](Branch const& c) { c.ForEachPane(visitor); });
     }
 }
 
@@ -131,8 +130,12 @@ inline Pane* Branch::FindPane(
 {
     if (auto* p = TryGet<Pane>()) return pred(*p) ? p : nullptr;
     if (auto* s = TryGet<Split>()) {
-        if (s->left)  if (auto* hit = s->left->FindPane(pred))  return hit;
-        if (s->right) if (auto* hit = s->right->FindPane(pred)) return hit;
+        Pane* hit = nullptr;
+        s->FindChild([&](Branch& c) {
+            hit = c.FindPane(pred);
+            return hit != nullptr;
+        });
+        return hit;
     }
     return nullptr;
 }
@@ -142,8 +145,12 @@ inline Pane const* Branch::FindPane(
 {
     if (auto* p = TryGet<Pane>()) return pred(*p) ? p : nullptr;
     if (auto* s = TryGet<Split>()) {
-        if (s->left)  if (auto* hit = s->left->FindPane(pred))  return hit;
-        if (s->right) if (auto* hit = s->right->FindPane(pred)) return hit;
+        Pane const* hit = nullptr;
+        s->FindChild([&](Branch const& c) {
+            hit = c.FindPane(pred);
+            return hit != nullptr;
+        });
+        return hit;
     }
     return nullptr;
 }
@@ -152,8 +159,12 @@ inline Branch* Branch::FindBranchOfPane(Pane const* target) {
     if (!target) return nullptr;
     if (auto* p = TryGet<Pane>()) return (p == target) ? this : nullptr;
     if (auto* s = TryGet<Split>()) {
-        if (s->left)  if (auto* hit = s->left ->FindBranchOfPane(target)) return hit;
-        if (s->right) if (auto* hit = s->right->FindBranchOfPane(target)) return hit;
+        Branch* hit = nullptr;
+        s->FindChild([&](Branch& c) {
+            hit = c.FindBranchOfPane(target);
+            return hit != nullptr;
+        });
+        return hit;
     }
     return nullptr;
 }
@@ -162,8 +173,12 @@ inline Branch const* Branch::FindBranchOfPane(Pane const* target) const {
     if (!target) return nullptr;
     if (auto* p = TryGet<Pane>()) return (p == target) ? this : nullptr;
     if (auto* s = TryGet<Split>()) {
-        if (s->left)  if (auto* hit = s->left ->FindBranchOfPane(target)) return hit;
-        if (s->right) if (auto* hit = s->right->FindBranchOfPane(target)) return hit;
+        Branch const* hit = nullptr;
+        s->FindChild([&](Branch const& c) {
+            hit = c.FindBranchOfPane(target);
+            return hit != nullptr;
+        });
+        return hit;
     }
     return nullptr;
 }

--- a/App/Tabs/Panes/Branch.h
+++ b/App/Tabs/Panes/Branch.h
@@ -1,0 +1,195 @@
+#pragma once
+
+#include "Tabs/Panes/Pane.h"
+#include "Tabs/Panes/Split.h"
+#include <winrt/Windows.Foundation.h>
+#include <functional>
+#include <variant>
+
+namespace winrt::GhosttyWin32::implementation {
+
+// The recursive unit of a pane tree — the "unknown-subtree" value.
+// Every position in the tree (root, and each child of every Split) is
+// a Branch, which is either a Pane (a single terminal, leaf-like) or a
+// Split (an internal node that divides further). Reading a `Branch*`
+// as "an unknown subtree" is deliberate: the caller doesn't have to
+// know which variant they're holding until they visit.
+//
+// Naming follows the tree metaphor as widely used in software (git
+// branches, filesystem branches): a branch is what grows from a node,
+// and the tip of a branch is either another branch (further division)
+// or the end (a single pane in our case). Pane vs Split names the
+// terminal-domain concept at each end; Branch names the recursive
+// structural unit.
+//
+// Move-disabled — parent back-pointers on children are raw Branch*s
+// that would be invalidated by relocation. Unique-ptr indirection is
+// how the tree is reshaped.
+struct Branch {
+    std::variant<Pane, Split> value;
+
+    // Back-pointer to the enclosing Branch (which will be a Split
+    // variant). Null at the tree's root. Set when this Branch is
+    // attached as a child of a Split, cleared when detached.
+    Branch* parent{ nullptr };
+
+    // Most-recent rectangle this branch was arranged into, in
+    // SplitPanel-local coordinates. Set by the layout pass; consumed
+    // by splitter-drag resize math and direction-based GOTO_SPLIT.
+    // Zero before the first arrange (callers treat that as "no info").
+    winrt::Windows::Foundation::Rect arrangedRect{};
+
+    Branch() = default;
+    explicit Branch(Pane p) : value(std::move(p)) {}
+    explicit Branch(Split s) : value(std::move(s)) {}
+
+    Branch(Branch const&) = delete;
+    Branch& operator=(Branch const&) = delete;
+    Branch(Branch&&) = delete;
+    Branch& operator=(Branch&&) = delete;
+
+    // Discriminators — every call site that used to gate on
+    // `pane->IsLeaf()` now asks the branch whether it holds a Pane.
+    bool IsPane()  const noexcept { return std::holds_alternative<Pane>(value); }
+    bool IsSplit() const noexcept { return std::holds_alternative<Split>(value); }
+
+    // Direct accessors. Returns nullptr if the branch is the other
+    // variant — callers are expected to check IsPane/IsSplit first,
+    // or use std::visit to handle both cases.
+    Pane*        AsPane()        noexcept { return std::get_if<Pane>(&value); }
+    Pane const*  AsPane()  const noexcept { return std::get_if<Pane>(&value); }
+    Split*       AsSplit()       noexcept { return std::get_if<Split>(&value); }
+    Split const* AsSplit() const noexcept { return std::get_if<Split>(&value); }
+
+    // ─── walker primitives (Composite-style: operate on subtree rooted at `this`) ───
+    //
+    // Named after the terminal-domain concept ("Pane") rather than the
+    // tree-theory word ("Leaf") — matches what callers actually mean
+    // ("does any pane in this subtree need X?") without dragging a
+    // plant metaphor into a terminal codebase.
+
+    // True if any Pane in this subtree satisfies `pred`. Short-circuits
+    // on the first match.
+    bool AnyPaneMatches(std::function<bool(Pane const&)> const& pred) const;
+
+    // Visit every Pane in this subtree in depth-first order. Mutable
+    // access — mutating pane content is allowed (setting content, etc.);
+    // mutating the tree shape from inside the visitor is not.
+    void ForEachPane(std::function<void(Pane&)> const& visitor);
+    void ForEachPane(std::function<void(Pane const&)> const& visitor) const;
+
+    // First Pane in this subtree matching `pred`, or nullptr.
+    Pane*       FindPane(std::function<bool(Pane const&)> const& pred);
+    Pane const* FindPane(std::function<bool(Pane const&)> const& pred) const;
+
+    // The enclosing Branch that carries a specific Pane back to its
+    // owner. Used when a pane needs to be replaced/removed and the
+    // caller only has a Pane* — the tree walker locates the Branch
+    // wrapping it so the unique_ptr can be rewired.
+    Branch*       FindBranchOfPane(Pane const* target);
+    Branch const* FindBranchOfPane(Pane const* target) const;
+};
+
+// ─── inline implementations ───
+// Header-only so the templates and const/non-const overloads don't
+// need a companion .cpp; the recursion is small.
+
+inline bool Branch::AnyPaneMatches(
+    std::function<bool(Pane const&)> const& pred) const
+{
+    if (auto* p = AsPane()) return pred(*p);
+    if (auto* s = AsSplit()) {
+        return (s->left  && s->left ->AnyPaneMatches(pred))
+            || (s->right && s->right->AnyPaneMatches(pred));
+    }
+    return false;
+}
+
+inline void Branch::ForEachPane(std::function<void(Pane&)> const& visitor) {
+    if (auto* p = AsPane()) { visitor(*p); return; }
+    if (auto* s = AsSplit()) {
+        if (s->left)  s->left ->ForEachPane(visitor);
+        if (s->right) s->right->ForEachPane(visitor);
+    }
+}
+
+inline void Branch::ForEachPane(std::function<void(Pane const&)> const& visitor) const {
+    if (auto* p = AsPane()) { visitor(*p); return; }
+    if (auto* s = AsSplit()) {
+        if (s->left)  s->left ->ForEachPane(visitor);
+        if (s->right) s->right->ForEachPane(visitor);
+    }
+}
+
+inline Pane* Branch::FindPane(
+    std::function<bool(Pane const&)> const& pred)
+{
+    if (auto* p = AsPane()) return pred(*p) ? p : nullptr;
+    if (auto* s = AsSplit()) {
+        if (s->left)  if (auto* hit = s->left->FindPane(pred))  return hit;
+        if (s->right) if (auto* hit = s->right->FindPane(pred)) return hit;
+    }
+    return nullptr;
+}
+
+inline Pane const* Branch::FindPane(
+    std::function<bool(Pane const&)> const& pred) const
+{
+    if (auto* p = AsPane()) return pred(*p) ? p : nullptr;
+    if (auto* s = AsSplit()) {
+        if (s->left)  if (auto* hit = s->left->FindPane(pred))  return hit;
+        if (s->right) if (auto* hit = s->right->FindPane(pred)) return hit;
+    }
+    return nullptr;
+}
+
+inline Branch* Branch::FindBranchOfPane(Pane const* target) {
+    if (!target) return nullptr;
+    if (auto* p = AsPane()) return (p == target) ? this : nullptr;
+    if (auto* s = AsSplit()) {
+        if (s->left)  if (auto* hit = s->left ->FindBranchOfPane(target)) return hit;
+        if (s->right) if (auto* hit = s->right->FindBranchOfPane(target)) return hit;
+    }
+    return nullptr;
+}
+
+inline Branch const* Branch::FindBranchOfPane(Pane const* target) const {
+    if (!target) return nullptr;
+    if (auto* p = AsPane()) return (p == target) ? this : nullptr;
+    if (auto* s = AsSplit()) {
+        if (s->left)  if (auto* hit = s->left ->FindBranchOfPane(target)) return hit;
+        if (s->right) if (auto* hit = s->right->FindBranchOfPane(target)) return hit;
+    }
+    return nullptr;
+}
+
+// ─── factories (kept as free functions so Branch itself stays a
+// plain aggregate over `value + parent + arrangedRect`) ───
+
+// Wrap a leaf pane in a Branch on the heap. Callers rarely construct
+// Branches directly — this factory keeps the parent/arrangedRect
+// defaults implicit at the call site.
+inline std::unique_ptr<Branch> MakePaneBranch(
+    winrt::Microsoft::UI::Xaml::UIElement content, PaneId id = {})
+{
+    return std::make_unique<Branch>(Pane{ std::move(content), id });
+}
+
+// Build a split subtree by combining two existing branches. The
+// parent back-pointers on the children are rewritten to point at the
+// new Branch. Ratio is clamped so both children stay meaningfully
+// visible.
+inline std::unique_ptr<Branch> MakeSplitBranch(
+    Split::Direction direction, double ratio,
+    std::unique_ptr<Branch> left, std::unique_ptr<Branch> right)
+{
+    auto branch = std::make_unique<Branch>(Split{
+        direction, ClampSplitRatio(ratio), std::move(left), std::move(right)
+    });
+    auto* split = branch->AsSplit();
+    if (split->left)  split->left ->parent = branch.get();
+    if (split->right) split->right->parent = branch.get();
+    return branch;
+}
+
+}  // namespace winrt::GhosttyWin32::implementation

--- a/App/Tabs/Panes/Branch.h
+++ b/App/Tabs/Panes/Branch.h
@@ -89,10 +89,12 @@ struct Branch {
 
     // The enclosing Branch that carries a specific Pane back to its
     // owner. Used when a pane needs to be replaced/removed and the
-    // caller only has a Pane* — the tree walker locates the Branch
-    // wrapping it so the unique_ptr can be rewired.
-    Branch*       FindBranchOfPane(Pane const* target);
-    Branch const* FindBranchOfPane(Pane const* target) const;
+    // caller only has a Pane& — the tree walker locates the Branch
+    // wrapping it so the unique_ptr can be rewired. Takes the target
+    // by reference so the "null target" failure mode doesn't exist
+    // as far as this API is concerned.
+    Branch*       FindBranchOfPane(Pane const& target);
+    Branch const* FindBranchOfPane(Pane const& target) const;
 };
 
 // ─── inline implementations ───
@@ -130,12 +132,9 @@ inline Pane* Branch::FindPaneBy(
 {
     if (auto* p = TryGet<Pane>()) return pred(*p) ? p : nullptr;
     if (auto* s = TryGet<Split>()) {
-        Pane* hit = nullptr;
-        s->FindChildBy([&](Branch& c) {
-            hit = c.FindPaneBy(pred);
-            return hit != nullptr;
+        return s->FirstChildResult([&](Branch& c) -> Pane* {
+            return c.FindPaneBy(pred);
         });
-        return hit;
     }
     return nullptr;
 }
@@ -145,40 +144,29 @@ inline Pane const* Branch::FindPaneBy(
 {
     if (auto* p = TryGet<Pane>()) return pred(*p) ? p : nullptr;
     if (auto* s = TryGet<Split>()) {
-        Pane const* hit = nullptr;
-        s->FindChildBy([&](Branch const& c) {
-            hit = c.FindPaneBy(pred);
-            return hit != nullptr;
+        return s->FirstChildResult([&](Branch const& c) -> Pane const* {
+            return c.FindPaneBy(pred);
         });
-        return hit;
     }
     return nullptr;
 }
 
-inline Branch* Branch::FindBranchOfPane(Pane const* target) {
-    if (!target) return nullptr;
-    if (auto* p = TryGet<Pane>()) return (p == target) ? this : nullptr;
+inline Branch* Branch::FindBranchOfPane(Pane const& target) {
+    if (auto* p = TryGet<Pane>()) return (p == &target) ? this : nullptr;
     if (auto* s = TryGet<Split>()) {
-        Branch* hit = nullptr;
-        s->FindChildBy([&](Branch& c) {
-            hit = c.FindBranchOfPane(target);
-            return hit != nullptr;
+        return s->FirstChildResult([&](Branch& c) -> Branch* {
+            return c.FindBranchOfPane(target);
         });
-        return hit;
     }
     return nullptr;
 }
 
-inline Branch const* Branch::FindBranchOfPane(Pane const* target) const {
-    if (!target) return nullptr;
-    if (auto* p = TryGet<Pane>()) return (p == target) ? this : nullptr;
+inline Branch const* Branch::FindBranchOfPane(Pane const& target) const {
+    if (auto* p = TryGet<Pane>()) return (p == &target) ? this : nullptr;
     if (auto* s = TryGet<Split>()) {
-        Branch const* hit = nullptr;
-        s->FindChildBy([&](Branch const& c) {
-            hit = c.FindBranchOfPane(target);
-            return hit != nullptr;
+        return s->FirstChildResult([&](Branch const& c) -> Branch const* {
+            return c.FindBranchOfPane(target);
         });
-        return hit;
     }
     return nullptr;
 }

--- a/App/Tabs/Panes/Branch.h
+++ b/App/Tabs/Panes/Branch.h
@@ -84,8 +84,8 @@ struct Branch {
     void ForEachPane(std::function<void(Pane const&)> const& visitor) const;
 
     // First Pane in this subtree matching `pred`, or nullptr.
-    Pane*       FindPane(std::function<bool(Pane const&)> const& pred);
-    Pane const* FindPane(std::function<bool(Pane const&)> const& pred) const;
+    Pane*       FindPaneBy(std::function<bool(Pane const&)> const& pred);
+    Pane const* FindPaneBy(std::function<bool(Pane const&)> const& pred) const;
 
     // The enclosing Branch that carries a specific Pane back to its
     // owner. Used when a pane needs to be replaced/removed and the
@@ -125,14 +125,14 @@ inline void Branch::ForEachPane(std::function<void(Pane const&)> const& visitor)
     }
 }
 
-inline Pane* Branch::FindPane(
+inline Pane* Branch::FindPaneBy(
     std::function<bool(Pane const&)> const& pred)
 {
     if (auto* p = TryGet<Pane>()) return pred(*p) ? p : nullptr;
     if (auto* s = TryGet<Split>()) {
         Pane* hit = nullptr;
-        s->FindChild([&](Branch& c) {
-            hit = c.FindPane(pred);
+        s->FindChildBy([&](Branch& c) {
+            hit = c.FindPaneBy(pred);
             return hit != nullptr;
         });
         return hit;
@@ -140,14 +140,14 @@ inline Pane* Branch::FindPane(
     return nullptr;
 }
 
-inline Pane const* Branch::FindPane(
+inline Pane const* Branch::FindPaneBy(
     std::function<bool(Pane const&)> const& pred) const
 {
     if (auto* p = TryGet<Pane>()) return pred(*p) ? p : nullptr;
     if (auto* s = TryGet<Split>()) {
         Pane const* hit = nullptr;
-        s->FindChild([&](Branch const& c) {
-            hit = c.FindPane(pred);
+        s->FindChildBy([&](Branch const& c) {
+            hit = c.FindPaneBy(pred);
             return hit != nullptr;
         });
         return hit;
@@ -160,7 +160,7 @@ inline Branch* Branch::FindBranchOfPane(Pane const* target) {
     if (auto* p = TryGet<Pane>()) return (p == target) ? this : nullptr;
     if (auto* s = TryGet<Split>()) {
         Branch* hit = nullptr;
-        s->FindChild([&](Branch& c) {
+        s->FindChildBy([&](Branch& c) {
             hit = c.FindBranchOfPane(target);
             return hit != nullptr;
         });
@@ -174,7 +174,7 @@ inline Branch const* Branch::FindBranchOfPane(Pane const* target) const {
     if (auto* p = TryGet<Pane>()) return (p == target) ? this : nullptr;
     if (auto* s = TryGet<Split>()) {
         Branch const* hit = nullptr;
-        s->FindChild([&](Branch const& c) {
+        s->FindChildBy([&](Branch const& c) {
             hit = c.FindBranchOfPane(target);
             return hit != nullptr;
         });

--- a/App/Tabs/Panes/Branch.h
+++ b/App/Tabs/Panes/Branch.h
@@ -8,45 +8,19 @@
 
 namespace winrt::GhosttyWin32::implementation {
 
-// The recursive unit of a pane tree — the "unknown-subtree" value.
-// Every position in the tree (root, and each child of every Split) is
-// a Branch, which is either a Pane (a single terminal, leaf-like) or a
-// Split (an internal node that divides further). Reading a `Branch*`
-// as "an unknown subtree" is deliberate: the caller doesn't have to
-// know which variant they're holding until they visit.
-//
-// Naming follows the tree metaphor as widely used in software (git
-// branches, filesystem branches): a branch is what grows from a node,
-// and the tip of a branch is either another branch (further division)
-// or the end (a single pane in our case). Pane vs Split names the
-// terminal-domain concept at each end; Branch names the recursive
-// structural unit.
-//
-// Move-disabled — parent back-pointers on children are raw Branch*s
-// that would be invalidated by relocation. Unique-ptr indirection is
-// how the tree is reshaped.
+// The recursive unit of a pane tree — either a Pane (leaf) or a
+// Split (internal node with two Branch children). Move-disabled
+// because parent back-pointers on children would be invalidated by
+// relocation; the tree is reshaped through unique_ptr indirection.
 struct Branch {
     std::variant<Pane, Split> value;
-
-    // Back-pointer to the enclosing Branch (which will be a Split
-    // variant). Null at the tree's root. Set when this Branch is
-    // attached as a child of a Split, cleared when detached.
     Branch* parent{ nullptr };
-
-    // Most-recent rectangle this branch was arranged into, in
-    // SplitPanel-local coordinates. Set by the layout pass; consumed
-    // by splitter-drag resize math and direction-based GOTO_SPLIT.
-    // Zero before the first arrange (callers treat that as "no info").
     winrt::Windows::Foundation::Rect arrangedRect{};
 
     Branch() = default;
     explicit Branch(Pane p) : value(std::move(p)) {}
-    // Split-variant construction wires each present child's parent
-    // back-pointer to this new Branch. Keeps the tree-linkage
-    // invariant on the type — direct `make_unique<Branch>(Split{...})`
-    // wouldn't otherwise set parents, and every consumer would need
-    // to remember to fix them up. The MakeSplitBranch factory now
-    // only exists as a convenient one-liner over this constructor.
+    // Wire each child's parent back-pointer here so the invariant
+    // holds even for callers that skip the MakeSplitBranch factory.
     explicit Branch(Split s) : value(std::move(s)) {
         if (auto* split = TryGet<Split>()) {
             if (split->left)  split->left ->parent = this;
@@ -59,56 +33,34 @@ struct Branch {
     Branch(Branch&&) = delete;
     Branch& operator=(Branch&&) = delete;
 
-    // Discriminator: does this branch hold a T? Templated on the
-    // target variant so a future third alternative wouldn't need a
-    // new named method (Is<Pane>() / Is<Split>() are the current uses).
+    // Templated so a future third variant doesn't need a new method.
+    // A T outside the variant fails to compile.
     template<class T>
     bool Is() const noexcept { return std::holds_alternative<T>(value); }
 
-    // Nullable extract — thin wrapper over std::get_if that keeps
-    // the branch-value indirection out of the call site and matches
-    // the WinRT try_as<T>() shape used elsewhere in this codebase.
-    // Returns nullptr when the branch holds a different variant, so
-    // callers can combine check-and-use in one line:
-    //     if (auto* p = branch.TryGet<Pane>()) { p->content; }
-    // A T not in the variant fails to compile — safe against typos.
+    // Matches WinRT's try_as<T>() shape: nullptr if the branch holds
+    // a different variant, so `if (auto* p = branch.TryGet<Pane>())`
+    // combines check and use in one line.
     template<class T>       T* TryGet()       noexcept { return std::get_if<T>(&value); }
     template<class T> T const* TryGet() const noexcept { return std::get_if<T>(&value); }
 
-    // ─── walker primitives (Composite-style: operate on subtree rooted at `this`) ───
-    //
-    // Named after the terminal-domain concept ("Pane") rather than the
-    // tree-theory word ("Leaf") — matches what callers actually mean
-    // ("does any pane in this subtree need X?") without dragging a
-    // plant metaphor into a terminal codebase.
-
-    // True if any Pane in this subtree satisfies `pred`. Short-circuits
-    // on the first match.
+    // Composite-style: each operates on the subtree rooted at `this`.
+    // Named after Pane rather than "leaf" so callers speak the
+    // terminal-domain vocabulary.
     bool AnyPaneMatches(std::function<bool(Pane const&)> const& pred) const;
 
-    // Visit every Pane in this subtree in depth-first order. Mutable
-    // access — mutating pane content is allowed (setting content, etc.);
-    // mutating the tree shape from inside the visitor is not.
     void ForEachPane(std::function<void(Pane&)> const& visitor);
     void ForEachPane(std::function<void(Pane const&)> const& visitor) const;
 
-    // First Pane in this subtree matching `pred`, or nullptr.
     Pane*       FindPaneBy(std::function<bool(Pane const&)> const& pred);
     Pane const* FindPaneBy(std::function<bool(Pane const&)> const& pred) const;
 
-    // The enclosing Branch that carries a specific Pane back to its
-    // owner. Used when a pane needs to be replaced/removed and the
-    // caller only has a Pane& — the tree walker locates the Branch
-    // wrapping it so the unique_ptr can be rewired. Takes the target
-    // by reference so the "null target" failure mode doesn't exist
-    // as far as this API is concerned.
+    // Returns the Branch wrapping `target`, or nullptr if the pane
+    // isn't in this subtree. Callers need the wrapping Branch to
+    // rewire tree links; they typically only have a Pane& in hand.
     Branch*       FindBranchOfPane(Pane const& target);
     Branch const* FindBranchOfPane(Pane const& target) const;
 };
-
-// ─── inline implementations ───
-// Header-only so the templates and const/non-const overloads don't
-// need a companion .cpp; the recursion is small.
 
 inline bool Branch::AnyPaneMatches(
     std::function<bool(Pane const&)> const& pred) const
@@ -180,23 +132,12 @@ inline Branch const* Branch::FindBranchOfPane(Pane const& target) const {
     return nullptr;
 }
 
-// ─── factories (kept as free functions so Branch itself stays a
-// plain aggregate over `value + parent + arrangedRect`) ───
-
-// Wrap a leaf pane in a Branch on the heap. Callers rarely construct
-// Branches directly — this factory keeps the parent/arrangedRect
-// defaults implicit at the call site.
 inline std::unique_ptr<Branch> MakePaneBranch(
     winrt::Microsoft::UI::Xaml::UIElement content, PaneId id = {})
 {
     return std::make_unique<Branch>(Pane{ std::move(content), id });
 }
 
-// Build a split subtree. Convenience wrapper — ratio clamping lives
-// inside Split's constructor and parent back-pointer wiring lives
-// inside Branch(Split), so calling `make_unique<Branch>(Split{...})`
-// directly is equivalent; this factory just spares one nested {} at
-// each call site.
 inline std::unique_ptr<Branch> MakeSplitBranch(
     Split::Direction direction, double ratio,
     std::unique_ptr<Branch> left, std::unique_ptr<Branch> right)

--- a/App/Tabs/Panes/Branch.h
+++ b/App/Tabs/Panes/Branch.h
@@ -48,11 +48,9 @@ struct Branch {
     Branch(Branch&&) = delete;
     Branch& operator=(Branch&&) = delete;
 
-    // Discriminator — every call site that used to gate on
-    // `pane->IsLeaf()` now asks the branch whether it holds a T.
-    // Templated on the target variant so a future third alternative
-    // wouldn't need a new named method (Is<Pane>() / Is<Split>()
-    // are the current uses).
+    // Discriminator: does this branch hold a T? Templated on the
+    // target variant so a future third alternative wouldn't need a
+    // new named method (Is<Pane>() / Is<Split>() are the current uses).
     template<class T>
     bool Is() const noexcept { return std::holds_alternative<T>(value); }
 

--- a/App/Tabs/Panes/Branch.h
+++ b/App/Tabs/Panes/Branch.h
@@ -41,7 +41,18 @@ struct Branch {
 
     Branch() = default;
     explicit Branch(Pane p) : value(std::move(p)) {}
-    explicit Branch(Split s) : value(std::move(s)) {}
+    // Split-variant construction wires each present child's parent
+    // back-pointer to this new Branch. Keeps the tree-linkage
+    // invariant on the type — direct `make_unique<Branch>(Split{...})`
+    // wouldn't otherwise set parents, and every consumer would need
+    // to remember to fix them up. The MakeSplitBranch factory now
+    // only exists as a convenient one-liner over this constructor.
+    explicit Branch(Split s) : value(std::move(s)) {
+        if (auto* split = TryGet<Split>()) {
+            if (split->left)  split->left ->parent = this;
+            if (split->right) split->right->parent = this;
+        }
+    }
 
     Branch(Branch const&) = delete;
     Branch& operator=(Branch const&) = delete;
@@ -181,21 +192,17 @@ inline std::unique_ptr<Branch> MakePaneBranch(
     return std::make_unique<Branch>(Pane{ std::move(content), id });
 }
 
-// Build a split subtree by combining two existing branches. The
-// parent back-pointers on the children are rewritten to point at the
-// new Branch. Ratio is clamped so both children stay meaningfully
-// visible.
+// Build a split subtree. Convenience wrapper — ratio clamping lives
+// inside Split's constructor and parent back-pointer wiring lives
+// inside Branch(Split), so calling `make_unique<Branch>(Split{...})`
+// directly is equivalent; this factory just spares one nested {} at
+// each call site.
 inline std::unique_ptr<Branch> MakeSplitBranch(
     Split::Direction direction, double ratio,
     std::unique_ptr<Branch> left, std::unique_ptr<Branch> right)
 {
-    auto branch = std::make_unique<Branch>(Split{
-        direction, ClampSplitRatio(ratio), std::move(left), std::move(right)
-    });
-    auto* split = branch->TryGet<Split>();
-    if (split->left)  split->left ->parent = branch.get();
-    if (split->right) split->right->parent = branch.get();
-    return branch;
+    return std::make_unique<Branch>(
+        Split{ direction, ratio, std::move(left), std::move(right) });
 }
 
 }  // namespace winrt::GhosttyWin32::implementation

--- a/App/Tabs/Panes/Branch.h
+++ b/App/Tabs/Panes/Branch.h
@@ -48,18 +48,23 @@ struct Branch {
     Branch(Branch&&) = delete;
     Branch& operator=(Branch&&) = delete;
 
-    // Discriminators — every call site that used to gate on
-    // `pane->IsLeaf()` now asks the branch whether it holds a Pane.
-    bool IsPane()  const noexcept { return std::holds_alternative<Pane>(value); }
-    bool IsSplit() const noexcept { return std::holds_alternative<Split>(value); }
+    // Discriminator — every call site that used to gate on
+    // `pane->IsLeaf()` now asks the branch whether it holds a T.
+    // Templated on the target variant so a future third alternative
+    // wouldn't need a new named method (Is<Pane>() / Is<Split>()
+    // are the current uses).
+    template<class T>
+    bool Is() const noexcept { return std::holds_alternative<T>(value); }
 
-    // Direct accessors. Returns nullptr if the branch is the other
-    // variant — callers are expected to check IsPane/IsSplit first,
-    // or use std::visit to handle both cases.
-    Pane*        AsPane()        noexcept { return std::get_if<Pane>(&value); }
-    Pane const*  AsPane()  const noexcept { return std::get_if<Pane>(&value); }
-    Split*       AsSplit()       noexcept { return std::get_if<Split>(&value); }
-    Split const* AsSplit() const noexcept { return std::get_if<Split>(&value); }
+    // Nullable extract — thin wrapper over std::get_if that keeps
+    // the branch-value indirection out of the call site and matches
+    // the WinRT try_as<T>() shape used elsewhere in this codebase.
+    // Returns nullptr when the branch holds a different variant, so
+    // callers can combine check-and-use in one line:
+    //     if (auto* p = branch.TryGet<Pane>()) { p->content; }
+    // A T not in the variant fails to compile — safe against typos.
+    template<class T>       T* TryGet()       noexcept { return std::get_if<T>(&value); }
+    template<class T> T const* TryGet() const noexcept { return std::get_if<T>(&value); }
 
     // ─── walker primitives (Composite-style: operate on subtree rooted at `this`) ───
     //
@@ -97,8 +102,8 @@ struct Branch {
 inline bool Branch::AnyPaneMatches(
     std::function<bool(Pane const&)> const& pred) const
 {
-    if (auto* p = AsPane()) return pred(*p);
-    if (auto* s = AsSplit()) {
+    if (auto* p = TryGet<Pane>()) return pred(*p);
+    if (auto* s = TryGet<Split>()) {
         return (s->left  && s->left ->AnyPaneMatches(pred))
             || (s->right && s->right->AnyPaneMatches(pred));
     }
@@ -106,16 +111,16 @@ inline bool Branch::AnyPaneMatches(
 }
 
 inline void Branch::ForEachPane(std::function<void(Pane&)> const& visitor) {
-    if (auto* p = AsPane()) { visitor(*p); return; }
-    if (auto* s = AsSplit()) {
+    if (auto* p = TryGet<Pane>()) { visitor(*p); return; }
+    if (auto* s = TryGet<Split>()) {
         if (s->left)  s->left ->ForEachPane(visitor);
         if (s->right) s->right->ForEachPane(visitor);
     }
 }
 
 inline void Branch::ForEachPane(std::function<void(Pane const&)> const& visitor) const {
-    if (auto* p = AsPane()) { visitor(*p); return; }
-    if (auto* s = AsSplit()) {
+    if (auto* p = TryGet<Pane>()) { visitor(*p); return; }
+    if (auto* s = TryGet<Split>()) {
         if (s->left)  s->left ->ForEachPane(visitor);
         if (s->right) s->right->ForEachPane(visitor);
     }
@@ -124,8 +129,8 @@ inline void Branch::ForEachPane(std::function<void(Pane const&)> const& visitor)
 inline Pane* Branch::FindPane(
     std::function<bool(Pane const&)> const& pred)
 {
-    if (auto* p = AsPane()) return pred(*p) ? p : nullptr;
-    if (auto* s = AsSplit()) {
+    if (auto* p = TryGet<Pane>()) return pred(*p) ? p : nullptr;
+    if (auto* s = TryGet<Split>()) {
         if (s->left)  if (auto* hit = s->left->FindPane(pred))  return hit;
         if (s->right) if (auto* hit = s->right->FindPane(pred)) return hit;
     }
@@ -135,8 +140,8 @@ inline Pane* Branch::FindPane(
 inline Pane const* Branch::FindPane(
     std::function<bool(Pane const&)> const& pred) const
 {
-    if (auto* p = AsPane()) return pred(*p) ? p : nullptr;
-    if (auto* s = AsSplit()) {
+    if (auto* p = TryGet<Pane>()) return pred(*p) ? p : nullptr;
+    if (auto* s = TryGet<Split>()) {
         if (s->left)  if (auto* hit = s->left->FindPane(pred))  return hit;
         if (s->right) if (auto* hit = s->right->FindPane(pred)) return hit;
     }
@@ -145,8 +150,8 @@ inline Pane const* Branch::FindPane(
 
 inline Branch* Branch::FindBranchOfPane(Pane const* target) {
     if (!target) return nullptr;
-    if (auto* p = AsPane()) return (p == target) ? this : nullptr;
-    if (auto* s = AsSplit()) {
+    if (auto* p = TryGet<Pane>()) return (p == target) ? this : nullptr;
+    if (auto* s = TryGet<Split>()) {
         if (s->left)  if (auto* hit = s->left ->FindBranchOfPane(target)) return hit;
         if (s->right) if (auto* hit = s->right->FindBranchOfPane(target)) return hit;
     }
@@ -155,8 +160,8 @@ inline Branch* Branch::FindBranchOfPane(Pane const* target) {
 
 inline Branch const* Branch::FindBranchOfPane(Pane const* target) const {
     if (!target) return nullptr;
-    if (auto* p = AsPane()) return (p == target) ? this : nullptr;
-    if (auto* s = AsSplit()) {
+    if (auto* p = TryGet<Pane>()) return (p == target) ? this : nullptr;
+    if (auto* s = TryGet<Split>()) {
         if (s->left)  if (auto* hit = s->left ->FindBranchOfPane(target)) return hit;
         if (s->right) if (auto* hit = s->right->FindBranchOfPane(target)) return hit;
     }
@@ -186,7 +191,7 @@ inline std::unique_ptr<Branch> MakeSplitBranch(
     auto branch = std::make_unique<Branch>(Split{
         direction, ClampSplitRatio(ratio), std::move(left), std::move(right)
     });
-    auto* split = branch->AsSplit();
+    auto* split = branch->TryGet<Split>();
     if (split->left)  split->left ->parent = branch.get();
     if (split->right) split->right->parent = branch.get();
     return branch;

--- a/App/Tabs/Panes/Pane.h
+++ b/App/Tabs/Panes/Pane.h
@@ -11,13 +11,6 @@ namespace winrt::GhosttyWin32::implementation {
 // that renders the terminal and the id ghostty uses to route
 // close_surface_cb back to this specific pane.
 //
-// Previously Pane was a Composite tree node (leaf + split roles on the
-// same class). That reading conflicted with the industry meaning:
-// "Pane containing Panes" is unnatural whereas "single terminal" is
-// the immediate mental picture. The split-node role now lives on its
-// own type (Split), and the ambiguous "either" wrapper is Branch. Pane
-// here is strictly the leaf.
-//
 // UIElement rather than TerminalControl so layout-only tests can build
 // a tree with placeholder Borders and the WinUI Panel side doesn't
 // depend on TerminalControl's constructor cost.

--- a/App/Tabs/Panes/Pane.h
+++ b/App/Tabs/Panes/Pane.h
@@ -3,188 +3,30 @@
 #include "Tabs/Panes/PaneId.h"
 #include <winrt/Microsoft.UI.Xaml.h>
 #include <winrt/Windows.Foundation.h>
-#include <memory>
 
 namespace winrt::GhosttyWin32::implementation {
 
-// Direction of a split node.
+// A single terminal — the industry-standard meaning of "pane" (tmux,
+// Windows Terminal, iTerm2, Ghostty upstream). Holds the UI element
+// that renders the terminal and the id ghostty uses to route
+// close_surface_cb back to this specific pane.
 //
-//   Horizontal : children laid out side by side, the split bar is vertical.
-//   Vertical   : children stacked, the split bar is horizontal.
-enum class SplitOrientation {
-    Horizontal,
-    Vertical,
-};
-
-// Binary-tree node describing how a Tab's content is partitioned into
-// terminal panes. A node is either a leaf (one UI element fills the
-// node's rectangle) or an internal node (two children, split by
-// `orientation` at `ratio`).
+// Previously Pane was a Composite tree node (leaf + split roles on the
+// same class). That reading conflicted with the industry meaning:
+// "Pane containing Panes" is unnatural whereas "single terminal" is
+// the immediate mental picture. The split-node role now lives on its
+// own type (Split), and the ambiguous "either" wrapper is Branch. Pane
+// here is strictly the leaf.
 //
-// Leaves hold a plain `UIElement` rather than a `TerminalControl` so
-// the same tree can host placeholder Borders during layout-only tests
-// and real TerminalControls in production. SplitPanel only cares about
-// "something to arrange", so erasing to the base class also keeps that
-// renderer agnostic.
-//
-// Ownership is unique_ptr-based: a parent owns its two children, the
-// SplitPanel owns the root. Parent back-pointers (`m_parent`) are kept
-// so direction-based navigation can walk up and across without a
-// separate index; they're set when a node is attached as a child and
-// cleared on detach.
-//
-// The class is move-disabled because raw `Pane*` back-pointers must
-// stay valid for the node's lifetime — moving would invalidate every
-// child's `m_parent`.
-class Pane {
-public:
-    // Construct a leaf wrapping `content`. `content` is the actual
-    // UIElement that will be added to the SplitPanel's Children
-    // collection when the leaf is arranged. `id` identifies the leaf
-    // for ghostty's close_surface_cb routing — required to be non-zero
-    // for production callers; a default-constructed PaneId is accepted
-    // (and exposed as Id()) so layout-only tests can build trees
-    // without an allocator.
-    static std::unique_ptr<Pane> MakeLeaf(Microsoft::UI::Xaml::UIElement content,
-                                          PaneId id = {}) {
-        auto p = std::unique_ptr<Pane>(new Pane{});
-        p->m_content = std::move(content);
-        p->m_id = id;
-        return p;
-    }
-
-    // Construct an internal node by combining two existing subtrees.
-    // `ratio` is the fraction of the available extent the first child
-    // gets along the split axis (clamped to [0.05, 0.95] to keep both
-    // children meaningfully visible).
-    static std::unique_ptr<Pane> MakeSplit(
-        SplitOrientation orientation,
-        double ratio,
-        std::unique_ptr<Pane> first,
-        std::unique_ptr<Pane> second
-    ) {
-        auto p = std::unique_ptr<Pane>(new Pane{});
-        p->m_orientation = orientation;
-        p->m_ratio = ClampRatio(ratio);
-        p->m_first = std::move(first);
-        p->m_second = std::move(second);
-        if (p->m_first) p->m_first->m_parent = p.get();
-        if (p->m_second) p->m_second->m_parent = p.get();
-        return p;
-    }
-
-    ~Pane() = default;
-    Pane(const Pane&) = delete;
-    Pane& operator=(const Pane&) = delete;
-    Pane(Pane&&) = delete;
-    Pane& operator=(Pane&&) = delete;
-
-    bool IsLeaf() const noexcept { return static_cast<bool>(m_content); }
-
-    // Leaf accessor. Returns null for internal nodes.
-    Microsoft::UI::Xaml::UIElement Content() const noexcept { return m_content; }
-
-    // Leaf-side identifier set at MakeLeaf time. Used as cfg.userdata
-    // for ghostty's close_surface_cb so the host can route the
-    // callback back to a specific leaf. Internal nodes have no ID
-    // (returns the zero sentinel).
-    PaneId Id() const noexcept { return m_id; }
-
-    // Internal-node accessors. Calling these on a leaf returns
-    // default-initialized values / nullptrs — callers should gate on
-    // IsLeaf() first.
-    SplitOrientation Orientation() const noexcept { return m_orientation; }
-    double Ratio() const noexcept { return m_ratio; }
-    void SetRatio(double ratio) noexcept { m_ratio = ClampRatio(ratio); }
-    Pane* First() const noexcept { return m_first.get(); }
-    Pane* Second() const noexcept { return m_second.get(); }
-
-    // Back-pointer to the enclosing internal node, or null at the root.
-    Pane* Parent() const noexcept { return m_parent; }
-
-    // Most-recent rectangle this node was arranged into, in
-    // SplitPanel-local coordinates. Set by SplitPanel::ArrangeNode on
-    // every layout pass; consumed by splitter-drag resize math and
-    // direction-based GOTO_SPLIT (finding the leaf adjacent to the
-    // active one). Defaults to zero before the first arrange, which
-    // callers treat as "no info" — the host should defer any rect-
-    // dependent action until the user can see the panel anyway.
-    Windows::Foundation::Rect ArrangedRect() const noexcept { return m_arrangedRect; }
-    void SetArrangedRect(Windows::Foundation::Rect r) noexcept { m_arrangedRect = r; }
-
-    // Swap the child unique_ptr matching `oldChild` for `newChild`.
-    // Returns true when `oldChild` was one of this node's children
-    // (the old subtree is destroyed when its unique_ptr is overwritten;
-    // the new child's parent back-pointer is rewritten to point here).
-    // No-op + false if called on a leaf or if `oldChild` isn't a
-    // child — the caller is expected to verify membership when the
-    // distinction matters.
-    //
-    // Used by SplitPanel::ReplaceLeaf for in-place tree edits like
-    // NEW_SPLIT (replace a leaf with a split subtree wrapping it) and
-    // CLOSE_PANE (replace a split with its surviving child).
-    bool ReplaceChild(Pane* oldChild, std::unique_ptr<Pane> newChild) noexcept {
-        if (IsLeaf() || !oldChild || !newChild) return false;
-        if (m_first.get() == oldChild) {
-            newChild->m_parent = this;
-            m_first = std::move(newChild);
-            return true;
-        }
-        if (m_second.get() == oldChild) {
-            newChild->m_parent = this;
-            m_second = std::move(newChild);
-            return true;
-        }
-        return false;
-    }
-
-    // Pull `child` out of this internal node and return ownership.
-    // The child becomes an orphan (parent back-pointer cleared) so
-    // the caller can re-attach it elsewhere — typically as a
-    // replacement for this node itself when collapsing a split.
-    // Returns nullptr if called on a leaf or if `child` isn't a child.
-    std::unique_ptr<Pane> DetachChild(Pane* child) noexcept {
-        if (IsLeaf() || !child) return nullptr;
-        if (m_first.get() == child) {
-            m_first->m_parent = nullptr;
-            return std::move(m_first);
-        }
-        if (m_second.get() == child) {
-            m_second->m_parent = nullptr;
-            return std::move(m_second);
-        }
-        return nullptr;
-    }
-
-private:
-    Pane() = default;
-
-    static double ClampRatio(double r) noexcept {
-        if (r < 0.05) return 0.05;
-        if (r > 0.95) return 0.95;
-        return r;
-    }
-
-    // Leaf payload — non-null iff IsLeaf().
-    Microsoft::UI::Xaml::UIElement m_content{ nullptr };
-
-    // Leaf identifier — zero sentinel for internal nodes and for
-    // layout-only test leaves built without an allocator.
-    PaneId m_id{};
-
-    // Internal-node fields — unused when IsLeaf().
-    SplitOrientation m_orientation{ SplitOrientation::Horizontal };
-    double m_ratio{ 0.5 };
-    std::unique_ptr<Pane> m_first;
-    std::unique_ptr<Pane> m_second;
-
-    // Set by MakeSplit when this node is attached as a child; null at
-    // the root. Used by future phases for direction-based navigation
-    // and for collapsing the tree on pane close.
-    Pane* m_parent{ nullptr };
-
-    // Refreshed on every SplitPanel arrange pass — see ArrangedRect.
-    Windows::Foundation::Rect m_arrangedRect{};
+// UIElement rather than TerminalControl so layout-only tests can build
+// a tree with placeholder Borders and the WinUI Panel side doesn't
+// depend on TerminalControl's constructor cost.
+struct Pane {
+    Microsoft::UI::Xaml::UIElement content{ nullptr };
+    // Zero sentinel is accepted so layout-only tests can build panes
+    // without an allocator. Production callers thread a real
+    // PaneIdAllocator through TabFactory.
+    PaneId id{};
 };
 
 }  // namespace winrt::GhosttyWin32::implementation

--- a/App/Tabs/Panes/Pane.h
+++ b/App/Tabs/Panes/Pane.h
@@ -6,19 +6,10 @@
 
 namespace winrt::GhosttyWin32::implementation {
 
-// A single terminal — the industry-standard meaning of "pane" (tmux,
-// Windows Terminal, iTerm2, Ghostty upstream). Holds the UI element
-// that renders the terminal and the id ghostty uses to route
-// close_surface_cb back to this specific pane.
-//
-// UIElement rather than TerminalControl so layout-only tests can build
-// a tree with placeholder Borders and the WinUI Panel side doesn't
-// depend on TerminalControl's constructor cost.
+// A single terminal — the tree's leaf. `content` is UIElement (not
+// TerminalControl) so layout-only tests can substitute a placeholder.
 struct Pane {
     Microsoft::UI::Xaml::UIElement content{ nullptr };
-    // Zero sentinel is accepted so layout-only tests can build panes
-    // without an allocator. Production callers thread a real
-    // PaneIdAllocator through TabFactory.
     PaneId id{};
 };
 

--- a/App/Tabs/Panes/Split.h
+++ b/App/Tabs/Panes/Split.h
@@ -63,13 +63,13 @@ struct Split {
     // findable children have to be mutable for the callers who use
     // this (tree walkers rewiring the tree).
     template<class Pred>
-    Branch* FindChild(Pred&& pred) {
+    Branch* FindChildBy(Pred&& pred) {
         if (left  && pred(*left))  return left.get();
         if (right && pred(*right)) return right.get();
         return nullptr;
     }
     template<class Pred>
-    Branch const* FindChild(Pred&& pred) const {
+    Branch const* FindChildBy(Pred&& pred) const {
         if (left  && pred(*left))  return left.get();
         if (right && pred(*right)) return right.get();
         return nullptr;

--- a/App/Tabs/Panes/Split.h
+++ b/App/Tabs/Panes/Split.h
@@ -11,12 +11,11 @@ struct Branch;
 // `ratio` of the total extent. Each child is another Branch (which is
 // again either a single Pane or another Split, recursively).
 //
-// Direction here is the axis of the split *bar*, not the layout axis
-// of the children — kept as-is from the legacy Pane class to avoid
-// renaming every call site all at once, but semantically it means:
+// Direction names the axis of the split *bar*, not the layout axis
+// of the children:
 //
 //   Horizontal : children are laid out side by side (bar is vertical)
-//   Vertical   : children are stacked            (bar is horizontal)
+//   Vertical   : children are stacked               (bar is horizontal)
 //
 // A Split isn't move-enabled — Branch back-pointers into left/right
 // children stay valid for the split's lifetime, and moving would

--- a/App/Tabs/Panes/Split.h
+++ b/App/Tabs/Panes/Split.h
@@ -32,8 +32,62 @@ struct Split {
 
     // Owned children. Both non-null in a well-formed tree; nullptr is
     // only ever a transient state during mutation.
+    //
+    // Named left / right because the layout code (SplitPanel Measure /
+    // Arrange) cares which side of the split axis a child sits on.
+    // Walker code that just needs "visit both children" should reach
+    // for AnyOfChildren / FindChild / ForEachChild below — those
+    // centralise the left+right iteration so callers don't repeat
+    // the pattern for every new walker.
     std::unique_ptr<Branch> left;
     std::unique_ptr<Branch> right;
+
+    // ─── child iteration helpers (used by Branch walker methods) ───
+    //
+    // Template + inline: the parameter pack references Branch::methods
+    // that get resolved at the call site (Branch is fully defined by
+    // the time any real caller includes Branch.h — which includes
+    // this header — and instantiates one of these).
+
+    // Short-circuiting "any": returns true on the first child whose
+    // pred(*child) returns true. Missing children (transient nullptr
+    // during mutation) are skipped.
+    template<class Pred>
+    bool AnyOfChildren(Pred&& pred) const {
+        return (left  && pred(*left))
+            || (right && pred(*right));
+    }
+
+    // Returns a pointer to the first child for which pred(*child) is
+    // true, or nullptr if neither matches. Non-const overload only —
+    // findable children have to be mutable for the callers who use
+    // this (tree walkers rewiring the tree).
+    template<class Pred>
+    Branch* FindChild(Pred&& pred) {
+        if (left  && pred(*left))  return left.get();
+        if (right && pred(*right)) return right.get();
+        return nullptr;
+    }
+    template<class Pred>
+    Branch const* FindChild(Pred&& pred) const {
+        if (left  && pred(*left))  return left.get();
+        if (right && pred(*right)) return right.get();
+        return nullptr;
+    }
+
+    // Non-short-circuit visit — calls fn on every present child.
+    // Callers who care about a specific direction or need early exit
+    // should use AnyOfChildren / FindChild instead.
+    template<class F>
+    void ForEachChild(F&& fn) {
+        if (left)  fn(*left);
+        if (right) fn(*right);
+    }
+    template<class F>
+    void ForEachChild(F&& fn) const {
+        if (left)  fn(*left);
+        if (right) fn(*right);
+    }
 };
 
 // Clamp helper shared by ratio-setters (in Tree / SplitPanel mutation

--- a/App/Tabs/Panes/Split.h
+++ b/App/Tabs/Panes/Split.h
@@ -58,21 +58,27 @@ struct Split {
             || (right && pred(*right));
     }
 
-    // Returns a pointer to the first child for which pred(*child) is
-    // true, or nullptr if neither matches. Non-const overload only —
-    // findable children have to be mutable for the callers who use
-    // this (tree walkers rewiring the tree).
-    template<class Pred>
-    Branch* FindChildBy(Pred&& pred) {
-        if (left  && pred(*left))  return left.get();
-        if (right && pred(*right)) return right.get();
-        return nullptr;
+    // Applies fn to each present child in order (left, right) and
+    // returns the first result that converts to true (non-null
+    // pointer, engaged optional, etc.). Falls back to a default-
+    // constructed R when no child yields one — nullptr for pointer
+    // returns, empty for optional returns. Mirrors Rust's find_map:
+    // callers propagate a value the child produced (a Pane* found
+    // deeper in the subtree, say) up through the composite without
+    // routing it via a captured outer variable.
+    template<class F>
+    auto FirstChildResult(F&& fn) -> decltype(fn(std::declval<Branch&>())) {
+        using R = decltype(fn(std::declval<Branch&>()));
+        if (left)  { if (auto r = fn(*left);  r) return r; }
+        if (right) { if (auto r = fn(*right); r) return r; }
+        return R{};
     }
-    template<class Pred>
-    Branch const* FindChildBy(Pred&& pred) const {
-        if (left  && pred(*left))  return left.get();
-        if (right && pred(*right)) return right.get();
-        return nullptr;
+    template<class F>
+    auto FirstChildResult(F&& fn) const -> decltype(fn(std::declval<Branch const&>())) {
+        using R = decltype(fn(std::declval<Branch const&>()));
+        if (left)  { if (auto r = fn(*left);  r) return r; }
+        if (right) { if (auto r = fn(*right); r) return r; }
+        return R{};
     }
 
     // Non-short-circuit visit — calls fn on every present child.

--- a/App/Tabs/Panes/Split.h
+++ b/App/Tabs/Panes/Split.h
@@ -6,6 +6,15 @@ namespace winrt::GhosttyWin32::implementation {
 
 struct Branch;
 
+// Clamp helper shared by ratio-setters (in Tree / SplitPanel mutation
+// paths) and by the Split constructor. Keeps both children
+// meaningfully visible when the user drags a splitter to the edge.
+constexpr double ClampSplitRatio(double r) noexcept {
+    if (r < 0.05) return 0.05;
+    if (r > 0.95) return 0.95;
+    return r;
+}
+
 // Split — an internal node in the pane tree. Divides its region into
 // two subregions along `direction`, with the first child taking
 // `ratio` of the total extent. Each child is another Branch (which is
@@ -40,6 +49,18 @@ struct Split {
     // the pattern for every new walker.
     std::unique_ptr<Branch> left;
     std::unique_ptr<Branch> right;
+
+    Split() = default;
+    // Full-init constructor. Clamps `r` into the safe range so bad
+    // ratios can't sneak in via direct construction — the invariant
+    // lives on the type, not on the MakeSplitBranch factory.
+    Split(Direction d, double r,
+          std::unique_ptr<Branch> l,
+          std::unique_ptr<Branch> right_)
+        : direction(d)
+        , ratio(ClampSplitRatio(r))
+        , left(std::move(l))
+        , right(std::move(right_)) {}
 
     // ─── child iteration helpers (used by Branch walker methods) ───
     //
@@ -94,14 +115,5 @@ struct Split {
         if (right) fn(*right);
     }
 };
-
-// Clamp helper shared by ratio-setters (in Tree / SplitPanel mutation
-// paths). Keeps both children meaningfully visible when the user
-// drags a splitter to the edge.
-constexpr double ClampSplitRatio(double r) noexcept {
-    if (r < 0.05) return 0.05;
-    if (r > 0.95) return 0.95;
-    return r;
-}
 
 }  // namespace winrt::GhosttyWin32::implementation

--- a/App/Tabs/Panes/Split.h
+++ b/App/Tabs/Panes/Split.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <memory>
+
+namespace winrt::GhosttyWin32::implementation {
+
+struct Branch;
+
+// Split — an internal node in the pane tree. Divides its region into
+// two subregions along `direction`, with the first child taking
+// `ratio` of the total extent. Each child is another Branch (which is
+// again either a single Pane or another Split, recursively).
+//
+// Direction here is the axis of the split *bar*, not the layout axis
+// of the children — kept as-is from the legacy Pane class to avoid
+// renaming every call site all at once, but semantically it means:
+//
+//   Horizontal : children are laid out side by side (bar is vertical)
+//   Vertical   : children are stacked            (bar is horizontal)
+//
+// A Split isn't move-enabled — Branch back-pointers into left/right
+// children stay valid for the split's lifetime, and moving would
+// invalidate them.
+struct Split {
+    enum class Direction {
+        Horizontal,
+        Vertical,
+    };
+
+    Direction direction{ Direction::Horizontal };
+    double    ratio{ 0.5 };
+
+    // Owned children. Both non-null in a well-formed tree; nullptr is
+    // only ever a transient state during mutation.
+    std::unique_ptr<Branch> left;
+    std::unique_ptr<Branch> right;
+};
+
+// Clamp helper shared by ratio-setters (in Tree / SplitPanel mutation
+// paths). Keeps both children meaningfully visible when the user
+// drags a splitter to the edge.
+constexpr double ClampSplitRatio(double r) noexcept {
+    if (r < 0.05) return 0.05;
+    if (r > 0.95) return 0.95;
+    return r;
+}
+
+}  // namespace winrt::GhosttyWin32::implementation

--- a/App/Tabs/Panes/Split.h
+++ b/App/Tabs/Panes/Split.h
@@ -62,6 +62,13 @@ struct Split {
         , left(std::move(l))
         , right(std::move(right_)) {}
 
+    // Direction predicates. Reads as `split->IsHorizontal()` at the
+    // call site instead of `split->direction == Direction::Horizontal`
+    // — same semantic, English clause style consistent with the
+    // Is<T>() / HasRoot() predicates elsewhere in this layer.
+    bool IsHorizontal() const noexcept { return direction == Direction::Horizontal; }
+    bool IsVertical()   const noexcept { return direction == Direction::Vertical; }
+
     // ─── child iteration helpers (used by Branch walker methods) ───
     //
     // Template + inline: the parameter pack references Branch::methods

--- a/App/Tabs/Panes/Split.h
+++ b/App/Tabs/Panes/Split.h
@@ -6,54 +6,28 @@ namespace winrt::GhosttyWin32::implementation {
 
 struct Branch;
 
-// Clamp helper shared by ratio-setters (in Tree / SplitPanel mutation
-// paths) and by the Split constructor. Keeps both children
-// meaningfully visible when the user drags a splitter to the edge.
+// Clamp the ratio so both children stay visible even if the user
+// drags a splitter all the way to the edge.
 constexpr double ClampSplitRatio(double r) noexcept {
     if (r < 0.05) return 0.05;
     if (r > 0.95) return 0.95;
     return r;
 }
 
-// Split — an internal node in the pane tree. Divides its region into
-// two subregions along `direction`, with the first child taking
-// `ratio` of the total extent. Each child is another Branch (which is
-// again either a single Pane or another Split, recursively).
-//
-// Direction names the axis of the split *bar*, not the layout axis
-// of the children:
-//
-//   Horizontal : children are laid out side by side (bar is vertical)
-//   Vertical   : children are stacked               (bar is horizontal)
-//
-// A Split isn't move-enabled — Branch back-pointers into left/right
-// children stay valid for the split's lifetime, and moving would
-// invalidate them.
+// A Split isn't move-enabled — raw Branch back-pointers on children
+// would be invalidated by relocation.
 struct Split {
     enum class Direction {
-        Horizontal,
-        Vertical,
+        Horizontal,   // children side by side, bar is vertical
+        Vertical,     // children stacked,       bar is horizontal
     };
 
     Direction direction{ Direction::Horizontal };
     double    ratio{ 0.5 };
-
-    // Owned children. Both non-null in a well-formed tree; nullptr is
-    // only ever a transient state during mutation.
-    //
-    // Named left / right because the layout code (SplitPanel Measure /
-    // Arrange) cares which side of the split axis a child sits on.
-    // Walker code that just needs "visit both children" should reach
-    // for AnyOfChildren / FindChild / ForEachChild below — those
-    // centralise the left+right iteration so callers don't repeat
-    // the pattern for every new walker.
     std::unique_ptr<Branch> left;
     std::unique_ptr<Branch> right;
 
     Split() = default;
-    // Full-init constructor. Clamps `r` into the safe range so bad
-    // ratios can't sneak in via direct construction — the invariant
-    // lives on the type, not on the MakeSplitBranch factory.
     Split(Direction d, double r,
           std::unique_ptr<Branch> l,
           std::unique_ptr<Branch> right_)
@@ -62,37 +36,21 @@ struct Split {
         , left(std::move(l))
         , right(std::move(right_)) {}
 
-    // Direction predicates. Reads as `split->IsHorizontal()` at the
-    // call site instead of `split->direction == Direction::Horizontal`
-    // — same semantic, English clause style consistent with the
-    // Is<T>() / HasRoot() predicates elsewhere in this layer.
     bool IsHorizontal() const noexcept { return direction == Direction::Horizontal; }
     bool IsVertical()   const noexcept { return direction == Direction::Vertical; }
 
-    // ─── child iteration helpers (used by Branch walker methods) ───
-    //
-    // Template + inline: the parameter pack references Branch::methods
-    // that get resolved at the call site (Branch is fully defined by
-    // the time any real caller includes Branch.h — which includes
-    // this header — and instantiates one of these).
-
-    // Short-circuiting "any": returns true on the first child whose
-    // pred(*child) returns true. Missing children (transient nullptr
-    // during mutation) are skipped.
+    // Templates instantiate at the call site, so Branch just needs to
+    // be forward-declared here; Branch.h includes this header before
+    // it defines the walker bodies.
     template<class Pred>
     bool AnyOfChildren(Pred&& pred) const {
         return (left  && pred(*left))
             || (right && pred(*right));
     }
 
-    // Applies fn to each present child in order (left, right) and
-    // returns the first result that converts to true (non-null
-    // pointer, engaged optional, etc.). Falls back to a default-
-    // constructed R when no child yields one — nullptr for pointer
-    // returns, empty for optional returns. Mirrors Rust's find_map:
-    // callers propagate a value the child produced (a Pane* found
-    // deeper in the subtree, say) up through the composite without
-    // routing it via a captured outer variable.
+    // Mirrors Rust's find_map: applies fn to each present child in
+    // order and returns the first truthy result, otherwise a
+    // default-constructed R.
     template<class F>
     auto FirstChildResult(F&& fn) -> decltype(fn(std::declval<Branch&>())) {
         using R = decltype(fn(std::declval<Branch&>()));
@@ -108,9 +66,6 @@ struct Split {
         return R{};
     }
 
-    // Non-short-circuit visit — calls fn on every present child.
-    // Callers who care about a specific direction or need early exit
-    // should use AnyOfChildren / FindChild instead.
     template<class F>
     void ForEachChild(F&& fn) {
         if (left)  fn(*left);

--- a/App/Tabs/Panes/Tree.h
+++ b/App/Tabs/Panes/Tree.h
@@ -1,0 +1,208 @@
+#pragma once
+
+#include "Tabs/Panes/Branch.h"
+#include <functional>
+#include <memory>
+#include <utility>
+
+namespace winrt::GhosttyWin32::implementation {
+
+// Container for a pane tree — the model layer for one tab's split
+// arrangement. Owns the root Branch (nullable = empty tree) plus
+// tree-wide state that doesn't belong on any single Branch: the
+// currently-zoomed pane (if any), the mutations that need to swap
+// the root pointer, etc.
+//
+// Tree is pure C++ — no WinUI, no Win32 — so its behaviour is
+// unit-testable in isolation with fake pane trees. The XAML-side
+// Panel (SplitPanel) holds a Tree as a member and drives
+// MeasureOverride / ArrangeOverride off it; the two layers meet at
+// the mutation methods on this class (SetRoot / ReplacePane /
+// RemovePane), where SplitPanel refreshes its Children collection
+// after Tree finishes rewiring pointers.
+//
+// This is the "SplitTree" of the Ghostty upstream Swift design (see
+// external/ghostty/macos/Sources/Features/Splits/SplitTree.swift),
+// adapted to C++ sum types (Branch = variant<Pane, Split>) instead
+// of Swift indirect enums. Named Tree here rather than SplitTree —
+// the "split" prefix would collide with the Split variant type
+// (making 'SplitTree' read as 'tree of Splits' when in fact the tree
+// contains a mix of Panes and Splits) and adds no information the
+// namespace / member type doesn't already convey.
+class Tree {
+public:
+    Tree() = default;
+    explicit Tree(std::unique_ptr<Branch> root) noexcept
+        : m_root(std::move(root)) {}
+
+    Tree(Tree const&) = delete;
+    Tree& operator=(Tree const&) = delete;
+    Tree(Tree&&) = default;
+    Tree& operator=(Tree&&) = default;
+
+    // ─── root access ───
+    bool Empty() const noexcept { return !m_root; }
+    Branch*       Root()       noexcept { return m_root.get(); }
+    Branch const* Root() const noexcept { return m_root.get(); }
+
+    // Replace the entire tree. Old subtree is destroyed as its
+    // unique_ptr is overwritten. The new root's parent back-pointer
+    // is cleared (a root has no parent).
+    void SetRoot(std::unique_ptr<Branch> root) noexcept {
+        if (root) root->parent = nullptr;
+        m_root = std::move(root);
+        // Zoom state can't survive a root replacement — the pointer
+        // targets nodes that just got dropped.
+        m_zoomed = nullptr;
+    }
+
+    // ─── walker delegation ───
+    // Thin wrappers around Branch's Composite-style methods. Empty
+    // trees answer conservatively (no matches, nothing to visit).
+
+    bool AnyPaneMatches(std::function<bool(Pane const&)> const& pred) const {
+        return m_root && m_root->AnyPaneMatches(pred);
+    }
+    void ForEachPane(std::function<void(Pane&)> const& visitor) {
+        if (m_root) m_root->ForEachPane(visitor);
+    }
+    void ForEachPane(std::function<void(Pane const&)> const& visitor) const {
+        if (m_root) m_root->ForEachPane(visitor);
+    }
+    Pane* FindPane(std::function<bool(Pane const&)> const& pred) {
+        return m_root ? m_root->FindPane(pred) : nullptr;
+    }
+    Pane const* FindPane(std::function<bool(Pane const&)> const& pred) const {
+        return m_root ? m_root->FindPane(pred) : nullptr;
+    }
+
+    // ─── structural mutations ───
+
+    // Replace the Branch currently wrapping `target` (a Pane pointer
+    // reachable from the root) with `newSubtree`. Returns true on
+    // success; false if `target` isn't in this tree or either pointer
+    // is null. Used by NEW_SPLIT to swap a leaf for a split-of-that-
+    // leaf-plus-a-new-leaf, preserving the existing pane's identity.
+    //
+    // The old subtree is destroyed as its unique_ptr is overwritten,
+    // and `newSubtree`'s parent back-pointer is rewritten to match
+    // the surrounding Split (or cleared, if `target`'s Branch was the
+    // root).
+    bool ReplacePane(Pane const* target, std::unique_ptr<Branch> newSubtree) noexcept {
+        if (!target || !newSubtree || !m_root) return false;
+
+        Branch* wrapping = m_root->FindBranchOfPane(target);
+        if (!wrapping) return false;
+
+        // Was `target` the root? Swap m_root itself.
+        if (wrapping == m_root.get()) {
+            newSubtree->parent = nullptr;
+            m_root = std::move(newSubtree);
+            if (m_zoomed == target) m_zoomed = nullptr;
+            return true;
+        }
+
+        // Otherwise `wrapping` is a child of some Split. Find that
+        // Split and rewire the matching unique_ptr slot.
+        Branch* parent = wrapping->parent;
+        if (!parent) return false;                       // shouldn't happen
+        auto* parentSplit = parent->AsSplit();
+        if (!parentSplit) return false;                  // shouldn't happen
+
+        newSubtree->parent = parent;
+        if (parentSplit->left.get() == wrapping) {
+            parentSplit->left = std::move(newSubtree);
+        } else if (parentSplit->right.get() == wrapping) {
+            parentSplit->right = std::move(newSubtree);
+        } else {
+            return false;                                // shouldn't happen
+        }
+        if (m_zoomed == target) m_zoomed = nullptr;
+        return true;
+    }
+
+    // Outcome of RemovePane — the caller keys UI reactions off which
+    // case occurred (last-pane closes the whole tab, split-collapse
+    // just relayouts, not-found is a stale close event).
+    enum class RemoveResult {
+        NotFound,      // `target` wasn't in this tree
+        Collapsed,     // pane removed; its enclosing split collapsed onto its sibling
+        RemovedRoot,   // pane was the tree's sole content; tree is now empty
+    };
+
+    // Remove the Pane `target` from the tree. If the pane was under a
+    // Split, that split collapses and its surviving sibling is
+    // promoted into the split's slot.
+    RemoveResult RemovePane(Pane const* target) noexcept {
+        if (!target || !m_root) return RemoveResult::NotFound;
+
+        Branch* wrapping = m_root->FindBranchOfPane(target);
+        if (!wrapping) return RemoveResult::NotFound;
+
+        // Root case: the pane was the whole tree.
+        if (wrapping == m_root.get()) {
+            m_root.reset();
+            m_zoomed = nullptr;
+            return RemoveResult::RemovedRoot;
+        }
+
+        // Under a Split: promote the sibling into the split's slot.
+        Branch* parent = wrapping->parent;
+        if (!parent) return RemoveResult::NotFound;      // shouldn't happen
+        auto* parentSplit = parent->AsSplit();
+        if (!parentSplit) return RemoveResult::NotFound; // shouldn't happen
+
+        // Pick the sibling; detach it from the Split so we can hand
+        // it over to the grandparent slot.
+        std::unique_ptr<Branch> sibling;
+        if (parentSplit->left.get() == wrapping) {
+            sibling = std::move(parentSplit->right);
+        } else if (parentSplit->right.get() == wrapping) {
+            sibling = std::move(parentSplit->left);
+        } else {
+            return RemoveResult::NotFound;               // shouldn't happen
+        }
+        if (!sibling) return RemoveResult::NotFound;     // malformed split
+
+        // Where does the split live? Root or under a grandparent Split.
+        Branch* grand = parent->parent;
+        if (!grand) {
+            // Split was the root — sibling becomes the new root.
+            sibling->parent = nullptr;
+            m_root = std::move(sibling);
+        } else {
+            auto* grandSplit = grand->AsSplit();
+            if (!grandSplit) return RemoveResult::NotFound; // shouldn't happen
+            sibling->parent = grand;
+            if (grandSplit->left.get() == parent) {
+                grandSplit->left = std::move(sibling);
+            } else if (grandSplit->right.get() == parent) {
+                grandSplit->right = std::move(sibling);
+            } else {
+                return RemoveResult::NotFound;           // shouldn't happen
+            }
+        }
+        if (m_zoomed == target) m_zoomed = nullptr;
+        return RemoveResult::Collapsed;
+    }
+
+    // ─── zoom state ───
+    // `toggle_split_zoom` action support: one pane in the tree can be
+    // marked "zoomed", meaning it should take up the whole SplitPanel
+    // area instead of participating in the split layout. Tree just
+    // records which pane; SplitPanel consults `Zoomed()` in its
+    // arrange pass and adjusts accordingly.
+
+    Pane const* Zoomed() const noexcept { return m_zoomed; }
+    void SetZoomed(Pane const* pane) noexcept { m_zoomed = pane; }
+    void ClearZoomed() noexcept { m_zoomed = nullptr; }
+
+private:
+    std::unique_ptr<Branch> m_root;
+    // Non-owning pointer into m_root's subtree. Cleared whenever the
+    // pane it points at could be destroyed (SetRoot, ReplacePane or
+    // RemovePane touching that pane).
+    Pane const* m_zoomed{ nullptr };
+};
+
+}  // namespace winrt::GhosttyWin32::implementation

--- a/App/Tabs/Panes/Tree.h
+++ b/App/Tabs/Panes/Tree.h
@@ -61,6 +61,10 @@ public:
     // was the root). Returns false only if the pane isn't in this
     // tree; a null newSubtree is a caller bug (asserted).
     bool ReplacePane(Pane const& target, std::unique_ptr<Branch> newSubtree) noexcept {
+        // Null newSubtree would leave the tree in a shape we don't
+        // model — RemovePane exists for the "make it empty here" case.
+        // Assert so the caller bug is caught in debug instead of
+        // silently returning false alongside the real not-found case.
         assert(newSubtree && "ReplacePane requires non-null newSubtree");
         Branch* wrapping = TryFindBranch(target);
         if (!wrapping) return false;

--- a/App/Tabs/Panes/Tree.h
+++ b/App/Tabs/Panes/Tree.h
@@ -93,29 +93,40 @@ public:
         return true;
     }
 
-    // Callers key UI reactions off the result: last-pane closes the
-    // whole tab, split-collapse just relayouts, not-found is a stale
-    // close event.
-    enum class RemoveResult {
-        NotFound,
-        Collapsed,
-        RemovedRoot,
+    // Callers key UI reactions off which case fired: last-pane closes
+    // the whole tab, split-collapse just relayouts, not-found is a
+    // stale close event. Predicate methods so call sites read as
+    // `result.IsCollapsed()` rather than `result == …::Collapsed`.
+    class RemoveResult {
+    public:
+        static constexpr RemoveResult NotFound()    noexcept { return { Kind::NotFound }; }
+        static constexpr RemoveResult Collapsed()   noexcept { return { Kind::Collapsed }; }
+        static constexpr RemoveResult RemovedRoot() noexcept { return { Kind::RemovedRoot }; }
+
+        constexpr bool IsNotFound()    const noexcept { return m_kind == Kind::NotFound; }
+        constexpr bool IsCollapsed()   const noexcept { return m_kind == Kind::Collapsed; }
+        constexpr bool IsRemovedRoot() const noexcept { return m_kind == Kind::RemovedRoot; }
+
+    private:
+        enum class Kind { NotFound, Collapsed, RemovedRoot };
+        constexpr RemoveResult(Kind k) noexcept : m_kind(k) {}
+        Kind m_kind;
     };
 
     RemoveResult RemovePane(Pane const& target) noexcept {
         Branch* wrapping = TryFindBranch(target);
-        if (!wrapping) return RemoveResult::NotFound;
+        if (!wrapping) return RemoveResult::NotFound();
 
         if (wrapping == m_root.get()) {
             m_root.reset();
             m_zoomed = nullptr;
-            return RemoveResult::RemovedRoot;
+            return RemoveResult::RemovedRoot();
         }
 
         Branch* parent = wrapping->parent;
-        if (!parent) return RemoveResult::NotFound;
+        if (!parent) return RemoveResult::NotFound();
         auto* parentSplit = parent->TryGet<Split>();
-        if (!parentSplit) return RemoveResult::NotFound;
+        if (!parentSplit) return RemoveResult::NotFound();
 
         // Detach the sibling first so its unique_ptr survives when
         // the parent Split is overwritten below.
@@ -125,9 +136,9 @@ public:
         } else if (parentSplit->right.get() == wrapping) {
             sibling = std::move(parentSplit->left);
         } else {
-            return RemoveResult::NotFound;
+            return RemoveResult::NotFound();
         }
-        if (!sibling) return RemoveResult::NotFound;
+        if (!sibling) return RemoveResult::NotFound();
 
         // Promote the sibling into the grandparent's slot (or the
         // root if the collapsing Split was the root).
@@ -137,18 +148,18 @@ public:
             m_root = std::move(sibling);
         } else {
             auto* grandSplit = grand->TryGet<Split>();
-            if (!grandSplit) return RemoveResult::NotFound;
+            if (!grandSplit) return RemoveResult::NotFound();
             sibling->parent = grand;
             if (grandSplit->left.get() == parent) {
                 grandSplit->left = std::move(sibling);
             } else if (grandSplit->right.get() == parent) {
                 grandSplit->right = std::move(sibling);
             } else {
-                return RemoveResult::NotFound;
+                return RemoveResult::NotFound();
             }
         }
         if (m_zoomed == &target) m_zoomed = nullptr;
-        return RemoveResult::Collapsed;
+        return RemoveResult::Collapsed();
     }
 
     // toggle_split_zoom support: SplitPanel consults Zoomed() in its

--- a/App/Tabs/Panes/Tree.h
+++ b/App/Tabs/Panes/Tree.h
@@ -93,7 +93,7 @@ public:
     // `Find` matches the fallible-lookup convention we already use
     // for Branch::TryGet<T>().
     Branch* TryFindBranch(Pane const& pane) noexcept {
-        return HasRoot() ? m_root->FindBranchOfPane(&pane) : nullptr;
+        return HasRoot() ? m_root->FindBranchOfPane(pane) : nullptr;
     }
 
     // Replace the Branch currently wrapping `target` with `newSubtree`.

--- a/App/Tabs/Panes/Tree.h
+++ b/App/Tabs/Panes/Tree.h
@@ -43,7 +43,7 @@ public:
     // ─── root access ───
     // Positive predicate: this tree has a root Branch (equivalently:
     // at least one Pane lives in it). Used as the guard in the
-    // walker delegations below and by the WrappingBranchOf lookup
+    // walker delegations below and by the TryFindBranch lookup
     // that the structural mutations key off. Named for the specific
     // state ("root exists") rather than the generic "not empty" —
     // callers read as `HasRoot()` without wondering "empty of what?".
@@ -84,12 +84,14 @@ public:
 
     // ─── structural mutations ───
 
-    // Look up the Branch that wraps `pane` in this tree, or nullptr
+    // Locate the Branch that wraps `pane` in this tree, or nullptr
     // if the tree is empty OR the pane isn't in it. Both structural
     // mutations (ReplacePane, RemovePane) start the same way — find
     // the wrapping Branch or bail — so the two failure modes collapse
-    // into one nullable return the callers dispatch on.
-    Branch* WrappingBranchOf(Pane const& pane) noexcept {
+    // into one nullable return the callers dispatch on. `Try` +
+    // `Find` matches the fallible-lookup convention we already use
+    // for Branch::TryGet<T>().
+    Branch* TryFindBranch(Pane const& pane) noexcept {
         return HasRoot() ? m_root->FindBranchOfPane(&pane) : nullptr;
     }
 
@@ -110,7 +112,7 @@ public:
     // root).
     bool ReplacePane(Pane const& target, std::unique_ptr<Branch> newSubtree) noexcept {
         if (!newSubtree) return false;
-        Branch* wrapping = WrappingBranchOf(target);
+        Branch* wrapping = TryFindBranch(target);
         if (!wrapping) return false;
 
         // Was `target` the root? Swap m_root itself.
@@ -155,7 +157,7 @@ public:
     // callers must have a real Pane to name; a stale close event on
     // a pane already gone from this tree still returns NotFound.
     RemoveResult RemovePane(Pane const& target) noexcept {
-        Branch* wrapping = WrappingBranchOf(target);
+        Branch* wrapping = TryFindBranch(target);
         if (!wrapping) return RemoveResult::NotFound;
 
         // Root case: the pane was the whole tree.

--- a/App/Tabs/Panes/Tree.h
+++ b/App/Tabs/Panes/Tree.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "Tabs/Panes/Branch.h"
+#include <cassert>
 #include <functional>
 #include <memory>
 #include <utility>
@@ -96,22 +97,26 @@ public:
     }
 
     // Replace the Branch currently wrapping `target` with `newSubtree`.
-    // Returns true on success; false if `target` isn't in this tree or
-    // `newSubtree` is null. Used by NEW_SPLIT to swap a leaf for a
-    // split-of-that-leaf-plus-a-new-leaf, preserving the existing
-    // pane's identity.
+    // Returns true on success; false only when `target` isn't in this
+    // tree (a stale event, a Pane from a sibling window, etc.). Used
+    // by NEW_SPLIT to swap a leaf for a split-of-that-leaf-plus-a-
+    // new-leaf, preserving the existing pane's identity.
     //
-    // `target` is by-reference — callers must have a real Pane to name.
-    // Non-membership in this tree still returns false; that's a
-    // different failure mode (stale event, wrong tab) from a null
-    // input, which the type prevents up front.
+    // Preconditions (checked by assert in debug builds; UB otherwise):
+    //   * `target` is a real Pane — the reference parameter guarantees
+    //     it up front, no runtime guard.
+    //   * `newSubtree` is a non-null unique_ptr, i.e. the caller
+    //     actually built one. Passing a default-constructed or
+    //     moved-from unique_ptr is a programming bug — factory
+    //     helpers (MakePaneBranch / MakeSplitBranch) always return
+    //     non-null, so real call sites shouldn't hit the assert.
     //
     // The old subtree is destroyed as its unique_ptr is overwritten,
     // and `newSubtree`'s parent back-pointer is rewritten to match
     // the surrounding Split (or cleared, if `target`'s Branch was the
     // root).
     bool ReplacePane(Pane const& target, std::unique_ptr<Branch> newSubtree) noexcept {
-        if (!newSubtree) return false;
+        assert(newSubtree && "ReplacePane requires non-null newSubtree");
         Branch* wrapping = TryFindBranch(target);
         if (!wrapping) return false;
 

--- a/App/Tabs/Panes/Tree.h
+++ b/App/Tabs/Panes/Tree.h
@@ -106,7 +106,7 @@ public:
         // Split and rewire the matching unique_ptr slot.
         Branch* parent = wrapping->parent;
         if (!parent) return false;                       // shouldn't happen
-        auto* parentSplit = parent->AsSplit();
+        auto* parentSplit = parent->TryGet<Split>();
         if (!parentSplit) return false;                  // shouldn't happen
 
         newSubtree->parent = parent;
@@ -149,7 +149,7 @@ public:
         // Under a Split: promote the sibling into the split's slot.
         Branch* parent = wrapping->parent;
         if (!parent) return RemoveResult::NotFound;      // shouldn't happen
-        auto* parentSplit = parent->AsSplit();
+        auto* parentSplit = parent->TryGet<Split>();
         if (!parentSplit) return RemoveResult::NotFound; // shouldn't happen
 
         // Pick the sibling; detach it from the Split so we can hand
@@ -171,7 +171,7 @@ public:
             sibling->parent = nullptr;
             m_root = std::move(sibling);
         } else {
-            auto* grandSplit = grand->AsSplit();
+            auto* grandSplit = grand->TryGet<Split>();
             if (!grandSplit) return RemoveResult::NotFound; // shouldn't happen
             sibling->parent = grand;
             if (grandSplit->left.get() == parent) {

--- a/App/Tabs/Panes/Tree.h
+++ b/App/Tabs/Panes/Tree.h
@@ -39,14 +39,19 @@ public:
     void ForEachPane(std::function<void(Pane&)> const& visitor) {
         if (HasRoot()) m_root->ForEachPane(visitor);
     }
+    // Const overloads go through Root() so the receiver is Branch
+    // const* — otherwise MSVC sees both Branch overloads as viable
+    // (mutable receiver + argument that matches either) and flags
+    // C2666. The mutable overloads work off m_root directly.
     void ForEachPane(std::function<void(Pane const&)> const& visitor) const {
-        if (HasRoot()) m_root->ForEachPane(visitor);
+        if (auto const* root = Root()) root->ForEachPane(visitor);
     }
     Pane* FindPaneBy(std::function<bool(Pane const&)> const& pred) {
         return HasRoot() ? m_root->FindPaneBy(pred) : nullptr;
     }
     Pane const* FindPaneBy(std::function<bool(Pane const&)> const& pred) const {
-        return HasRoot() ? m_root->FindPaneBy(pred) : nullptr;
+        auto const* root = Root();
+        return root ? root->FindPaneBy(pred) : nullptr;
     }
 
     // Both structural mutations start by locating the wrapping Branch

--- a/App/Tabs/Panes/Tree.h
+++ b/App/Tabs/Panes/Tree.h
@@ -41,7 +41,13 @@ public:
     Tree& operator=(Tree&&) = default;
 
     // ─── root access ───
-    bool Empty() const noexcept { return !m_root; }
+    // Positive predicate: this tree has a root Branch (equivalently:
+    // at least one Pane lives in it). Used as the guard in the
+    // walker delegations below and by the WrappingBranchOf lookup
+    // that the structural mutations key off. Named for the specific
+    // state ("root exists") rather than the generic "not empty" —
+    // callers read as `HasRoot()` without wondering "empty of what?".
+    bool HasRoot() const noexcept { return static_cast<bool>(m_root); }
     Branch*       Root()       noexcept { return m_root.get(); }
     Branch const* Root() const noexcept { return m_root.get(); }
 
@@ -61,44 +67,57 @@ public:
     // trees answer conservatively (no matches, nothing to visit).
 
     bool AnyPaneMatches(std::function<bool(Pane const&)> const& pred) const {
-        return m_root && m_root->AnyPaneMatches(pred);
+        return HasRoot() && m_root->AnyPaneMatches(pred);
     }
     void ForEachPane(std::function<void(Pane&)> const& visitor) {
-        if (m_root) m_root->ForEachPane(visitor);
+        if (HasRoot()) m_root->ForEachPane(visitor);
     }
     void ForEachPane(std::function<void(Pane const&)> const& visitor) const {
-        if (m_root) m_root->ForEachPane(visitor);
+        if (HasRoot()) m_root->ForEachPane(visitor);
     }
     Pane* FindPane(std::function<bool(Pane const&)> const& pred) {
-        return m_root ? m_root->FindPane(pred) : nullptr;
+        return HasRoot() ? m_root->FindPane(pred) : nullptr;
     }
     Pane const* FindPane(std::function<bool(Pane const&)> const& pred) const {
-        return m_root ? m_root->FindPane(pred) : nullptr;
+        return HasRoot() ? m_root->FindPane(pred) : nullptr;
     }
 
     // ─── structural mutations ───
 
-    // Replace the Branch currently wrapping `target` (a Pane pointer
-    // reachable from the root) with `newSubtree`. Returns true on
-    // success; false if `target` isn't in this tree or either pointer
-    // is null. Used by NEW_SPLIT to swap a leaf for a split-of-that-
-    // leaf-plus-a-new-leaf, preserving the existing pane's identity.
+    // Look up the Branch that wraps `pane` in this tree, or nullptr
+    // if the tree is empty OR the pane isn't in it. Both structural
+    // mutations (ReplacePane, RemovePane) start the same way — find
+    // the wrapping Branch or bail — so the two failure modes collapse
+    // into one nullable return the callers dispatch on.
+    Branch* WrappingBranchOf(Pane const& pane) noexcept {
+        return HasRoot() ? m_root->FindBranchOfPane(&pane) : nullptr;
+    }
+
+    // Replace the Branch currently wrapping `target` with `newSubtree`.
+    // Returns true on success; false if `target` isn't in this tree or
+    // `newSubtree` is null. Used by NEW_SPLIT to swap a leaf for a
+    // split-of-that-leaf-plus-a-new-leaf, preserving the existing
+    // pane's identity.
+    //
+    // `target` is by-reference — callers must have a real Pane to name.
+    // Non-membership in this tree still returns false; that's a
+    // different failure mode (stale event, wrong tab) from a null
+    // input, which the type prevents up front.
     //
     // The old subtree is destroyed as its unique_ptr is overwritten,
     // and `newSubtree`'s parent back-pointer is rewritten to match
     // the surrounding Split (or cleared, if `target`'s Branch was the
     // root).
-    bool ReplacePane(Pane const* target, std::unique_ptr<Branch> newSubtree) noexcept {
-        if (!target || !newSubtree || !m_root) return false;
-
-        Branch* wrapping = m_root->FindBranchOfPane(target);
+    bool ReplacePane(Pane const& target, std::unique_ptr<Branch> newSubtree) noexcept {
+        if (!newSubtree) return false;
+        Branch* wrapping = WrappingBranchOf(target);
         if (!wrapping) return false;
 
         // Was `target` the root? Swap m_root itself.
         if (wrapping == m_root.get()) {
             newSubtree->parent = nullptr;
             m_root = std::move(newSubtree);
-            if (m_zoomed == target) m_zoomed = nullptr;
+            if (m_zoomed == &target) m_zoomed = nullptr;
             return true;
         }
 
@@ -117,7 +136,7 @@ public:
         } else {
             return false;                                // shouldn't happen
         }
-        if (m_zoomed == target) m_zoomed = nullptr;
+        if (m_zoomed == &target) m_zoomed = nullptr;
         return true;
     }
 
@@ -132,11 +151,11 @@ public:
 
     // Remove the Pane `target` from the tree. If the pane was under a
     // Split, that split collapses and its surviving sibling is
-    // promoted into the split's slot.
-    RemoveResult RemovePane(Pane const* target) noexcept {
-        if (!target || !m_root) return RemoveResult::NotFound;
-
-        Branch* wrapping = m_root->FindBranchOfPane(target);
+    // promoted into the split's slot. `target` is by-reference —
+    // callers must have a real Pane to name; a stale close event on
+    // a pane already gone from this tree still returns NotFound.
+    RemoveResult RemovePane(Pane const& target) noexcept {
+        Branch* wrapping = WrappingBranchOf(target);
         if (!wrapping) return RemoveResult::NotFound;
 
         // Root case: the pane was the whole tree.
@@ -182,7 +201,7 @@ public:
                 return RemoveResult::NotFound;           // shouldn't happen
             }
         }
-        if (m_zoomed == target) m_zoomed = nullptr;
+        if (m_zoomed == &target) m_zoomed = nullptr;
         return RemoveResult::Collapsed;
     }
 

--- a/App/Tabs/Panes/Tree.h
+++ b/App/Tabs/Panes/Tree.h
@@ -8,28 +8,9 @@
 
 namespace winrt::GhosttyWin32::implementation {
 
-// Container for a pane tree — the model layer for one tab's split
-// arrangement. Owns the root Branch (nullable = empty tree) plus
-// tree-wide state that doesn't belong on any single Branch: the
-// currently-zoomed pane (if any), the mutations that need to swap
-// the root pointer, etc.
-//
-// Tree is pure C++ — no WinUI, no Win32 — so its behaviour is
-// unit-testable in isolation with fake pane trees. The XAML-side
-// Panel (SplitPanel) holds a Tree as a member and drives
-// MeasureOverride / ArrangeOverride off it; the two layers meet at
-// the mutation methods on this class (SetRoot / ReplacePane /
-// RemovePane), where SplitPanel refreshes its Children collection
-// after Tree finishes rewiring pointers.
-//
-// This is the "SplitTree" of the Ghostty upstream Swift design (see
-// external/ghostty/macos/Sources/Features/Splits/SplitTree.swift),
-// adapted to C++ sum types (Branch = variant<Pane, Split>) instead
-// of Swift indirect enums. Named Tree here rather than SplitTree —
-// the "split" prefix would collide with the Split variant type
-// (making 'SplitTree' read as 'tree of Splits' when in fact the tree
-// contains a mix of Panes and Splits) and adds no information the
-// namespace / member type doesn't already convey.
+// Model layer for one tab's split arrangement. Pure C++ so the tree
+// mutations and walks are unit-testable without WinUI. SplitPanel
+// owns a Tree and syncs its Children collection after each mutation.
 class Tree {
 public:
     Tree() = default;
@@ -41,31 +22,16 @@ public:
     Tree(Tree&&) = default;
     Tree& operator=(Tree&&) = default;
 
-    // ─── root access ───
-    // Positive predicate: this tree has a root Branch (equivalently:
-    // at least one Pane lives in it). Used as the guard in the
-    // walker delegations below and by the TryFindBranch lookup
-    // that the structural mutations key off. Named for the specific
-    // state ("root exists") rather than the generic "not empty" —
-    // callers read as `HasRoot()` without wondering "empty of what?".
     bool HasRoot() const noexcept { return static_cast<bool>(m_root); }
     Branch*       Root()       noexcept { return m_root.get(); }
     Branch const* Root() const noexcept { return m_root.get(); }
 
-    // Replace the entire tree. Old subtree is destroyed as its
-    // unique_ptr is overwritten. The new root's parent back-pointer
-    // is cleared (a root has no parent).
     void SetRoot(std::unique_ptr<Branch> root) noexcept {
         if (root) root->parent = nullptr;
         m_root = std::move(root);
-        // Zoom state can't survive a root replacement — the pointer
-        // targets nodes that just got dropped.
+        // The old zoomed pointer targeted a node we just dropped.
         m_zoomed = nullptr;
     }
-
-    // ─── walker delegation ───
-    // Thin wrappers around Branch's Composite-style methods. Empty
-    // trees answer conservatively (no matches, nothing to visit).
 
     bool AnyPaneMatches(std::function<bool(Pane const&)> const& pred) const {
         return HasRoot() && m_root->AnyPaneMatches(pred);
@@ -83,44 +49,22 @@ public:
         return HasRoot() ? m_root->FindPaneBy(pred) : nullptr;
     }
 
-    // ─── structural mutations ───
-
-    // Locate the Branch that wraps `pane` in this tree, or nullptr
-    // if the tree is empty OR the pane isn't in it. Both structural
-    // mutations (ReplacePane, RemovePane) start the same way — find
-    // the wrapping Branch or bail — so the two failure modes collapse
-    // into one nullable return the callers dispatch on. `Try` +
-    // `Find` matches the fallible-lookup convention we already use
-    // for Branch::TryGet<T>().
+    // Both structural mutations start by locating the wrapping Branch
+    // or bailing — collapsed here so the two failure modes (empty
+    // tree, pane not present) share one nullable return.
     Branch* TryFindBranch(Pane const& pane) noexcept {
         return HasRoot() ? m_root->FindBranchOfPane(pane) : nullptr;
     }
 
-    // Replace the Branch currently wrapping `target` with `newSubtree`.
-    // Returns true on success; false only when `target` isn't in this
-    // tree (a stale event, a Pane from a sibling window, etc.). Used
-    // by NEW_SPLIT to swap a leaf for a split-of-that-leaf-plus-a-
-    // new-leaf, preserving the existing pane's identity.
-    //
-    // Preconditions (checked by assert in debug builds; UB otherwise):
-    //   * `target` is a real Pane — the reference parameter guarantees
-    //     it up front, no runtime guard.
-    //   * `newSubtree` is a non-null unique_ptr, i.e. the caller
-    //     actually built one. Passing a default-constructed or
-    //     moved-from unique_ptr is a programming bug — factory
-    //     helpers (MakePaneBranch / MakeSplitBranch) always return
-    //     non-null, so real call sites shouldn't hit the assert.
-    //
-    // The old subtree is destroyed as its unique_ptr is overwritten,
-    // and `newSubtree`'s parent back-pointer is rewritten to match
-    // the surrounding Split (or cleared, if `target`'s Branch was the
-    // root).
+    // Preserves `target`'s identity by rewiring its wrapping Branch's
+    // owning unique_ptr slot (in the parent Split, or m_root if it
+    // was the root). Returns false only if the pane isn't in this
+    // tree; a null newSubtree is a caller bug (asserted).
     bool ReplacePane(Pane const& target, std::unique_ptr<Branch> newSubtree) noexcept {
         assert(newSubtree && "ReplacePane requires non-null newSubtree");
         Branch* wrapping = TryFindBranch(target);
         if (!wrapping) return false;
 
-        // Was `target` the root? Swap m_root itself.
         if (wrapping == m_root.get()) {
             newSubtree->parent = nullptr;
             m_root = std::move(newSubtree);
@@ -128,12 +72,10 @@ public:
             return true;
         }
 
-        // Otherwise `wrapping` is a child of some Split. Find that
-        // Split and rewire the matching unique_ptr slot.
         Branch* parent = wrapping->parent;
-        if (!parent) return false;                       // shouldn't happen
+        if (!parent) return false;
         auto* parentSplit = parent->TryGet<Split>();
-        if (!parentSplit) return false;                  // shouldn't happen
+        if (!parentSplit) return false;
 
         newSubtree->parent = parent;
         if (parentSplit->left.get() == wrapping) {
@@ -141,84 +83,72 @@ public:
         } else if (parentSplit->right.get() == wrapping) {
             parentSplit->right = std::move(newSubtree);
         } else {
-            return false;                                // shouldn't happen
+            return false;
         }
         if (m_zoomed == &target) m_zoomed = nullptr;
         return true;
     }
 
-    // Outcome of RemovePane — the caller keys UI reactions off which
-    // case occurred (last-pane closes the whole tab, split-collapse
-    // just relayouts, not-found is a stale close event).
+    // Callers key UI reactions off the result: last-pane closes the
+    // whole tab, split-collapse just relayouts, not-found is a stale
+    // close event.
     enum class RemoveResult {
-        NotFound,      // `target` wasn't in this tree
-        Collapsed,     // pane removed; its enclosing split collapsed onto its sibling
-        RemovedRoot,   // pane was the tree's sole content; tree is now empty
+        NotFound,
+        Collapsed,
+        RemovedRoot,
     };
 
-    // Remove the Pane `target` from the tree. If the pane was under a
-    // Split, that split collapses and its surviving sibling is
-    // promoted into the split's slot. `target` is by-reference —
-    // callers must have a real Pane to name; a stale close event on
-    // a pane already gone from this tree still returns NotFound.
     RemoveResult RemovePane(Pane const& target) noexcept {
         Branch* wrapping = TryFindBranch(target);
         if (!wrapping) return RemoveResult::NotFound;
 
-        // Root case: the pane was the whole tree.
         if (wrapping == m_root.get()) {
             m_root.reset();
             m_zoomed = nullptr;
             return RemoveResult::RemovedRoot;
         }
 
-        // Under a Split: promote the sibling into the split's slot.
         Branch* parent = wrapping->parent;
-        if (!parent) return RemoveResult::NotFound;      // shouldn't happen
+        if (!parent) return RemoveResult::NotFound;
         auto* parentSplit = parent->TryGet<Split>();
-        if (!parentSplit) return RemoveResult::NotFound; // shouldn't happen
+        if (!parentSplit) return RemoveResult::NotFound;
 
-        // Pick the sibling; detach it from the Split so we can hand
-        // it over to the grandparent slot.
+        // Detach the sibling first so its unique_ptr survives when
+        // the parent Split is overwritten below.
         std::unique_ptr<Branch> sibling;
         if (parentSplit->left.get() == wrapping) {
             sibling = std::move(parentSplit->right);
         } else if (parentSplit->right.get() == wrapping) {
             sibling = std::move(parentSplit->left);
         } else {
-            return RemoveResult::NotFound;               // shouldn't happen
+            return RemoveResult::NotFound;
         }
-        if (!sibling) return RemoveResult::NotFound;     // malformed split
+        if (!sibling) return RemoveResult::NotFound;
 
-        // Where does the split live? Root or under a grandparent Split.
+        // Promote the sibling into the grandparent's slot (or the
+        // root if the collapsing Split was the root).
         Branch* grand = parent->parent;
         if (!grand) {
-            // Split was the root — sibling becomes the new root.
             sibling->parent = nullptr;
             m_root = std::move(sibling);
         } else {
             auto* grandSplit = grand->TryGet<Split>();
-            if (!grandSplit) return RemoveResult::NotFound; // shouldn't happen
+            if (!grandSplit) return RemoveResult::NotFound;
             sibling->parent = grand;
             if (grandSplit->left.get() == parent) {
                 grandSplit->left = std::move(sibling);
             } else if (grandSplit->right.get() == parent) {
                 grandSplit->right = std::move(sibling);
             } else {
-                return RemoveResult::NotFound;           // shouldn't happen
+                return RemoveResult::NotFound;
             }
         }
         if (m_zoomed == &target) m_zoomed = nullptr;
         return RemoveResult::Collapsed;
     }
 
-    // ─── zoom state ───
-    // `toggle_split_zoom` action support: one pane in the tree can be
-    // marked "zoomed", meaning it should take up the whole SplitPanel
-    // area instead of participating in the split layout. Tree just
-    // records which pane; SplitPanel consults `Zoomed()` in its
-    // arrange pass and adjusts accordingly.
-
+    // toggle_split_zoom support: SplitPanel consults Zoomed() in its
+    // arrange pass and gives the zoomed pane the whole area.
     Pane const* Zoomed() const noexcept { return m_zoomed; }
     void SetZoomed(Pane const* pane) noexcept { m_zoomed = pane; }
     void ClearZoomed() noexcept { m_zoomed = nullptr; }
@@ -226,8 +156,7 @@ public:
 private:
     std::unique_ptr<Branch> m_root;
     // Non-owning pointer into m_root's subtree. Cleared whenever the
-    // pane it points at could be destroyed (SetRoot, ReplacePane or
-    // RemovePane touching that pane).
+    // pointed-at pane could go away (SetRoot, ReplacePane, RemovePane).
     Pane const* m_zoomed{ nullptr };
 };
 

--- a/App/Tabs/Panes/Tree.h
+++ b/App/Tabs/Panes/Tree.h
@@ -76,11 +76,11 @@ public:
     void ForEachPane(std::function<void(Pane const&)> const& visitor) const {
         if (HasRoot()) m_root->ForEachPane(visitor);
     }
-    Pane* FindPane(std::function<bool(Pane const&)> const& pred) {
-        return HasRoot() ? m_root->FindPane(pred) : nullptr;
+    Pane* FindPaneBy(std::function<bool(Pane const&)> const& pred) {
+        return HasRoot() ? m_root->FindPaneBy(pred) : nullptr;
     }
-    Pane const* FindPane(std::function<bool(Pane const&)> const& pred) const {
-        return HasRoot() ? m_root->FindPane(pred) : nullptr;
+    Pane const* FindPaneBy(std::function<bool(Pane const&)> const& pred) const {
+        return HasRoot() ? m_root->FindPaneBy(pred) : nullptr;
     }
 
     // ─── structural mutations ───

--- a/App/Tabs/Tab.h
+++ b/App/Tabs/Tab.h
@@ -52,7 +52,7 @@ public:
         // Initial active pane is the first pane found in depth-first
         // order — SetActivePane keeps the per-tab dim invariant
         // consistent (active bright, everything else dim).
-        auto* firstPane = panelImpl->Tree().FindPane(
+        auto* firstPane = panelImpl->Tree().FindPaneBy(
             [](Pane const&) { return true; });
         if (!firstPane) {
             throw winrt::hresult_error(E_INVALIDARG, L"Tab: pane tree has no pane");

--- a/App/Tabs/Tab.h
+++ b/App/Tabs/Tab.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "Tabs/Panes/Pane.h"
+#include "Tabs/Panes/Tree.h"
 #include "SplitPanel.h"
 #include "TerminalControl.xaml.h"
 #include <winrt/Microsoft.UI.Xaml.h>
@@ -12,29 +12,23 @@ namespace winrt::GhosttyWin32::implementation {
 // One tab in the window's TabView.
 //
 // Each Tab references:
-//   * A SplitPanel (`m_panel`) that owns the Pane tree describing how
+//   * A SplitPanel (`m_panel`) that owns the pane tree describing how
 //     this tab's content is partitioned across one or more terminal
 //     panes. The host (MainWindow) parents the panel under AppContent
 //     alongside every other tab's panel; selection drives per-panel
 //     Visibility, which is why TabViewItem.Content stays unset. The
 //     panel keeps its Children() collection in sync with the tree's
-//     leaf set so framework input routing, hit-testing, and measure /
-//     arrange work end-to-end. Today the tree is always a single leaf
-//     — NEW_SPLIT plumbing comes in the next phase — but the structure
-//     is in place so callers (Tabs::FindBySurface, action callbacks)
-//     walk the tree instead of assuming a single TerminalControl per
-//     tab.
-//   * A pointer to the currently active leaf (`m_activeLeaf`). All
+//     pane set so framework input routing, hit-testing, and measure /
+//     arrange work end-to-end.
+//   * A pointer to the currently active pane (`m_activePane`). All
 //     "focused terminal" operations (key events, IME, clipboard,
-//     action targets) flow through this. Today there is exactly one
-//     leaf so it never moves; phase 4 (#13) will retarget it on
-//     GOTO_SPLIT / pointer focus.
+//     action targets) flow through this. On tree mutations (future
+//     NEW_SPLIT / CLOSE_PANE) `m_activePane` must be reset before any
+//     pane it points at is destroyed.
 //
-// The Pane tree itself lives inside the SplitPanel (one unique_ptr
-// owner) — Tab borrows it via panel.Root() and stores `m_activeLeaf`
-// as a non-owning pointer into that tree. On tree mutations (future
-// NEW_SPLIT / CLOSE_PANE) `m_activeLeaf` must be reset before any leaf
-// is destroyed.
+// The tree itself lives inside the SplitPanel — Tab borrows it via
+// `panel.Tree()` for pane walks and reaches into individual panes for
+// TerminalControl bridge calls.
 //
 // Construction is just validation + member init — failable setup
 // (creating the surface handle, attaching it, calling
@@ -52,22 +46,22 @@ public:
             throw winrt::hresult_error(E_INVALIDARG, L"Tab: missing resource");
         }
         auto* panelImpl = winrt::get_self<implementation::SplitPanel>(m_panel);
-        if (!panelImpl || !panelImpl->Root()) {
-            throw winrt::hresult_error(E_INVALIDARG, L"Tab: SplitPanel has no root");
+        if (!panelImpl || panelImpl->Tree().Empty()) {
+            throw winrt::hresult_error(E_INVALIDARG, L"Tab: SplitPanel has no tree");
         }
-        // Initial active leaf is the first (and currently only) leaf
-        // found via depth-first descent. Route through SetActiveLeaf so
-        // the per-tab dim state is applied consistently: active leaf
-        // bright, everything else dim.
-        auto* firstLeaf = FindFirstLeaf(panelImpl->Root());
-        if (!firstLeaf) {
-            throw winrt::hresult_error(E_INVALIDARG, L"Tab: pane tree has no leaf");
+        // Initial active pane is the first pane found in depth-first
+        // order — SetActivePane keeps the per-tab dim invariant
+        // consistent (active bright, everything else dim).
+        auto* firstPane = panelImpl->Tree().FindPane(
+            [](Pane const&) { return true; });
+        if (!firstPane) {
+            throw winrt::hresult_error(E_INVALIDARG, L"Tab: pane tree has no pane");
         }
-        SetActiveLeaf(firstLeaf);
+        SetActivePane(firstPane);
     }
 
     ~Tab() {
-        // Catch-all teardown: any leaves still attached at destruction
+        // Catch-all teardown: any panes still attached at destruction
         // get released here. The host's close paths (TabCloseRequested,
         // CLOSE_TAB action, close_surface_cb) all call DetachAll()
         // explicitly first so the framework's panel unparenting doesn't
@@ -84,13 +78,13 @@ public:
     Tab& operator=(Tab&&) = delete;
 
     // Returns the currently-focused TerminalControl in this tab —
-    // i.e. the impl of the active leaf in the pane tree. Callers that
-    // need the surface, composition handle, or inner SwapChainPanel
-    // should go through here so they keep working when the tree gains
-    // additional leaves and the active leaf shifts on GOTO_SPLIT.
+    // the impl paired with the active pane. Callers that need the
+    // surface, composition handle, or inner SwapChainPanel should go
+    // through here so they keep working when the tree gains additional
+    // panes and the active pane shifts on GOTO_SPLIT.
     implementation::TerminalControl* ActiveControl() const noexcept {
-        if (!m_activeLeaf) return nullptr;
-        return LeafToTerminalControl(*m_activeLeaf);
+        if (!m_activePane) return nullptr;
+        return PaneToTerminalControl(*m_activePane);
     }
 
     Microsoft::UI::Xaml::Controls::TabViewItem const& Item() const noexcept { return m_item; }
@@ -115,33 +109,49 @@ public:
         m_lastForegroundName = std::move(name);
     }
 
-    // Read-only access to the SplitPanel hosting this tab's tree, used
-    // by Tabs::FindBySurface to walk every leaf and locate the one
-    // whose TerminalControl owns a given ghostty_surface_t.
+    // Read-only access to the SplitPanel hosting this tab's tree — the
+    // starting point for pane walks (`tab->Panel()` → `.Tree()` →
+    // walker methods).
     winrt::GhosttyWin32::SplitPanel const& Panel() const noexcept { return m_panel; }
-    Pane* ActiveLeaf() const noexcept { return m_activeLeaf; }
+    Pane* ActivePane() const noexcept { return m_activePane; }
 
-    // Retarget the active leaf — used by NEW_SPLIT (focus shifts to
+    // Per-tab confirmation predicate: does any pane in this tab's tree
+    // currently report ghostty_surface_needs_confirm_quit? Owns the
+    // walk here because Tab already owns the tree via its SplitPanel
+    // — callers (close-flow gate for tab scope, MainWindow iterating
+    // tabs for window scope) get a straight bool.
+    bool NeedsConfirmClose() const {
+        auto* panelImpl = winrt::get_self<implementation::SplitPanel>(m_panel);
+        if (!panelImpl) return false;
+        return panelImpl->Tree().AnyPaneMatches([](Pane const& p) {
+            auto const* tc = PaneToTerminalControl(p);
+            return tc && tc->Surface().NeedsConfirmQuit();
+        });
+    }
+
+    // Retarget the active pane — used by NEW_SPLIT (focus shifts to
     // the freshly-created pane), GOTO_SPLIT (direction-based pane
     // nav), and the pointer-focus path (a click on a non-active pane).
-    // `leaf` must reach back to a leaf currently inside this tab's
-    // SplitPanel tree, or be nullptr to indicate "no active leaf yet"
-    // during a tree mutation. Callers verify with FindLeafByPaneId or
-    // build the leaf themselves before the tree mutation.
+    // `pane` must reach back to a pane currently inside this tab's
+    // SplitPanel tree, or be nullptr to indicate "no active pane yet"
+    // during a tree mutation.
     //
-    // Owns the per-tab dim invariant: the active leaf's UnfocusedDim
-    // is Collapsed (bright), every other leaf's is Visible (dim).
-    // Walking the tree on every SetActiveLeaf call is the canonical
-    // path — the dim state is a property of which leaf the tab thinks
+    // Owns the per-tab dim invariant: the active pane's UnfocusedDim
+    // is Collapsed (bright), every other pane's is Visible (dim).
+    // Walking the tree on every SetActivePane call is the canonical
+    // path — the dim state is a property of which pane the tab thinks
     // is active, not of XAML keyboard focus, so tab switches and
-    // alt-tabs don't disturb it (they don't change m_activeLeaf).
-    // Pointer clicks and keybind navigation come in through here too;
-    // the corresponding TerminalControl GotFocus / LostFocus hooks no
-    // longer touch the overlay.
-    void SetActiveLeaf(Pane* leaf) {
-        m_activeLeaf = leaf;
+    // alt-tabs don't disturb it. Pointer clicks and keybind navigation
+    // come in through here too; the corresponding TerminalControl
+    // GotFocus / LostFocus hooks no longer touch the overlay.
+    void SetActivePane(Pane* pane) {
+        m_activePane = pane;
         if (auto* panelImpl = winrt::get_self<implementation::SplitPanel>(m_panel)) {
-            ApplyDimRecursive(panelImpl->Root(), leaf);
+            panelImpl->Tree().ForEachPane([this](Pane& p) {
+                if (auto* tc = PaneToTerminalControl(p)) {
+                    tc->ApplyFocusVisual(&p == m_activePane);
+                }
+            });
         }
     }
 
@@ -153,17 +163,21 @@ public:
     // cleared.
     void DetachAll() {
         if (auto* panelImpl = winrt::get_self<implementation::SplitPanel>(m_panel)) {
-            DetachAllLeaves(panelImpl->Root());
+            panelImpl->Tree().ForEachPane([](Pane& p) {
+                if (auto* tc = PaneToTerminalControl(p)) {
+                    tc->Detach();
+                }
+            });
         }
     }
 
-    // Whether XAML accepted the focus request. The active leaf's
+    // Whether XAML accepted the focus request. The active pane's
     // TerminalControl is a UserControl with IsTabStop=true, so unlike
     // a bare SwapChainPanel this Focus call actually moves focus
     // reliably.
     bool Focus() {
-        if (!m_activeLeaf) return false;
-        auto element = m_activeLeaf->Content();
+        if (!m_activePane) return false;
+        auto element = m_activePane->content;
         if (!element) return false;
         if (auto tc = element.try_as<winrt::GhosttyWin32::TerminalControl>()) {
             return tc.Focus(Microsoft::UI::Xaml::FocusState::Programmatic);
@@ -171,13 +185,13 @@ public:
         return false;
     }
 
-    // Extracts the impl pointer for a leaf's TerminalControl, or
-    // returns nullptr if the leaf hosts something else (Phase 1
-    // scaffolding accepts any UIElement, but in practice every leaf
+    // Extracts the impl pointer for a pane's TerminalControl, or
+    // returns nullptr if the pane hosts something else (Phase 1
+    // scaffolding accepts any UIElement, but in practice every pane
     // in a real Tab is a TerminalControl). Kept public-static so
     // helpers outside Tab can walk the tree consistently.
-    static implementation::TerminalControl* LeafToTerminalControl(Pane const& leaf) noexcept {
-        auto element = leaf.Content();
+    static implementation::TerminalControl* PaneToTerminalControl(Pane const& pane) noexcept {
+        auto element = pane.content;
         if (!element) return nullptr;
         if (auto tc = element.try_as<winrt::GhosttyWin32::TerminalControl>()) {
             return winrt::get_self<implementation::TerminalControl>(tc);
@@ -186,51 +200,15 @@ public:
     }
 
 private:
-    static Pane* FindFirstLeaf(Pane* node) noexcept {
-        if (!node) return nullptr;
-        if (node->IsLeaf()) return node;
-        if (auto* p = FindFirstLeaf(node->First())) return p;
-        return FindFirstLeaf(node->Second());
-    }
-
-    // Walk the tree and apply the per-tab dim invariant: the leaf
-    // whose Pane* matches `active` gets its UnfocusedDim Collapsed
-    // (bright); every other leaf's gets Visible (dim). Static because
-    // it doesn't touch this instance's mutable state beyond the
-    // leaves it visits.
-    static void ApplyDimRecursive(Pane* node, Pane const* active) {
-        if (!node) return;
-        if (node->IsLeaf()) {
-            if (auto* tc = LeafToTerminalControl(*node)) {
-                tc->ApplyFocusVisual(node == active);
-            }
-            return;
-        }
-        ApplyDimRecursive(node->First(), active);
-        ApplyDimRecursive(node->Second(), active);
-    }
-
-    static void DetachAllLeaves(Pane* node) {
-        if (!node) return;
-        if (node->IsLeaf()) {
-            if (auto* tc = LeafToTerminalControl(*node)) {
-                tc->Detach();
-            }
-            return;
-        }
-        DetachAllLeaves(node->First());
-        DetachAllLeaves(node->Second());
-    }
-
-    // SplitPanel owns the Pane tree (via its own m_root). The host
-    // parents it under AppContent — Tab just borrows it via Panel()
-    // for tree walks and Detach plumbing.
+    // SplitPanel owns the pane tree. The host parents it under
+    // AppContent — Tab just borrows it via Panel() for tree walks and
+    // Detach plumbing.
     winrt::GhosttyWin32::SplitPanel m_panel{ nullptr };
     Microsoft::UI::Xaml::Controls::TabViewItem m_item{ nullptr };
     // Borrowed pointer into the SplitPanel's tree — never owning.
-    // Reset to nullptr or another leaf on tree mutations before any
-    // leaf is destroyed.
-    Pane* m_activeLeaf{ nullptr };
+    // Reset to nullptr or another pane on tree mutations before any
+    // pane is destroyed.
+    Pane* m_activePane{ nullptr };
 
     // See HasExplicitTitle. Sticky: once the shell sets a title the
     // poll leaves it alone for the rest of the tab's life.

--- a/App/Tabs/Tab.h
+++ b/App/Tabs/Tab.h
@@ -47,7 +47,7 @@ public:
         }
         auto* panelImpl = winrt::get_self<implementation::SplitPanel>(m_panel);
         if (!panelImpl || !panelImpl->Tree().HasRoot()) {
-            throw winrt::hresult_error(E_INVALIDARG, L"Tab: SplitPanel has no tree");
+            throw winrt::hresult_error(E_INVALIDARG, L"Tab: SplitPanel has no root");
         }
         // Initial active pane is the first pane found in depth-first
         // order — SetActivePane keeps the per-tab dim invariant

--- a/App/Tabs/Tab.h
+++ b/App/Tabs/Tab.h
@@ -12,23 +12,24 @@ namespace winrt::GhosttyWin32::implementation {
 // One tab in the window's TabView.
 //
 // Each Tab references:
-//   * A SplitPanel (`m_panel`) that owns the pane tree describing how
-//     this tab's content is partitioned across one or more terminal
-//     panes. The host (MainWindow) parents the panel under AppContent
-//     alongside every other tab's panel; selection drives per-panel
-//     Visibility, which is why TabViewItem.Content stays unset. The
-//     panel keeps its Children() collection in sync with the tree's
-//     pane set so framework input routing, hit-testing, and measure /
-//     arrange work end-to-end.
-//   * A pointer to the currently active pane (`m_activePane`). All
+//   * A SplitPanel (`m_panel`) that owns the Tree of Branches
+//     describing how this tab's content is partitioned across one or
+//     more Panes (single terminals). The host (MainWindow) parents
+//     the panel under AppContent alongside every other tab's panel;
+//     selection drives per-panel Visibility, which is why
+//     TabViewItem.Content stays unset. The panel keeps its
+//     Children() collection in sync with the tree's Pane set so
+//     framework input routing, hit-testing, and measure / arrange
+//     work end-to-end.
+//   * A pointer to the currently active Pane (`m_activePane`). All
 //     "focused terminal" operations (key events, IME, clipboard,
-//     action targets) flow through this. On tree mutations (future
-//     NEW_SPLIT / CLOSE_PANE) `m_activePane` must be reset before any
-//     pane it points at is destroyed.
+//     action targets) flow through this. On tree mutations (NEW_SPLIT
+//     / CLOSE_PANE) `m_activePane` must be reset before any Pane it
+//     points at is destroyed.
 //
-// The tree itself lives inside the SplitPanel — Tab borrows it via
-// `panel.Tree()` for pane walks and reaches into individual panes for
-// TerminalControl bridge calls.
+// The tree lives inside the SplitPanel — Tab borrows it via
+// `panel.Tree()` for Pane walks and reaches into individual Panes
+// for TerminalControl bridge calls.
 //
 // Construction is just validation + member init — failable setup
 // (creating the surface handle, attaching it, calling

--- a/App/Tabs/Tab.h
+++ b/App/Tabs/Tab.h
@@ -142,8 +142,8 @@ public:
     // path — the dim state is a property of which pane the tab thinks
     // is active, not of XAML keyboard focus, so tab switches and
     // alt-tabs don't disturb it. Pointer clicks and keybind navigation
-    // come in through here too; the corresponding TerminalControl
-    // GotFocus / LostFocus hooks no longer touch the overlay.
+    // funnel through here too; the overlay stays untouched by
+    // TerminalControl's GotFocus / LostFocus hooks.
     void SetActivePane(Pane* pane) {
         m_activePane = pane;
         if (auto* panelImpl = winrt::get_self<implementation::SplitPanel>(m_panel)) {

--- a/App/Tabs/Tab.h
+++ b/App/Tabs/Tab.h
@@ -46,7 +46,7 @@ public:
             throw winrt::hresult_error(E_INVALIDARG, L"Tab: missing resource");
         }
         auto* panelImpl = winrt::get_self<implementation::SplitPanel>(m_panel);
-        if (!panelImpl || panelImpl->Tree().Empty()) {
+        if (!panelImpl || !panelImpl->Tree().HasRoot()) {
             throw winrt::hresult_error(E_INVALIDARG, L"Tab: SplitPanel has no tree");
         }
         // Initial active pane is the first pane found in depth-first

--- a/App/Tabs/TabFactory.h
+++ b/App/Tabs/TabFactory.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "Ghostty/Config.h"
-#include "Tabs/Panes/Pane.h"
+#include "Tabs/Panes/Branch.h"
 #include "Tabs/Panes/PaneId.h"
 #include "Tabs/Panes/PaneIdAllocator.h"
 #include "SplitPanel.h"
@@ -82,10 +82,10 @@ public:
         uint32_t initialWidth = 0,
         uint32_t initialHeight = 0)
     {
-        auto leaf = MakeLeaf(initialWidth, initialHeight, std::move(onActivated));
-        if (!leaf) return nullptr;
+        auto branch = MakePane(initialWidth, initialHeight, std::move(onActivated));
+        if (!branch) return nullptr;
 
-        // Wrap the leaf in a SplitPanel. With one leaf the panel
+        // Wrap the pane in a SplitPanel. With one pane the panel
         // collapses to "arrange the single child at the full rect".
         // The host parents the returned panel under AppContent — the
         // factory deliberately doesn't, so it stays unaware of the
@@ -94,36 +94,37 @@ public:
         auto* splitPanelImpl = winrt::get_self<implementation::SplitPanel>(splitPanel);
         if (!splitPanelImpl) {
             OutputDebugStringA("TabFactory::Make: get_self<SplitPanel> FAILED\n");
-            DetachLeaf(*leaf);
+            DetachSubtree(*branch);
             return nullptr;
         }
         // Apply the divider colour before any tree exists so the
         // first splitter Border built by SetRoot already paints
         // with the correct brush.
         splitPanelImpl->SetDividerColor(m_dividerColor);
-        splitPanelImpl->SetRoot(std::move(leaf));
+        splitPanelImpl->SetRoot(std::move(branch));
 
         try {
             return std::make_unique<Tab>(std::move(splitPanel), std::move(item));
         } catch (winrt::hresult_error const&) {
             // Tab construction validation failed. Detach synchronously
-            // so the surface/handle don't leak. The splitPanel /
-            // tree own the leaf at this point.
-            if (auto* root = splitPanelImpl->Root()) DetachLeaf(*root);
+            // so the surface/handle don't leak. The splitPanel / tree
+            // own the pane at this point.
+            if (auto* root = splitPanelImpl->Tree().Root()) DetachSubtree(*root);
             return nullptr;
         }
     }
 
     // Build a new pane: TerminalControl + DComp surface handle +
-    // ghostty surface + freshly-allocated PaneId, returned as a Pane
-    // leaf. Shared between Make() (the leaf becomes the only pane in
-    // a brand-new tab) and the NEW_SPLIT action handler (the leaf is
-    // inserted into an existing tab's tree alongside its source pane).
+    // ghostty surface + freshly-allocated PaneId, wrapped in a
+    // Branch (Pane variant). Shared between Make() (the branch
+    // becomes the only pane in a brand-new tab) and the NEW_SPLIT
+    // action handler (the branch is inserted into an existing tab's
+    // tree alongside its source pane).
     //
     // Returns nullptr on any failure. Resources acquired before the
     // failure point are released before the return — caller doesn't
     // need to clean up after a null result.
-    std::unique_ptr<Pane> MakeLeaf(
+    std::unique_ptr<Branch> MakePane(
         uint32_t initialWidth,
         uint32_t initialHeight,
         std::function<void()> onActivated = {})
@@ -133,12 +134,12 @@ public:
         auto control = winrt::GhosttyWin32::TerminalControl();
         auto* controlImpl = winrt::get_self<implementation::TerminalControl>(control);
         if (!controlImpl) {
-            OutputDebugStringA("TabFactory::MakeLeaf: get_self<TerminalControl> FAILED\n");
+            OutputDebugStringA("TabFactory::MakePane: get_self<TerminalControl> FAILED\n");
             return nullptr;
         }
         auto panel = controlImpl->InnerPanel();
         if (!panel) {
-            OutputDebugStringA("TabFactory::MakeLeaf: TerminalControl has no inner panel\n");
+            OutputDebugStringA("TabFactory::MakePane: TerminalControl has no inner panel\n");
             return nullptr;
         }
 
@@ -152,7 +153,7 @@ public:
 
         HANDLE handle = nullptr;
         if (FAILED(DCompositionCreateSurfaceHandle(COMPOSITIONSURFACE_ALL_ACCESS, nullptr, &handle))) {
-            OutputDebugStringA("TabFactory::MakeLeaf: DCompositionCreateSurfaceHandle FAILED\n");
+            OutputDebugStringA("TabFactory::MakePane: DCompositionCreateSurfaceHandle FAILED\n");
             return nullptr;
         }
 
@@ -233,7 +234,7 @@ public:
 
         ghostty_surface_t surface = ghostty_surface_new(m_app, &cfg);
         if (!surface) {
-            OutputDebugStringA("TabFactory::MakeLeaf: ghostty_surface_new FAILED\n");
+            OutputDebugStringA("TabFactory::MakePane: ghostty_surface_new FAILED\n");
             // Callback won't fire — release the renderer's owning handle.
             delete attachOwned;
             CloseHandle(handle);
@@ -260,24 +261,21 @@ public:
             1.0 - m_cfg.UnfocusedSplitOpacity(),
             m_cfg.UnfocusedSplitFill());
 
-        return Pane::MakeLeaf(control, paneId);
+        return MakePaneBranch(control, paneId);
     }
 
 private:
-    // Synchronously detach every TerminalControl under `node` so the
-    // surface / DComp handle don't leak when an error path discards a
-    // partially-constructed tree. Mirrors Tab::DetachAllLeaves but is
-    // factored locally so the error paths above can call it without
-    // depending on Tab.
-    static void DetachLeaf(Pane const& node) {
-        if (node.IsLeaf()) {
-            if (auto* tc = Tab::LeafToTerminalControl(node)) {
+    // Synchronously detach every TerminalControl under `branch` so
+    // the surface / DComp handle don't leak when an error path
+    // discards a partially-constructed subtree. Mirrors Tab::DetachAll
+    // but is factored locally so the error paths above can call it
+    // without depending on Tab.
+    static void DetachSubtree(Branch& branch) {
+        branch.ForEachPane([](Pane& p) {
+            if (auto* tc = Tab::PaneToTerminalControl(p)) {
                 tc->Detach();
             }
-            return;
-        }
-        if (auto* f = node.First()) DetachLeaf(*f);
-        if (auto* s = node.Second()) DetachLeaf(*s);
+        });
     }
 
     ghostty_app_t m_app;

--- a/App/Tabs/Tabs.h
+++ b/App/Tabs/Tabs.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "Tabs/Panes/Pane.h"
+#include "Tabs/Panes/Tree.h"
 #include "SplitPanel.h"
 #include "Tabs/Tab.h"
 #include "ghostty.h"
@@ -39,25 +39,23 @@ public:
     }
 
     // Resolve a ghostty_surface_t back to the owning Tab by walking
-    // each tab's Pane tree. ActiveControl alone would miss surfaces in
-    // non-active leaves once splits exist; the tree walk is correct
-    // for both the single-leaf case (today) and any future split
-    // configuration. O(N * leaves) — both factors are small enough
-    // that a flat scan is strictly cheaper than maintaining an index.
+    // each tab's pane tree. ActiveControl alone would miss surfaces in
+    // non-active panes once splits exist; the tree walk is correct for
+    // both the single-pane case and any split configuration.
     Tab* FindBySurface(ghostty_surface_t surface) const {
-        return FindLeafBySurface(surface).tab;
+        return FindPaneBySurface(surface).tab;
     }
 
-    // Look up the Tab + leaf for the pane carrying `id`. Used by the
-    // close_surface_cb callback path: ghostty hands us back the ID we
-    // placed in cfg.userdata, and the dispatched lambda calls this on
-    // the UI thread. Returns { nullptr, nullptr } if the user already
-    // closed the surface via the UI before the dispatched close
-    // arrived (or if the ID is otherwise unknown), making stale
-    // callbacks a safe no-op.
+    // Look up the Tab + pane carrying `id`. Used by the close_surface_cb
+    // callback path: ghostty hands us back the ID we placed in
+    // cfg.userdata, and the dispatched lambda calls this on the UI
+    // thread. Returns { nullptr, nullptr } if the user already closed
+    // the surface via the UI before the dispatched close arrived (or
+    // if the ID is otherwise unknown), making stale callbacks a safe
+    // no-op.
     struct PaneLookup {
         Tab* tab;
-        Pane* leaf;
+        Pane* pane;
     };
     PaneLookup FindByPaneId(PaneId id) const {
         if (!id) return { nullptr, nullptr };
@@ -65,26 +63,29 @@ public:
             if (!t) continue;
             auto* panelImpl = winrt::get_self<implementation::SplitPanel>(t->Panel());
             if (!panelImpl) continue;
-            if (auto* leaf = FindLeafByPaneId(panelImpl->Root(), id)) {
-                return { t.get(), leaf };
+            if (auto* pane = panelImpl->Tree().FindPane(
+                    [id](Pane const& p) { return p.id == id; })) {
+                return { t.get(), pane };
             }
         }
         return { nullptr, nullptr };
     }
 
-    // Surface-driven leaf lookup. Mirrors FindBySurface but returns the
-    // specific leaf in addition to the owning Tab, so callers that need
-    // both (e.g. desktop notification routing — find the pane that
-    // emitted the toast and embed its PaneId in the click argument)
-    // don't repeat the tree walk.
-    PaneLookup FindLeafBySurface(ghostty_surface_t surface) const {
+    // Surface-driven pane lookup. Mirrors FindBySurface but returns the
+    // specific pane in addition to the owning Tab, so callers that need
+    // both (e.g. desktop notification routing) don't repeat the walk.
+    PaneLookup FindPaneBySurface(ghostty_surface_t surface) const {
         if (!surface) return { nullptr, nullptr };
         for (auto& t : m_tabs) {
             if (!t) continue;
             auto* panelImpl = winrt::get_self<implementation::SplitPanel>(t->Panel());
             if (!panelImpl) continue;
-            if (auto* leaf = FindLeafBySurfaceRecursive(panelImpl->Root(), surface)) {
-                return { t.get(), leaf };
+            if (auto* pane = panelImpl->Tree().FindPane(
+                    [surface](Pane const& p) {
+                        auto const* tc = Tab::PaneToTerminalControl(p);
+                        return tc && tc->Surface().Owns(surface);
+                    })) {
+                return { t.get(), pane };
             }
         }
         return { nullptr, nullptr };
@@ -144,35 +145,6 @@ public:
     auto end() const noexcept { return m_tabs.end(); }
 
 private:
-    // Depth-first search for the leaf whose TerminalControl owns
-    // `surface`. Returns the leaf node (mutable so callers updating
-    // the active-leaf pointer can do so) or nullptr. Used by both
-    // FindBySurface (which only cares whether the leaf exists) and
-    // FindLeafBySurface (which needs the leaf itself).
-    static Pane* FindLeafBySurfaceRecursive(Pane* node, ghostty_surface_t surface) {
-        if (!node) return nullptr;
-        if (node->IsLeaf()) {
-            if (auto* c = Tab::LeafToTerminalControl(*node); c && c->Surface().Owns(surface)) {
-                return node;
-            }
-            return nullptr;
-        }
-        if (auto* p = FindLeafBySurfaceRecursive(node->First(), surface)) return p;
-        return FindLeafBySurfaceRecursive(node->Second(), surface);
-    }
-
-    // Depth-first search for a leaf carrying `id`. Returns the leaf
-    // node (mutable so callers can update active-leaf pointers when
-    // collapsing the tree on close) or nullptr.
-    static Pane* FindLeafByPaneId(Pane* node, PaneId id) {
-        if (!node) return nullptr;
-        if (node->IsLeaf()) {
-            return node->Id() == id ? node : nullptr;
-        }
-        if (auto* p = FindLeafByPaneId(node->First(), id)) return p;
-        return FindLeafByPaneId(node->Second(), id);
-    }
-
     std::vector<std::unique_ptr<Tab>> m_tabs;
 };
 

--- a/App/Tabs/Tabs.h
+++ b/App/Tabs/Tabs.h
@@ -63,7 +63,7 @@ public:
             if (!t) continue;
             auto* panelImpl = winrt::get_self<implementation::SplitPanel>(t->Panel());
             if (!panelImpl) continue;
-            if (auto* pane = panelImpl->Tree().FindPane(
+            if (auto* pane = panelImpl->Tree().FindPaneBy(
                     [id](Pane const& p) { return p.id == id; })) {
                 return { t.get(), pane };
             }
@@ -80,7 +80,7 @@ public:
             if (!t) continue;
             auto* panelImpl = winrt::get_self<implementation::SplitPanel>(t->Panel());
             if (!panelImpl) continue;
-            if (auto* pane = panelImpl->Tree().FindPane(
+            if (auto* pane = panelImpl->Tree().FindPaneBy(
                     [surface](Pane const& p) {
                         auto const* tc = Tab::PaneToTerminalControl(p);
                         return tc && tc->Surface().Owns(surface);

--- a/App/TerminalControl.xaml.cpp
+++ b/App/TerminalControl.xaml.cpp
@@ -84,7 +84,7 @@ namespace winrt::GhosttyWin32::implementation
             auto self = weakSelf.get();
             if (!self) return;
             if (self->m_editContext) self->m_editContext.NotifyFocusEnter();
-            // The UnfocusedDim overlay is driven by Tab.SetActiveLeaf,
+            // The UnfocusedDim overlay is driven by Tab.SetActivePane,
             // not by XAML focus events. Reason: the dim represents
             // "this leaf is the active split in its tab", which has
             // nothing to do with XAML keyboard focus. Hooking it on
@@ -93,7 +93,7 @@ namespace winrt::GhosttyWin32::implementation
             // alt-tab away), even though the active leaf hasn't
             // changed. The surface-focused notification still fires
             // here — the host's NotifySurfaceFocused routes through
-            // Tab.SetActiveLeaf, so a real focus shift (pointer
+            // Tab.SetActivePane, so a real focus shift (pointer
             // click on a non-active pane) still updates the dim by
             // going through the tab.
             //

--- a/App/TerminalControl.xaml.h
+++ b/App/TerminalControl.xaml.h
@@ -160,7 +160,7 @@ namespace winrt::GhosttyWin32::implementation
         // Surface() returns the wrapper itself so call sites can issue
         // typed operations (Refresh, Key, MouseButton, …) without
         // touching raw ghostty C API. Identity-comparison call sites
-        // (action callbacks, FindLeafBySurface) compare via
+        // (action callbacks, FindPaneBySurface) compare via
         // `tc->Surface().Handle()` against ghostty's raw handle.
         core::ghostty::Surface const& Surface() const noexcept { return m_surface; }
         core::ghostty::Surface& Surface() noexcept { return m_surface; }


### PR DESCRIPTION
Follow-up to #123 (walker naming). Rebuilds the pane data model from a Composite class that doubled as leaf + internal node into a sum type where each concept has one job.

## Why

The old `Pane` class was both:

- a single terminal (the leaf reading, matching tmux / WT / iTerm2 usage), and
- an internal split node (with First/Second/orientation/ratio)

Reading `Pane* p = ...; p->First()` as "a pane returns other panes" is unnatural — a pane in the terminal-domain sense is one terminal, not a container of terminals. That mismatch cascaded into the codebase as scattered walker helpers on Tab and Tabs (six static functions between them, each reimplementing depth-first descent because the composite Pane exposed only the raw First/Second/IsLeaf primitives).

## What

Three data types + one container, each carrying only what belongs at its layer:

- **`Pane`** — one terminal (content + PaneId). Pure leaf. Matches industry vocabulary.
- **`Split`** — internal node: direction, ratio, two child Branches.
- **`Branch`** — the recursive unit. `std::variant<Pane, Split>` wrapped in a struct so it can hold the shared per-node bits (parent back-pointer, arrangedRect) and expose Composite-style walker methods (`AnyPaneMatches`, `ForEachPane`, `FindPaneBy`, `FindBranchOfPane`).
- **`Tree`** — model layer: owns the root Branch (nullable = empty tree), the zoom state, the walker delegation, and the structural mutations (`SetRoot`, `ReplacePane`, `RemovePane`). Pure C++ — no WinUI dependency — so tree code is unit-testable in isolation.

The XAML side (`SplitPanel`) holds a `Tree` as a member and drives `MeasureOverride` / `ArrangeOverride` off it. Public API (SetRoot / ReplacePane / RemovePane) delegates to Tree and then refreshes Children + invalidates layout. Callers wanting to READ the tree go through `splitPanel->Tree().Foo(...)` and skip the XAML sync entirely.

## Naming

Domain layer (what terminal users think): **Pane**, **Split**. Established industry vocabulary.

Implementation layer (data structure): **Branch**, **Tree**. Common software metaphors for recursive containers; deliberately *not* `Node` (positional, hides essence) or `Leaf` (plant metaphor when we already have Pane for the same concept). Walker methods use `Pane` in their names (`AnyPaneMatches`, not `AnyLeafMatches`) because `Pane` is what the caller cares about.

The single sum-type wrapper is `Branch` rather than `PaneOrSplit` in the final iteration — the recursive-subtree metaphor from tree/git terminology captures "either a leaf or a further division" without spelling out the variant. The header comment records the reasoning.

## Commit structure

1. Introduce `Pane` (now leaf-only) / `Split` / `Branch` data types
2. Introduce `Tree` container
3. Migrate `SplitPanel` to `Tree`
4. Migrate `Tab` — the 4 static walkers collapse into calls into Tree methods
5. Migrate `Tabs` — 2 more static walkers collapse
6. Migrate `MainWindow` / `TabFactory` / `TerminalControl` — final call sites; tests need no touch (mocks reference method names, not Pane types)

Between commits 1 and 6 the tree isn't fully migrated so intermediate commits don't build. Final state (commit 6) compiles.

## Related

- Closes #123 (walker naming) — the Composite-shaped walkers this refactor targeted are gone.
- Sets up #126 (WindowCloseGate) to sit cleanly on top: the gate's `NeedsConfirm` predicate is a one-liner delegating to `Tab::NeedsConfirmClose()`, which is a one-liner delegating to `Tree::AnyPaneMatches` — no more scattered walker functors.

## Verification

Behaviour-preserving refactor — the visible surface (tabs, splits, drag-resize, zoom, close-confirm, keybinds) should be indistinguishable from before. Test plan:

- [x] Single tab, single pane — works as before
- [x] `Ctrl+Shift+O` / `Ctrl+Shift+E` split — new pane appears in the right slot, focus lands there
- [x] Splitter drag — ratio updates, layout reflows
- [x] `Ctrl+Shift+Alt+Arrow` resize — same as splitter drag
- [x] `Ctrl+Shift+[` / `]` cycle panes — DFS order preserved
- [x] `Ctrl+Shift+Arrow` cycle tabs — unaffected
- [x] Zoom on / off — pane fills / restores
- [x] Equalize — every ratio returns to 0.5
- [x] Close last pane in tab — tab closes
- [x] Close pane with sibling — sibling promotes into split's slot, focus lands on sibling
- [x] Confirm-close dialog still gates window close (#112 behaviour preserved)
- [x] Multi-window tab tear-out — dragged tab retains its full pane tree in the new window

<details>
<summary>日本語</summary>

## 目的

旧 `Pane` は Composite で「1つの terminal (leaf)」と「分割ノード (internal node with First/Second)」の 2役を兼ねてた。`Pane* p = ...; p->First()` を読むと「pane が pane たちを返す」ように読めるが、業界慣習の pane は 1つの terminal そのものであってコンテナじゃない。この意味不一致が Tab / Tabs 側に 6個の static walker として蓄積してた (Composite の First/Second/IsLeaf しか露出してなかったので、DFS 再帰を毎回書き直してた)。

## 変更

sum type + container の 4 型構成に組み替え:

- **`Pane`** — 1 terminal (content + PaneId)。leaf 専用。tmux/WT/iTerm2 の業界慣習に一致
- **`Split`** — 分割ノード: direction, ratio, 2つの子 Branch
- **`Branch`** — 再帰の単位。`std::variant<Pane, Split>` を struct でラップし、parent back-pointer と arrangedRect を持つ + Composite 風の walker メソッド (`AnyPaneMatches`, `ForEachPane`, `FindPaneBy`, `FindBranchOfPane`) を露出
- **`Tree`** — model 層。root Branch (nullable = 空木) の所有、zoom 状態、walker delegation、構造 mutation (`SetRoot`, `ReplacePane`, `RemovePane`) を持つ。pure C++、WinUI 依存なし → 単体テスト可能

XAML 側の `SplitPanel` は `Tree` をメンバに持って `MeasureOverride`/`ArrangeOverride` を動かす。public API (SetRoot/ReplacePane/RemovePane) は Tree に委譲後、Children 同期+レイアウト再計算。walker 系の読み取りは `splitPanel->Tree().AnyPaneMatches(...)` で XAML 同期をスキップ。

## 命名

domain (terminal ユーザーの語彙): **Pane**, **Split** — 業界慣習
implementation (データ構造): **Branch**, **Tree** — CS 界の再帰コンテナ慣用語。**`Node`** (位置役割、essence を隠す) や **`Leaf`** (植物メタファー、Pane と競合) は避ける。walker のメソッド名も `AnyPaneMatches` (`AnyLeafMatches` じゃなく) — 呼び手が知りたい概念は Pane

sum type の名前は最終的に `Branch` に。`PaneOrSplit` の代わりに tree/git 由来の subtree metaphor で「未確定の subtree unit」を表現。

## コミット構造

1. `Pane` (leaf 化) / `Split` / `Branch` を導入
2. `Tree` コンテナを導入
3. `SplitPanel` を `Tree` 経由に
4. `Tab` を migration — 4 static walker が Tree メソッド呼び出しに折りたたむ
5. `Tabs` を migration — 2 static walker が同様に
6. `MainWindow` / `TabFactory` / `TerminalControl` を migration — 最終 call site。テストは Pane 型を直接使ってないので触らず

1〜6 の途中は tree がフル migrate されてないので intermediate commit はビルド通らない。6 の最終状態で通る。

## 関連

- **#123 (walker naming) を close** — 対象だった Composite 風 walker は消えた
- **#126 (WindowCloseGate)** の実装が綺麗に載る: gate の needsConfirm predicate は Tab::NeedsConfirmClose → Tree::AnyPaneMatches で 1行

## 検証

挙動保存の refactor — 見た目 (tabs / splits / drag-resize / zoom / close-confirm / keybinds) は refactor 前と区別できないはず。テスト項目は英語版参照。

</details>
