### PR TITLE
Route every close path through WindowCloseGate

### DIFF
--- a/App/App.vcxproj
+++ b/App/App.vcxproj
@@ -157,6 +157,7 @@
     </ClInclude>
     <ClInclude Include="MainWindows.h" />
     <ClInclude Include="SplitPanel.h" />
+    <ClInclude Include="WindowCloseGate.h" />
     <ClInclude Include="Tabs\Panes\Branch.h" />
     <ClInclude Include="Tabs\Panes\Pane.h" />
     <ClInclude Include="Tabs\Panes\PaneId.h" />
@@ -193,6 +194,7 @@
     <ClCompile Include="MainWindows.cpp" />
     <ClCompile Include="Ghostty\MainWindowRuntime.cpp" />
     <ClCompile Include="SplitPanel.cpp" />
+    <ClCompile Include="WindowCloseGate.cpp" />
     <ClCompile Include="TerminalControl.xaml.cpp">
       <DependentUpon>TerminalControl.xaml</DependentUpon>
     </ClCompile>

--- a/App/MainWindow.xaml.cpp
+++ b/App/MainWindow.xaml.cpp
@@ -636,6 +636,7 @@ namespace winrt::GhosttyWin32::implementation
             // themes with light/dark variants pick the right one at
             // launch without waiting for the first user toggle.
             HookSystemThemeSignal();
+            HookCloseGate();
             PushCurrentSystemColorScheme();
             // Tear-out hosts don't create an initial tab: they adopt
             // the dragged one (possibly before this handler even ran).
@@ -696,6 +697,7 @@ namespace winrt::GhosttyWin32::implementation
         // SizeLimit's (which uses id=1) so both subclasses coexist
         // on the same HWND without either replacing the other.
         constexpr UINT_PTR kSystemThemeSubclassId = 2;
+        constexpr UINT_PTR kCloseGateSubclassId   = 3;
 
         // Read HKCU\...\Themes\Personalize\AppsUseLightTheme. Missing
         // key or read failure defaults to DARK — the terminal's
@@ -733,6 +735,28 @@ namespace winrt::GhosttyWin32::implementation
             }
             return DefSubclassProc(hwnd, msg, wp, lp);
         }
+
+        // Alt+F4 and any other OS-issued WM_CLOSE bypass WinUI's
+        // event routing. Without an intercept the default handler
+        // destroys the window synchronously — no confirmation, and
+        // Actions callbacks queued on the dispatcher blow up on a
+        // dangling m_view (see issue #126). This subclass turns
+        // every WM_CLOSE into a gate submission; the gate's
+        // approval path sets m_bypassCloseGate so the follow-up
+        // Close() gets through this proc unimpeded.
+        LRESULT CALLBACK CloseGateSubclassProc(
+            HWND hwnd, UINT msg, WPARAM wp, LPARAM lp,
+            UINT_PTR /*id*/, DWORD_PTR ref) noexcept
+        {
+            if (msg == WM_CLOSE) {
+                auto* self = reinterpret_cast<MainWindow*>(ref);
+                if (self && !self->m_bypassCloseGate) {
+                    try { self->TryClose(); } catch (winrt::hresult_error const&) {}
+                    return 0;
+                }
+            }
+            return DefSubclassProc(hwnd, msg, wp, lp);
+        }
     }
 
     void MainWindow::HookSystemThemeSignal() noexcept
@@ -740,6 +764,14 @@ namespace winrt::GhosttyWin32::implementation
         if (!m_hwnd) return;
         SetWindowSubclass(m_hwnd, &SystemThemeSubclassProc,
                           kSystemThemeSubclassId,
+                          reinterpret_cast<DWORD_PTR>(this));
+    }
+
+    void MainWindow::HookCloseGate() noexcept
+    {
+        if (!m_hwnd) return;
+        SetWindowSubclass(m_hwnd, &CloseGateSubclassProc,
+                          kCloseGateSubclassId,
                           reinterpret_cast<DWORD_PTR>(this));
     }
 
@@ -940,6 +972,13 @@ namespace winrt::GhosttyWin32::implementation
 
     void MainWindow::RequestClose()
     {
+        // Every RequestClose is a committed close — the confirmation
+        // (if any) already happened upstream. Setting the bypass here
+        // means the CloseGate subclass won't re-prompt on whatever
+        // WM_CLOSE the framework emits during Close(), and covers
+        // paths that call RequestClose without going through TryClose
+        // (last-tab-close, tear-out empty shell, driver-error exit).
+        m_bypassCloseGate = true;
         // WinUI's Window::Close throws when the window has already
         // begun tearing down; swallow so callers can fire and
         // forget. The hresult_error variant is the only one that
@@ -966,7 +1005,9 @@ namespace winrt::GhosttyWin32::implementation
                 return false;
             },
             // Weak ref because the dialog can outlive the C++ object
-            // if teardown starts while it's still up.
+            // if teardown starts while it's still up. RequestClose
+            // itself flips the bypass, so any WM_CLOSE the framework
+            // re-emits during Close() sails past the subclass.
             [weak]() {
                 if (auto self = weak.get()) self->RequestClose();
             });

--- a/App/MainWindow.xaml.cpp
+++ b/App/MainWindow.xaml.cpp
@@ -2154,6 +2154,27 @@ namespace winrt::GhosttyWin32::implementation
     {
         auto lookup = m_tabs.FindByPaneId(id);
         if (!lookup.tab || !lookup.pane) return;
+        auto* tc = Tab::PaneToTerminalControl(*lookup.pane);
+        auto content = Content();
+        auto xamlRoot = content ? content.XamlRoot() : nullptr;
+        auto weak = get_weak();
+        m_closeGate.Submit(
+            WindowCloseGate::Scope::Surface,
+            std::move(xamlRoot),
+            // Surface-level predicate: ask this pane alone. When the
+            // shell exits naturally ghostty returns false, so
+            // spontaneous close_surface_cb fires (child exit) sail
+            // through without a dialog.
+            [tc]() { return tc && tc->Surface().NeedsConfirmQuit(); },
+            [weak, id]() {
+                if (auto self = weak.get()) self->RemovePaneByIdApproved(id);
+            });
+    }
+
+    void MainWindow::RemovePaneByIdApproved(PaneId id)
+    {
+        auto lookup = m_tabs.FindByPaneId(id);
+        if (!lookup.tab || !lookup.pane) return;
         auto* tab = lookup.tab;
         auto* pane = lookup.pane;
 

--- a/App/MainWindow.xaml.cpp
+++ b/App/MainWindow.xaml.cpp
@@ -750,7 +750,7 @@ namespace winrt::GhosttyWin32::implementation
         {
             if (msg == WM_CLOSE) {
                 auto* self = reinterpret_cast<MainWindow*>(ref);
-                if (self && !self->m_bypassCloseGate) {
+                if (self && !self->IsCloseGateBypassed()) {
                     try { self->TryClose(); } catch (winrt::hresult_error const&) {}
                     return 0;
                 }

--- a/App/MainWindow.xaml.cpp
+++ b/App/MainWindow.xaml.cpp
@@ -985,50 +985,26 @@ namespace winrt::GhosttyWin32::implementation
 
     void MainWindow::TryClose()
     {
-        // Ask each Tab whether any of its panes need confirmation.
-        // Tab::NeedsConfirmClose owns the pane-tree walk (Tab owns
-        // the tree, so the query belongs there); the surface-level
-        // ghostty_surface_needs_confirm_quit already factors in the
-        // `confirm-close-surface` config, so users who set it false
-        // sail through without a dialog on every close.
-        bool anyNeedsConfirm = false;
-        for (auto& tab : m_tabs) {
-            if (tab && tab->NeedsConfirmClose()) { anyNeedsConfirm = true; break; }
-        }
-
-        if (!anyNeedsConfirm) {
-            RequestClose();
-            return;
-        }
-
-        // XamlRoot is required for a ContentDialog to know which
-        // Window / island to overlay. Fall back to a plain close
-        // if the tree isn't realised yet (shouldn't happen — a
-        // close reaching TryClose means the window has been shown).
         auto content = Content();
         auto xamlRoot = content ? content.XamlRoot() : nullptr;
-        if (!xamlRoot) {
-            RequestClose();
-            return;
-        }
-
-        muxc::ContentDialog dlg;
-        dlg.XamlRoot(xamlRoot);
-        dlg.Title(winrt::box_value(winrt::hstring{ L"Close window?" }));
-        dlg.Content(winrt::box_value(winrt::hstring{
-            L"One or more terminals in this window still have running "
-            L"processes. They will be terminated." }));
-        dlg.PrimaryButtonText(L"Close");
-        dlg.CloseButtonText(L"Cancel");
-        dlg.DefaultButton(muxc::ContentDialogButton::Close);
-
-        auto op = dlg.ShowAsync();
         auto weak = get_weak();
-        op.Completed([weak](auto&& sender, auto&& status) {
-            if (status != winrt::Windows::Foundation::AsyncStatus::Completed) return;
-            if (sender.GetResults() != muxc::ContentDialogResult::Primary) return;
-            if (auto self = weak.get()) self->RequestClose();
-        });
+        m_closeGate.Submit(
+            WindowCloseGate::Scope::Window,
+            std::move(xamlRoot),
+            // Any pane in any tab reporting needs_confirm_quit means
+            // we should prompt. Tab owns its own tree walk so the
+            // window-level query is a linear scan over tabs.
+            [this]() {
+                for (auto& tab : m_tabs) {
+                    if (tab && tab->NeedsConfirmClose()) return true;
+                }
+                return false;
+            },
+            // Weak ref because the dialog can outlive the C++ object
+            // if teardown starts while it's still up.
+            [weak]() {
+                if (auto self = weak.get()) self->RequestClose();
+            });
     }
 
     void MainWindow::InitGhostty()

--- a/App/MainWindow.xaml.cpp
+++ b/App/MainWindow.xaml.cpp
@@ -557,55 +557,20 @@ namespace winrt::GhosttyWin32::implementation
                 walk(tv);
             });
 
-            tv.TabCloseRequested([this](muxc::TabView const& sender, muxc::TabViewTabCloseRequestedEventArgs const& args) {
+            tv.TabCloseRequested([this](muxc::TabView const&, muxc::TabViewTabCloseRequestedEventArgs const& args) {
                 auto item = args.Tab();
-                // Detach the control BEFORE removing it from TabView.
-                // Detach calls ISwapChainPanelNative2::SetSwapChainHandle(nullptr)
-                // on the inner panel, and that call AVs at +0x1F8 inside
-                // microsoft.ui.xaml.dll if the panel has already been
-                // unparented from the live visual tree (reproducer:
-                // Ctrl+Shift+W long-press across multiple tabs, where
-                // XAML hasn't finished processing the previous RemoveAt
-                // when the next Detach kicks in). Doing it pre-RemoveAt
-                // keeps the panel in the live tree for the duration of
-                // SetSwapChainHandle. Detach is idempotent, so the
-                // ~Tab → ~TerminalControl path runs it again as a no-op.
-                if (auto* t = m_tabs.FindByItem(item)) {
-                    // Detach every pane in the tab, not just the active
-                    // one — multi-pane tabs have multiple swap chains
-                    // and each needs SetSwapChainHandle(nullptr) before
-                    // the panel is unparented.
-                    t->DetachAll();
-                }
-                uint32_t idx = 0;
-                if (sender.TabItems().IndexOf(item, idx)) {
-                    sender.TabItems().RemoveAt(idx);
-                }
-                DwmFlush();              // wait for compositor to release
-                if (sender.TabItems().Size() == 0) {
-                    // Last tab: defer Tab object destruction to
-                    // ~MainWindow's m_tabs.Clear. Tearing down the
-                    // focused control synchronously here leaves XAML's
-                    // focus subsystem holding a stale pointer that AVs
-                    // at +0x1F8 once mw->Close() kicks off window
-                    // teardown — same path as a normal title-bar X
-                    // close, which works fine precisely because XAML
-                    // finishes its own focus cleanup before our
-                    // destructors run. The orphan SplitPanel under
-                    // AppContent comes down with the window, no
-                    // explicit Remove needed.
-                    this->Close();
-                } else {
-                    // Unparent the panel from AppContent before
-                    // destroying the Tab. ~Tab doesn't touch the
-                    // visual tree (Tab doesn't know about AppContent),
-                    // so without this the panel would leak as an
-                    // orphan child of AppContent.
-                    if (auto* t = m_tabs.FindByItem(item)) {
-                        RemoveTabPanelFromAppContent(*t);
-                    }
-                    m_tabs.Remove(item);
-                }
+                auto* t = m_tabs.FindByItem(item);
+                if (!t) return;
+                auto content = Content();
+                auto xamlRoot = content ? content.XamlRoot() : nullptr;
+                auto weak = get_weak();
+                m_closeGate.Submit(
+                    WindowCloseGate::Scope::Tab,
+                    std::move(xamlRoot),
+                    [t]() { return t->NeedsConfirmClose(); },
+                    [weak, item]() {
+                        if (auto self = weak.get()) self->CloseTabByItem(item);
+                    });
             });
 
             // Whenever the selected tab changes — explicit click on a
@@ -1230,15 +1195,30 @@ namespace winrt::GhosttyWin32::implementation
 
     void MainWindow::CloseTabBySurface(ghostty_surface_t surface)
     {
-        // Mirror the TabCloseRequested handler — see there for why
-        // Detach runs before RemoveAt and why the last tab's Tab
-        // destruction is deferred to ~MainWindow.
         auto* t = m_tabs.FindBySurface(surface);
         if (!t) return;
         auto item = t->Item();
-        // CLOSE_TAB closes the whole tab regardless of pane count —
-        // detach every leaf so each swap chain handle is cleared
-        // before unparent.
+        auto content = Content();
+        auto xamlRoot = content ? content.XamlRoot() : nullptr;
+        auto weak = get_weak();
+        m_closeGate.Submit(
+            WindowCloseGate::Scope::Tab,
+            std::move(xamlRoot),
+            [t]() { return t->NeedsConfirmClose(); },
+            [weak, item]() {
+                if (auto self = weak.get()) self->CloseTabByItem(item);
+            });
+    }
+
+    void MainWindow::CloseTabByItem(muxc::TabViewItem const& item)
+    {
+        auto* t = m_tabs.FindByItem(item);
+        if (!t) return;
+        // Detach every pane before RemoveAt: SetSwapChainHandle(nullptr)
+        // AVs at +0x1F8 inside microsoft.ui.xaml.dll if the panel has
+        // already been unparented. Multi-pane tabs have multiple swap
+        // chains and each one needs clearing before the panel comes
+        // out of the live visual tree.
         t->DetachAll();
         auto tv = TabView();
         uint32_t idx = 0;
@@ -1247,11 +1227,14 @@ namespace winrt::GhosttyWin32::implementation
         }
         DwmFlush();
         if (tv.TabItems().Size() == 0) {
+            // Defer Tab destruction to ~MainWindow's m_tabs.Clear:
+            // tearing down the focused control synchronously here
+            // leaves XAML's focus subsystem holding a stale pointer
+            // that AVs at +0x1F8 once the window teardown starts.
             RequestClose();
         } else {
-            // Mirror the TabCloseRequested handler: unparent the
-            // SplitPanel from AppContent before destroying the Tab so
-            // it doesn't leak as an orphan child.
+            // ~Tab doesn't know about AppContent — unparent here or
+            // the panel leaks as an orphan child.
             RemoveTabPanelFromAppContent(*t);
             m_tabs.Remove(item);
         }

--- a/App/MainWindow.xaml.h
+++ b/App/MainWindow.xaml.h
@@ -207,10 +207,13 @@ namespace winrt::GhosttyWin32::implementation
         // close) and routes it through the confirmation gate. See
         // CloseGateSubclassProc.
         void HookCloseGate() noexcept;
+
+    public:
         // Read by CloseGateSubclassProc (free function in the .cpp)
         // so the subclass can honour the bypass without needing a
-        // friend declaration for a namespace-scoped function.
+        // friend declaration for an anonymous-namespace function.
         bool IsCloseGateBypassed() const noexcept { return m_bypassCloseGate; }
+    private:
 
         // Publish a single drag rectangle to AppWindowTitleBar covering
         // the DragRegion's current bounds. Called from

--- a/App/MainWindow.xaml.h
+++ b/App/MainWindow.xaml.h
@@ -100,6 +100,11 @@ namespace winrt::GhosttyWin32::implementation
         // dispatcher reaches them through the interface.
         void CreateTab() override;
         void CloseTabBySurface(ghostty_surface_t surface) override;
+        // Shared tab-teardown primitive used by every close path (tab
+        // X, close_tab keybind, gate-approved close). Assumes the
+        // caller already ran confirmation; keeps the tricky detach /
+        // unparent / RemoveAt ordering in one place.
+        void CloseTabByItem(winrt::Microsoft::UI::Xaml::Controls::TabViewItem const& item);
         void GoToTab(int requested) override;
         void SetTabTitleForSurface(ghostty_surface_t surface,
                                    std::wstring title) override;

--- a/App/MainWindow.xaml.h
+++ b/App/MainWindow.xaml.h
@@ -207,6 +207,10 @@ namespace winrt::GhosttyWin32::implementation
         // close) and routes it through the confirmation gate. See
         // CloseGateSubclassProc.
         void HookCloseGate() noexcept;
+        // Read by CloseGateSubclassProc (free function in the .cpp)
+        // so the subclass can honour the bypass without needing a
+        // friend declaration for a namespace-scoped function.
+        bool IsCloseGateBypassed() const noexcept { return m_bypassCloseGate; }
 
         // Publish a single drag rectangle to AppWindowTitleBar covering
         // the DragRegion's current bounds. Called from

--- a/App/MainWindow.xaml.h
+++ b/App/MainWindow.xaml.h
@@ -173,6 +173,10 @@ namespace winrt::GhosttyWin32::implementation
 
 
         void InitGhostty();
+        // Post-gate teardown for CloseSurfaceByPaneId. Runs when the
+        // close gate has already asked the user (or determined the
+        // surface doesn't need confirmation).
+        void RemovePaneByIdApproved(PaneId id);
         Tab* ActiveTab();
         // Convenience wrapper around ActiveTab()->ActiveControl(). Most
         // input/IME paths only care about the focused TerminalControl,
@@ -211,6 +215,8 @@ namespace winrt::GhosttyWin32::implementation
 
         // Tear down the pane carrying `id` and update the tree / tab
         // list. Dispatched from close_surface_cb. UI thread only.
+        // Goes through the close gate — the actual mutation lives in
+        // RemovePaneByIdApproved and only runs on approval.
         void CloseSurfaceByPaneId(PaneId id);
 
         // The TerminalControl hosting the pane carrying `id`, or null

--- a/App/MainWindow.xaml.h
+++ b/App/MainWindow.xaml.h
@@ -14,6 +14,7 @@
 #include "Tabs/Tab.h"
 #include "Tabs/TabFactory.h"
 #include "Tabs/Tabs.h"
+#include "WindowCloseGate.h"
 
 namespace winrt::GhosttyWin32::implementation
 {
@@ -310,6 +311,10 @@ namespace winrt::GhosttyWin32::implementation
         ghostty::actions::tags::Fullscreen         m_fullscreen;
         ghostty::actions::tags::WindowDecorations  m_windowDecorations;
         Tabs m_tabs;
+        // Guards every close intent (window / tab / surface) so
+        // needs_confirm_quit prompts land once, not one dialog per
+        // path. Constructed inline so it's usable from the ctor.
+        WindowCloseGate m_closeGate;
         // Focus-tracked active surface. Set by NotifySurfaceFocused
         // when a TerminalControl gains focus, cleared when the
         // matching surface is torn down through CloseSurfaceByPaneId.

--- a/App/MainWindow.xaml.h
+++ b/App/MainWindow.xaml.h
@@ -203,6 +203,10 @@ namespace winrt::GhosttyWin32::implementation
         // updated OS light/dark preference into ghostty. Called once from
         // the one-shot Activated init after m_hwnd is captured.
         void HookSystemThemeSignal() noexcept;
+        // WndProc subclass that intercepts WM_CLOSE (Alt+F4, OS-issued
+        // close) and routes it through the confirmation gate. See
+        // CloseGateSubclassProc.
+        void HookCloseGate() noexcept;
 
         // Publish a single drag rectangle to AppWindowTitleBar covering
         // the DragRegion's current bounds. Called from
@@ -326,6 +330,11 @@ namespace winrt::GhosttyWin32::implementation
         // needs_confirm_quit prompts land once, not one dialog per
         // path. Constructed inline so it's usable from the ctor.
         WindowCloseGate m_closeGate;
+        // Set to true by the gate's approval callback before it calls
+        // Window::Close(); the CloseGate WndProc subclass reads this
+        // to let the resulting WM_CLOSE (if any) through without
+        // re-prompting. One-shot — the window is about to die.
+        bool m_bypassCloseGate = false;
         // Focus-tracked active surface. Set by NotifySurfaceFocused
         // when a TerminalControl gains focus, cleared when the
         // matching surface is torn down through CloseSurfaceByPaneId.

--- a/App/WindowCloseGate.cpp
+++ b/App/WindowCloseGate.cpp
@@ -1,0 +1,86 @@
+#include "pch.h"
+#include "WindowCloseGate.h"
+
+#include <winrt/Microsoft.UI.Xaml.Controls.h>
+#include <winrt/Windows.Foundation.h>
+
+namespace muxc = winrt::Microsoft::UI::Xaml::Controls;
+
+namespace winrt::GhosttyWin32::implementation {
+
+namespace {
+
+winrt::hstring DialogTitle(WindowCloseGate::Scope scope) noexcept {
+    switch (scope) {
+        case WindowCloseGate::Scope::Surface: return L"Close terminal?";
+        case WindowCloseGate::Scope::Tab:     return L"Close tab?";
+        case WindowCloseGate::Scope::Window:  return L"Close window?";
+    }
+    return L"Close?";
+}
+
+winrt::hstring DialogBody(WindowCloseGate::Scope scope) noexcept {
+    switch (scope) {
+        case WindowCloseGate::Scope::Surface:
+            return L"This terminal still has a running process. It will be terminated.";
+        case WindowCloseGate::Scope::Tab:
+            return L"One or more terminals in this tab still have running processes. "
+                   L"They will be terminated.";
+        case WindowCloseGate::Scope::Window:
+            return L"One or more terminals in this window still have running processes. "
+                   L"They will be terminated.";
+    }
+    return L"There are still running processes. They will be terminated.";
+}
+
+}  // namespace
+
+void WindowCloseGate::Submit(Scope scope,
+                             winrt::Microsoft::UI::Xaml::XamlRoot xamlRoot,
+                             std::function<bool()> needsConfirm,
+                             std::function<void()> onApproved)
+{
+    // Overlapping submit while a dialog is already up would stack a
+    // second ContentDialog under the first — drop the newcomer.
+    if (*m_pending) return;
+
+    if (!needsConfirm || !needsConfirm()) {
+        if (onApproved) onApproved();
+        return;
+    }
+
+    // Without XamlRoot the ContentDialog has nothing to anchor to.
+    // Fall back to approving so the close path still completes
+    // (matches the pre-gate behaviour of TryClose).
+    if (!xamlRoot) {
+        if (onApproved) onApproved();
+        return;
+    }
+
+    muxc::ContentDialog dlg;
+    dlg.XamlRoot(xamlRoot);
+    dlg.Title(winrt::box_value(DialogTitle(scope)));
+    dlg.Content(winrt::box_value(DialogBody(scope)));
+    dlg.PrimaryButtonText(L"Close");
+    dlg.CloseButtonText(L"Cancel");
+    dlg.DefaultButton(muxc::ContentDialogButton::Close);
+
+    *m_pending = true;
+    auto op = dlg.ShowAsync();
+    op.Completed(
+        [pending = m_pending, approved = std::move(onApproved)]
+        (auto&& sender, auto&& status)
+    {
+        // Reset before firing so an approval callback that triggers
+        // another close (e.g. last-tab-close → close window) sees
+        // IsIdle(). The pending flag lives in a shared_ptr so this
+        // lambda stays safe when the gate has already been destroyed
+        // (dialog can outlive MainWindow on abrupt teardown).
+        *pending = false;
+        if (status != winrt::Windows::Foundation::AsyncStatus::Completed) return;
+        if (sender.GetResults() != muxc::ContentDialogResult::Primary) return;
+        if (approved) approved();
+    });
+}
+
+}  // namespace winrt::GhosttyWin32::implementation

--- a/App/WindowCloseGate.h
+++ b/App/WindowCloseGate.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include <winrt/Microsoft.UI.Xaml.h>
+#include <functional>
+#include <memory>
+
+namespace winrt::GhosttyWin32::implementation {
+
+// Single point that every close intent inside one MainWindow flows
+// through. Turns the "should we prompt?" decision into a state — no
+// dialog in flight, or one dialog for one scope — so overlapping
+// close requests can't stack ContentDialogs on top of each other.
+//
+// The gate owns no ghostty state; it only holds the XamlRoot (needed
+// to anchor the dialog) and the in-flight flag. Callers pass the
+// scope-aware needs-confirm predicate and the "actually close" action
+// as callbacks — the gate never reaches into MainWindow directly, so
+// the close paths still express their own teardown ordering.
+class WindowCloseGate {
+public:
+    // What is being closed. Chooses the dialog wording and — via the
+    // caller-provided predicate — which panes get walked for
+    // needs_confirm_quit.
+    enum class Scope {
+        Surface,   // single pane (close_surface action)
+        Tab,       // one tab   (tab X, close_tab action)
+        Window,    // whole window (titlebar X, Alt+F4)
+    };
+
+    WindowCloseGate() noexcept = default;
+    WindowCloseGate(WindowCloseGate const&) = delete;
+    WindowCloseGate& operator=(WindowCloseGate const&) = delete;
+    WindowCloseGate(WindowCloseGate&&) = delete;
+    WindowCloseGate& operator=(WindowCloseGate&&) = delete;
+
+    bool IsIdle()    const noexcept { return !*m_pending; }
+    bool IsPending() const noexcept { return  *m_pending; }
+
+    // Enter the gate. On the UI thread. If `needsConfirm()` returns
+    // false the gate fires `onApproved` synchronously and stays Idle;
+    // otherwise it shows the ContentDialog, transitions to Pending,
+    // and fires `onApproved` from the dialog's Completed handler on
+    // the OK path. Requests submitted while Pending are dropped so
+    // dialogs don't stack. `xamlRoot` is the anchor for the dialog —
+    // passed per-call because MainWindow.Content().XamlRoot() only
+    // becomes available once the tree is realised, and re-reading
+    // it each time avoids caching a stale root across teardown.
+    void Submit(Scope scope,
+                winrt::Microsoft::UI::Xaml::XamlRoot xamlRoot,
+                std::function<bool()> needsConfirm,
+                std::function<void()> onApproved);
+
+private:
+    // Heap-owned so the dialog's Completed lambda can reset it via
+    // a shared_ptr copy — capturing `this` would dangle if the gate
+    // (owned by MainWindow) is destroyed while the dialog is still
+    // in flight.
+    std::shared_ptr<bool> m_pending{ std::make_shared<bool>(false) };
+};
+
+}  // namespace winrt::GhosttyWin32::implementation

--- a/Core/Ghostty/Actions/Actions.h
+++ b/Core/Ghostty/Actions/Actions.h
@@ -149,4 +149,4 @@ private:
     uint32_t m_initialHeight = 0;
 };
 
-}  // namespace core::ghostty::actions
+} // namespace core::ghostty::actions


### PR DESCRIPTION
Closes #126. Stacks on top of #128 (`refactor/pane-sum-type`).

## Why

`confirm-close-surface = true` only fired on the custom titlebar × — every other close path (tab X, `Ctrl+Shift+W`, `close_tab`, `close_window`, Alt+F4) bypassed the dialog entirely, so a busy pane could vanish without a prompt. And Alt+F4 didn't just skip confirmation, it destroyed the HWND synchronously through `DefWindowProc`, so any queued `Actions::Dispatch` lambda would try to reach `m_view` after MainWindow was gone and blow up in `nvmcorei` / `microsoft.ui.xaml`.

## What

`WindowCloseGate` — a small value class held on `MainWindow` that owns two things:

- a `pending` flag (heap-owned via `shared_ptr` so the ContentDialog's `Completed` lambda stays safe if MainWindow dies mid-dialog), and
- the scope-aware `ContentDialog` construction.

Every close path funnels into `gate.Submit(scope, xamlRoot, needsConfirm, onApproved)`:

- **Titlebar ×** → `TryClose` → gate (Window scope).
- **Tab ×** (`TabCloseRequested`) → gate (Tab scope) → `CloseTabByItem`.
- **`Ctrl+Shift+W` / `close_surface`** → gate (Surface scope) → `RemovePaneByIdApproved`.
- **`close_tab`** → gate (Tab scope) → `CloseTabByItem` (shared with tab ×).
- **`close_window`** → `TryClose` (already went here, unchanged).
- **Alt+F4 / OS `WM_CLOSE`** → new `CloseGateSubclassProc` WndProc subclass intercepts the raw message and routes it through `TryClose`. `RequestClose` sets a one-shot `m_bypassCloseGate` before calling `Window::Close()` so the framework's follow-up `WM_CLOSE` doesn't loop back through the gate.

Scope decides two things: which `needs_confirm_quit` predicate the caller supplies (per-pane / per-tab / per-window walk) and which dialog wording the gate shows.

## Commit structure

1. Introduce `WindowCloseGate` (class only, no wiring).
2. Route `MainWindow::TryClose` through the gate (behaviour-preserving — X button still gated).
3. Route tab-close paths (tab X + `close_tab`).
4. Route `close_surface`.
5. Add `CloseGateSubclassProc` for Alt+F4 / OS `WM_CLOSE`.

## Related

- Closes #126.
- Note on #126 documented the Alt+F4 crash from #128 verification; commit 5 fixes it for gated paths — when the confirmation dialog is up the user provides enough latency for pending dispatcher lambdas to drain safely. The residual **fast-teardown race** (`confirm-close-surface = false` or any gate-approved-without-prompt path → `Actions::OnMouseShape` etc. land on dangling `m_view`) is tracked separately in #131 — the fix is a stop flag inside `Actions` flipped from `RequestClose`, out of scope for this PR.

## Caveat for pwsh users

Upstream ghostty's `confirm-close-surface = true` returns `!cursorIsAtPrompt()` from `needs_confirm_quit`, and `cursorIsAtPrompt()` **always returns false when there is no shell-integration** (per `Terminal.zig`). Ghostty upstream ships shell-integration for bash/zsh/fish/nushell/elvish but **not for pwsh** — so on Windows with pwsh, `confirm-close-surface = true` fires the dialog on **every** close intent, whether or not a command is actually running.

This isn't the gate's decision — the same dialog fires on `refactor/pane-sum-type` (verified) whenever the titlebar × goes through `TryClose`. The change from this PR is only that the same "always prompt" now covers tab × / `Ctrl+Shift+W` / `Alt+F4` too, matching upstream ghostty on other apprts. For daily pwsh use, `confirm-close-surface = false` remains the right setting until upstream ships pwsh shell-integration.

## Verification

Command state doesn't need to be manipulated for the verify — on pwsh the dialog fires on every close intent regardless (see the caveat above).

- [x] `confirm-close-surface = true`:
  - [x] Titlebar × → dialog fires (Window scope wording), Close proceeds, Cancel aborts
  - [x] Tab × → dialog fires (Tab scope wording), Close proceeds, Cancel aborts
  - [x] `Ctrl+Shift+W` → dialog fires (Surface scope wording), Close proceeds, Cancel aborts
  - [x] `Alt+F4` → dialog fires (Window scope wording), Close proceeds, Cancel aborts (no crash)
- [x] `confirm-close-surface = false` → every path closes silently (Alt+F4 still hits the residual dispatcher race tracked in #131)
- [x] Close last pane in tab → tab closes cleanly (no double-prompt from the last-tab-close → RequestClose path)
- [x] Close last tab in window → window closes cleanly
- [x] Rapid Alt+F4 while dialog is up → second submit is dropped (no stacked dialogs)

<details>
<summary>日本語</summary>

## 目的

`confirm-close-surface = true` の確認ダイアログが custom titlebar × でしか出てなかった。tab X / `Ctrl+Shift+W` / `close_tab` / `close_window` / Alt+F4 は全部 bypass。Alt+F4 に至っては HWND を default WndProc で即破棄していたので、`Actions::Dispatch` のキュー残りが `m_view` dangling で AV する race まで抱えてた。

## 変更

`WindowCloseGate` を導入。MainWindow が 1 個所有し、全 close 経路がここに集約:

- `pending` flag (dialog の Completed lambda が gate 破棄後に触っても safe なように `shared_ptr` で heap 上に持つ)
- scope-aware な ContentDialog 構築

全ての close 呼び出しが `gate.Submit(scope, xamlRoot, needsConfirm, onApproved)` を通る。scope が predicate (per-pane / per-tab / per-window の walk) と dialog 文言を決める。

Alt+F4 用に `CloseGateSubclassProc` WndProc subclass を追加、`WM_CLOSE` を intercept して `TryClose` 経由に。`RequestClose` は Close() 前に one-shot の `m_bypassCloseGate` を立て、framework 側の follow-up WM_CLOSE が gate を再度通らないようにしてる。

## コミット構造

1. `WindowCloseGate` 導入 (class のみ、wiring なし)
2. `MainWindow::TryClose` を gate 経由に (X ボタン挙動保存)
3. tab close 経路 (tab X + `close_tab`) を gate に
4. `close_surface` を gate に
5. Alt+F4 / OS `WM_CLOSE` に WndProc subclass 追加

## 関連

- Closes #126
- #128 verify 中に見つかった Alt+F4 crash の #126 コメントを解消。ただし残る「dispatcher の teardown race」(Actions callback が MainWindow 破棄後に発火する) は Alt+F4 を gate したことで確実に踏む場面は減ったが完全には消えてない。RequestClose 内で dispatcher を detach する follow-up commit を検討中。

</details>
