### PR TITLE
Fix garbage-colored unfocused-split overlay after config replace

### DIFF
--- a/App/MainWindow.xaml.cpp
+++ b/App/MainWindow.xaml.cpp
@@ -1028,14 +1028,12 @@ namespace winrt::GhosttyWin32::implementation
             auto onLeafFocused = [this](ghostty_surface_t surface) noexcept {
                 NotifySurfaceFocused(surface);
             };
-            // GhosttyConfig wraps the raw ghostty_config_t with
-            // typed, fallback-aware accessors so TabFactory (and
-            // future callers) stop reimplementing the key-length /
-            // fallback dance every time they need a config value.
-            ghostty::Config cfg(m_ghosttyApp->ConfigHandle());
+            // Hand the factory the App wrapper, not a Config snapshot:
+            // the config handle is freed and swapped on every config
+            // change (reload, theme follow), so the factory must
+            // re-resolve it per Make/MakePane call.
             m_tabFactory = std::make_unique<TabFactory>(
-                m_ghosttyApp->Handle(),
-                cfg,
+                *m_ghosttyApp,
                 m_hwnd,
                 App::g_app->PaneIds(),
                 std::move(onLeafFocused));

--- a/App/Tabs/TabFactory.h
+++ b/App/Tabs/TabFactory.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "Ghostty/App.h"
 #include "Ghostty/Config.h"
 #include "Tabs/Panes/Branch.h"
 #include "Tabs/Panes/PaneId.h"
@@ -22,28 +23,35 @@ namespace winrt::GhosttyWin32::implementation {
 namespace ghostty = core::ghostty;
 
 
-// Builds Tabs. Holds the cross-cutting context (ghostty app handle, the
-// HWND for DPI/initial-size, the PaneIdAllocator that produces fresh
-// per-leaf IDs, and an optional "leaf gained focus" callback that
-// every TerminalControl this factory creates will fire) so callers
-// don't have to thread those through every Make() call.
+// Builds Tabs. Holds the cross-cutting context (the ghostty::App
+// wrapper for the app/config handles, the HWND for DPI/initial-size,
+// the PaneIdAllocator that produces fresh per-leaf IDs, and an
+// optional "leaf gained focus" callback that every TerminalControl
+// this factory creates will fire) so callers don't have to thread
+// those through every Make() call.
 //
 // The focus callback is the one piece of MainWindow-side context that
 // needs to reach into each leaf without each leaf knowing about
 // MainWindow directly. Wiring it here keeps the dependency direction
 // host -> control (the inverse would be a layering violation).
 //
+// Config values are re-read from ghostty::App::ConfigHandle() on
+// every Make/MakePane — never cached across calls. The handle is
+// swapped and the OLD ghostty_config_t FREED on every config change
+// (App::ReplaceConfig; fired by reload and by the system-theme
+// follow), so a cached ghostty::Config would dangle and feed
+// freed-memory garbage into e.g. the unfocused-split overlay color.
+//
 // Stateless beyond the injected references — no mutable state of its
 // own. ID counter mutation lives in PaneIdAllocator; the factory only
 // borrows it.
 class TabFactory {
 public:
-    TabFactory(ghostty_app_t app, ghostty::Config const& cfg, HWND hwnd,
+    TabFactory(ghostty::App const& app, HWND hwnd,
                PaneIdAllocator& idAllocator,
                std::function<void(ghostty_surface_t)> onLeafFocused = {}) noexcept
-        : m_app(app), m_cfg(cfg), m_hwnd(hwnd), m_idAllocator(idAllocator),
-          m_onLeafFocused(std::move(onLeafFocused)),
-          m_dividerColor(cfg.SplitDividerColor()) {}
+        : m_ghostty(app), m_hwnd(hwnd), m_idAllocator(idAllocator),
+          m_onLeafFocused(std::move(onLeafFocused)) {}
 
     TabFactory(const TabFactory&) = delete;
     TabFactory& operator=(const TabFactory&) = delete;
@@ -99,8 +107,11 @@ public:
         }
         // Apply the divider colour before any tree exists so the
         // first splitter Border built by SetRoot already paints
-        // with the correct brush.
-        splitPanelImpl->SetDividerColor(m_dividerColor);
+        // with the correct brush. Resolved fresh from the live config
+        // handle — see the class comment for why nothing config-
+        // derived may be cached across calls.
+        splitPanelImpl->SetDividerColor(
+            ghostty::Config(m_ghostty.ConfigHandle()).SplitDividerColor());
         splitPanelImpl->SetRoot(std::move(branch));
 
         try {
@@ -232,7 +243,7 @@ public:
         // the panel's settled scale changes.
         swapChainChanged->compositionScale.store(scaleX, std::memory_order_release);
 
-        ghostty_surface_t surface = ghostty_surface_new(m_app, &cfg);
+        ghostty_surface_t surface = ghostty_surface_new(m_ghostty.Handle(), &cfg);
         if (!surface) {
             OutputDebugStringA("TabFactory::MakePane: ghostty_surface_new FAILED\n");
             // Callback won't fire — release the renderer's owning handle.
@@ -244,7 +255,7 @@ public:
         // Hand surface ownership to the control. From here on the
         // control's Detach() is responsible for freeing the surface
         // and closing the handle.
-        controlImpl->Attach(m_app, surface, handle, m_hwnd, attach, std::move(swapChainChanged));
+        controlImpl->Attach(m_ghostty.Handle(), surface, handle, m_hwnd, attach, std::move(swapChainChanged));
 
         // Wire the host-supplied focus callback so the control can
         // notify MainWindow whenever it gains keyboard focus without
@@ -256,10 +267,14 @@ public:
         // background fallback so this call site just asks for what
         // it wants. ghostty's `unfocused-split-opacity` measures
         // "how visible the unfocused side should be", so the
-        // overlay alpha is (1 - that).
+        // overlay alpha is (1 - that). Wrap the live handle fresh —
+        // a wrapper cached at construction would read a config that
+        // ReplaceConfig has already freed (the "inactive pane turns
+        // black/pink after a split" garbage-color bug).
+        ghostty::Config liveCfg(m_ghostty.ConfigHandle());
         controlImpl->SetUnfocusedAppearance(
-            1.0 - m_cfg.UnfocusedSplitOpacity(),
-            m_cfg.UnfocusedSplitFill());
+            1.0 - liveCfg.UnfocusedSplitOpacity(),
+            liveCfg.UnfocusedSplitFill());
 
         return MakePaneBranch(control, paneId);
     }
@@ -278,19 +293,17 @@ private:
         });
     }
 
-    ghostty_app_t m_app;
-    ghostty::Config m_cfg;
+    // App-scope wrapper; outlives every MainWindow (and therefore
+    // this factory). Provides the app handle and, crucially, the
+    // CURRENT config handle — the factory reads config through this
+    // on every call instead of caching, because ReplaceConfig frees
+    // the old handle on every config change.
+    ghostty::App const& m_ghostty;
     HWND m_hwnd;
     PaneIdAllocator& m_idAllocator;
     // Optional. Fires with the leaf's ghostty_surface_t whenever the
     // leaf's TerminalControl receives keyboard focus.
     std::function<void(ghostty_surface_t)> m_onLeafFocused;
-    // Resolved once in the ctor (config is read-only here) and
-    // stamped onto every SplitPanel built by Make. Reload-time
-    // updates would re-run m_cfg.SplitDividerColor() and push the
-    // new value into existing SplitPanels via SetDividerColor —
-    // wired but not yet triggered by anyone on this branch.
-    winrt::Windows::UI::Color m_dividerColor;
 };
 
 }  // namespace winrt::GhosttyWin32::implementation


### PR DESCRIPTION
Closes #129.

## Why

Splitting a pane and focusing away left the inactive pane painted solid black — or pink, depending on the day. First and only the second-and-later panes were affected; activating the pane restored it.

## Root cause

Use-after-free on the config handle:

1. `TabFactory` cached a `ghostty::Config` **by value** at construction. The wrapper is a thin view over a raw `ghostty_config_t`.
2. `App::ReplaceConfig` **frees the old `ghostty_config_t`** on every config change.
3. Since the system-theme follow (#110), a config change fires automatically at startup (`PushCurrentSystemColorScheme` → `SetColorScheme` → soft reload → `OnConfigChange` → `ReplaceConfig`). No manual reload needed.
4. Every pane created after that — i.e. **every split-created pane** — read `unfocused-split-opacity` / `unfocused-split-fill` out of freed memory. The `UnfocusedDim` overlay painted with garbage color and opacity.

This explains every observed symptom:

- Only panes 2+ affected — pane 1 was stamped at tab creation, before the first replace.
- Black one session, pink another — freed-heap contents vary.
- Activating "fixes" it — `ApplyFocusVisual(true)` collapses the overlay; the terminal underneath was never damaged.
- Not reproducible on v0.4.2 — no #110, so nothing replaced the config before the user split.
- Appeared "around #128" — #110 merged in the same v0.5.0 batch; #128's verification was the first heavy split testing on a build containing it.

## What

- `TabFactory` now stores `ghostty::App const&` (App-scope, outlives every window) and wraps `ConfigHandle()` **fresh inside every `Make` / `MakePane`** — never caches a config-derived wrapper across calls.
- The split-divider colour moves to the same per-call resolution; a reloaded divider colour now reaches new tabs instead of the construction-time snapshot.
- Class comment documents the invariant so the next config consumer doesn't reintroduce the cache.

## Verification

- [x] Build, split a pane, focus the other side → inactive pane shows the normal dim (bg-colored, subtle), not black/pink
- [x] Repeat after `ctrl+shift+,` (manual reload) → still normal
- [x] Repeat after flipping Windows light/dark theme → still normal
- [x] Splits 3+ deep → all inactive panes dim normally

<details>
<summary>日本語</summary>

## 原因

config handle の use-after-free。`TabFactory` が構築時に `ghostty::Config` (生ポインタの薄い view) を値でキャッシュ → `App::ReplaceConfig` は config 差し替えのたび旧 handle を `ghostty_config_free` → #110 (システムテーマ追従) 以降は起動時に自動で差し替えが発生 → 以降に作られる pane (= split で作る pane 全部) が解放済みメモリから `unfocused-split-opacity` / `unfocused-split-fill` を読み、UnfocusedDim overlay がゴミ色・ゴミ不透明度で塗られてた。

- 2 個目以降だけ: 1 個目は差し替え前に stamp 済み
- 黒だったりピンクだったり: 解放済みヒープの中身次第
- アクティブにすると直る: overlay が Collapsed になるだけで下は無傷
- v0.4.2 で出ない: #110 が無いので split 前に config が差し替わらない

## 変更

`TabFactory` は `ghostty::App const&` を持ち、`Make`/`MakePane` の中で毎回 `ConfigHandle()` を fresh に wrap する。divider 色も同じく per-call 解決に (reload 後の新 tab に新色が乗るようになる)。

</details>
