### PR TITLE
Clear the focused-surface cache on whole-tab close

### DIFF
--- a/App/MainWindow.xaml.cpp
+++ b/App/MainWindow.xaml.cpp
@@ -1255,6 +1255,23 @@ namespace winrt::GhosttyWin32::implementation
     {
         auto* t = m_tabs.FindByItem(item);
         if (!t) return;
+        // The focused-surface cache must not outlive the surfaces this
+        // close is about to free — same invariant CloseSurfaceByPaneId
+        // and ReleaseTornOutTab already hold. m_activeSurface can point
+        // at any pane in the tab, so walk them all rather than checking
+        // only the active control. The next GotFocus on the newly
+        // selected tab refills the slot.
+        if (m_activeSurface) {
+            if (auto* panelImpl =
+                    winrt::get_self<implementation::SplitPanel>(t->Panel())) {
+                if (panelImpl->Tree().FindPaneBy([this](Pane const& p) {
+                        auto const* tc = Tab::PaneToTerminalControl(p);
+                        return tc && tc->Surface().Owns(m_activeSurface);
+                    })) {
+                    m_activeSurface = nullptr;
+                }
+            }
+        }
         // Detach every pane before RemoveAt: SetSwapChainHandle(nullptr)
         // AVs at +0x1F8 inside microsoft.ui.xaml.dll if the panel has
         // already been unparented. Multi-pane tabs have multiple swap


### PR DESCRIPTION
Hardening follow-up from the #133 investigation — same lifetime-audit pass, second (latent) finding.

## Why

`m_activeSurface` caches the last-focused `ghostty_surface_t`. Two close paths already reset it before freeing the surface it points at (`CloseSurfaceByPaneId`, `ReleaseTornOutTab`), but the whole-tab close path (tab X / `close_tab` → `CloseTabByItem`) frees every surface in the tab and leaves the cache untouched. Until the next `GotFocus` refills it, the cache dangles.

Nothing crashes **today**: `GetActiveSurface()` has no consumers yet, and the internal uses are `Owns()` value comparisons that never dereference. But the first future consumer (APP-target action routing is the obvious one) would inherit a use-after-free that only reproduces in the narrow window between a tab close and the next focus delivery — exactly the kind of sometimes-garbage bug #133 just cleaned up.

## What

`CloseTabByItem` now walks the closing tab's panes and clears `m_activeSurface` if any of them owns it, before `DetachAll` frees the surfaces. Same shape as the existing `ReleaseTornOutTab` walk.

## Verification

- [x] Close a tab via tab X with multiple tabs open → next tab focuses normally, typing lands there
- [x] Close a tab via `close_tab` keybind → same
- [x] Tab tear-out / merge still behaves (existing clear path untouched)

<details>
<summary>日本語</summary>

## 目的

`m_activeSurface` (最後に focus された surface のキャッシュ) は、pane 単体の close と tear-out ではクリアされるのに、タブ丸ごとの close (タブの× / `close_tab`) ではクリアされずに残っていた。タブ close はタブ内の surface を全部 free するので、次の GotFocus が来るまでキャッシュは解放済みの surface を指したままになる。

今は実害がない。`GetActiveSurface()` を使っている箇所がまだ無く、内部の利用も `Owns()` の値比較だけで dereference しないため。ただ、将来これを使う機能が入った瞬間に #133 と同じ型の use-after-free になるので、先に塞いでおく。

## 変更

`CloseTabByItem` の冒頭で、閉じるタブの pane を walk して `m_activeSurface` を持っていればクリアする。`ReleaseTornOutTab` の既存 walk と同じ形。

</details>

