### PR TITLE
Tear out the dragged tab, not the first tab

### DIFF
--- a/App/App.vcxproj
+++ b/App/App.vcxproj
@@ -165,6 +165,7 @@
     <ClInclude Include="Tabs\Panes\Split.h" />
     <ClInclude Include="Tabs\Panes\Tree.h" />
     <ClInclude Include="Tabs\Tab.h" />
+    <ClInclude Include="Tabs\PressedTab.h" />
     <ClInclude Include="Tabs\TabFactory.h" />
     <ClInclude Include="Tabs\Tabs.h" />
     <ClInclude Include="Display\PhysicalPixels.h" />

--- a/App/App.vcxproj
+++ b/App/App.vcxproj
@@ -166,6 +166,7 @@
     <ClInclude Include="Tabs\Panes\Tree.h" />
     <ClInclude Include="Tabs\Tab.h" />
     <ClInclude Include="Tabs\PressedTab.h" />
+    <ClInclude Include="Tabs\TabDrag.h" />
     <ClInclude Include="Tabs\TabFactory.h" />
     <ClInclude Include="Tabs\Tabs.h" />
     <ClInclude Include="Display\PhysicalPixels.h" />

--- a/App/App.xaml.h
+++ b/App/App.xaml.h
@@ -4,6 +4,7 @@
 #include "Ghostty/App.h"
 #include "MainWindows.h"
 #include "Tabs/Panes/PaneIdAllocator.h"
+#include "Tabs/PressedTab.h"
 #include <winrt/Microsoft.Windows.AppLifecycle.h>
 #include <winrt/Microsoft.Windows.AppNotifications.h>
 #include <memory>
@@ -147,6 +148,12 @@ namespace winrt::GhosttyWin32::implementation
             return m_draggedTab;
         }
 
+        // App-scope like the slot above: the press handler travels
+        // with the TabViewItem across tear-out windows, so the slot
+        // it writes must not belong to any one window.
+        BasicPressedTab<Microsoft::UI::Xaml::Controls::TabViewItem>&
+        PressedTab() noexcept { return m_pressedTab; }
+
     private:
         // Shared tail of CreateNewWindow / CreateTearOutWindow:
         // strong-ref the window in m_topLevelWindows and subscribe
@@ -219,5 +226,6 @@ namespace winrt::GhosttyWin32::implementation
         // See SetDraggedTab. Strong ref for the duration of the drag
         // only; TabDragCompleted always clears it.
         Microsoft::UI::Xaml::Controls::TabViewItem m_draggedTab{ nullptr };
+        BasicPressedTab<Microsoft::UI::Xaml::Controls::TabViewItem> m_pressedTab;
     };
 }

--- a/App/App.xaml.h
+++ b/App/App.xaml.h
@@ -5,6 +5,7 @@
 #include "MainWindows.h"
 #include "Tabs/Panes/PaneIdAllocator.h"
 #include "Tabs/PressedTab.h"
+#include "Tabs/TabDrag.h"
 #include <winrt/Microsoft.Windows.AppLifecycle.h>
 #include <winrt/Microsoft.Windows.AppNotifications.h>
 #include <memory>
@@ -128,29 +129,19 @@ namespace winrt::GhosttyWin32::implementation
         // when only one window exists. UI thread only.
         void PresentWindow(ghostty_action_goto_window_e direction);
 
-        // The tab drag currently in flight, if any. Cross-window
-        // drag-and-drop rides OLE, which only marshals primitive
-        // DataPackage values — a TabViewItem stuffed into the
-        // package's Properties comes out empty on another window's
-        // TabStripDrop. Every window shares this process, so the
-        // dragged item travels through this slot instead: set in
-        // TabDragStarting, read by any window's drop handlers,
-        // cleared in TabDragCompleted (which fires on the source
-        // whether or not a drop landed).
-        void SetDraggedTab(
-            Microsoft::UI::Xaml::Controls::TabViewItem const& item)
-        {
-            m_draggedTab = item;
-        }
-        void ClearDraggedTab() noexcept { m_draggedTab = nullptr; }
-        Microsoft::UI::Xaml::Controls::TabViewItem DraggedTab() const noexcept
-        {
-            return m_draggedTab;
-        }
+        // The tab drag currently (or most recently) in flight.
+        // Cross-window drag-and-drop rides OLE, which only marshals
+        // primitive DataPackage values — a TabViewItem stuffed into
+        // the package's Properties comes out empty on another
+        // window's TabStripDrop. Every window shares this process,
+        // so the dragged item travels through this object instead.
+        // Lifecycle and the two-lifetime design live on BasicTabDrag.
+        BasicTabDrag<Microsoft::UI::Xaml::Controls::TabViewItem>&
+        TabDrag() noexcept { return m_tabDrag; }
 
-        // App-scope like the slot above: the press handler travels
-        // with the TabViewItem across tear-out windows, so the slot
-        // it writes must not belong to any one window.
+        // App-scope like TabDrag: the press handler travels with the
+        // TabViewItem across tear-out windows, so the slot it writes
+        // must not belong to any one window.
         BasicPressedTab<Microsoft::UI::Xaml::Controls::TabViewItem>&
         PressedTab() noexcept { return m_pressedTab; }
 
@@ -223,9 +214,7 @@ namespace winrt::GhosttyWin32::implementation
         // Token for the primary AppInstance's Activated event; the
         // subscription lives for the lifetime of the App.
         winrt::event_token m_activatedToken{};
-        // See SetDraggedTab. Strong ref for the duration of the drag
-        // only; TabDragCompleted always clears it.
-        Microsoft::UI::Xaml::Controls::TabViewItem m_draggedTab{ nullptr };
+        BasicTabDrag<Microsoft::UI::Xaml::Controls::TabViewItem> m_tabDrag;
         BasicPressedTab<Microsoft::UI::Xaml::Controls::TabViewItem> m_pressedTab;
     };
 }

--- a/App/MainWindow.xaml.cpp
+++ b/App/MainWindow.xaml.cpp
@@ -317,31 +317,24 @@ namespace winrt::GhosttyWin32::implementation
             // the tab there, dropping anywhere else spawns a window at
             // the drop point. Only a drag ghost is shown mid-drag.
             //
-            // The dragged TabViewItem travels through App's
-            // dragged-tab slot (SetDraggedTab), NOT the DataPackage:
-            // a drop on another top-level window rides OLE, which
-            // only marshals primitive package values — a TabViewItem
-            // stuffed into Properties comes out missing on the other
-            // window and the merge silently degrades into a
-            // drop-outside. The package deliberately stays empty
-            // (operation only) so foreign drop targets — a text
-            // editor, say — have nothing to accept and can't swallow
-            // the drag away from TabDroppedOutside.
+            // The DataPackage deliberately stays empty (operation
+            // only): the dragged tab travels through App's TabDrag
+            // instead (see App::TabDrag() for why OLE can't carry it),
+            // and an empty package gives foreign drop targets — a
+            // text editor, say — nothing to accept, so they can't
+            // swallow the drag away from TabDroppedOutside.
             tv.TabDragStarting([](auto const&, auto const& args) {
-                if (App::g_app) App::g_app->SetDraggedTab(args.Tab());
+                App::g_app->TabDrag().Begin(App::g_app->PressedTab().Take());
                 args.Data().RequestedOperation(
                     winrt::Windows::ApplicationModel::DataTransfer::DataPackageOperation::Move);
             });
 
-            // Fires on the source when the drag ends, whether or not
-            // any drop landed — the one reliable place to clear the
-            // in-flight slot.
             tv.TabDragCompleted([](auto const&, auto const&) {
-                if (App::g_app) App::g_app->ClearDraggedTab();
+                App::g_app->TabDrag().End();
             });
 
             tv.TabStripDragOver([](auto const&, auto const& e) {
-                if (App::g_app && App::g_app->DraggedTab()) {
+                if (App::g_app->TabDrag().InFlight()) {
                     e.AcceptedOperation(
                         winrt::Windows::ApplicationModel::DataTransfer::DataPackageOperation::Move);
                 }
@@ -349,14 +342,12 @@ namespace winrt::GhosttyWin32::implementation
 
             tv.TabStripDrop([weakActivated](auto const& sender, auto const& e) {
                 auto self = weakActivated.get();
-                if (!self || !App::g_app) return;
+                if (!self) return;
                 // TabStripDrop is a plain DragEventHandler, so the
                 // sender arrives as IInspectable, not a typed TabView.
                 auto strip = sender.template try_as<muxc::TabView>();
                 if (!strip) return;
-                // Source's TabDragCompleted (which clears the slot)
-                // fires only after this drop returns.
-                auto item = App::g_app->DraggedTab();
+                auto item = App::g_app->TabDrag().DraggedTab();
                 if (!item) return;
                 auto* source = App::g_app->FindWindowByTabItem(item);
                 // Same-strip drops are reorders, which CanReorderTabs
@@ -386,10 +377,13 @@ namespace winrt::GhosttyWin32::implementation
                 }
             });
 
-            tv.TabDroppedOutside([weakActivated](auto const&, auto const& args) {
+            tv.TabDroppedOutside([weakActivated](auto const&, auto const&) {
                 auto self = weakActivated.get();
-                if (!self || !App::g_app) return;
-                auto item = args.Tab();
+                if (!self) return;
+                // No fallback on purpose: args.Tab() would name the
+                // wrong tab (see TabDrag), and tearing out the wrong
+                // tab is worse than doing nothing.
+                auto item = App::g_app->TabDrag().TakeLastDraggedTab();
                 if (!item) return;
                 POINT cursor{};
                 bool haveCursor = GetCursorPos(&cursor) != 0;

--- a/App/MainWindow.xaml.cpp
+++ b/App/MainWindow.xaml.cpp
@@ -1080,6 +1080,21 @@ namespace winrt::GhosttyWin32::implementation
         // it's driven by click, not keyboard tab order.
         item.IsTabStop(false);
         item.AllowFocusOnInteraction(false);
+        // Record header presses so TabDrag::Begin knows which tab a
+        // drag started on (TabView's own args can't say — see
+        // TabDrag). handledEventsToo: the inner ListViewItem marks
+        // the press handled before it would reach a plain subscriber.
+        // The handler travels with the item across tear-out windows.
+        item.AddHandler(
+            UIElement::PointerPressedEvent(),
+            box_value(Input::PointerEventHandler(
+                [](winrt::Windows::Foundation::IInspectable const& s,
+                   Input::PointerRoutedEventArgs const&) {
+                    if (auto tab = s.try_as<muxc::TabViewItem>()) {
+                        App::g_app->PressedTab().Record(tab);
+                    }
+                })),
+            /*handledEventsToo*/ true);
         tv.TabItems().Append(item);
         // Append-only — don't switch to the new tab yet. The SelectedItem
         // call (which is what makes the panel visible) is deferred to the
@@ -1253,6 +1268,8 @@ namespace winrt::GhosttyWin32::implementation
     {
         auto* t = m_tabs.FindByItem(item);
         if (!t) return;
+        // A stale press record must not keep the closed item alive.
+        App::g_app->PressedTab().Forget(item);
         // The focused-surface cache must not outlive the surfaces this
         // close is about to free — same invariant CloseSurfaceByPaneId
         // and ReleaseTornOutTab already hold. m_activeSurface can point
@@ -2294,6 +2311,7 @@ namespace winrt::GhosttyWin32::implementation
         // already detached above and sweeps any remaining ones.
         tab->DetachAll();
         auto item = tab->Item();
+        App::g_app->PressedTab().Forget(item);
         auto tv = TabView();
         uint32_t idx = 0;
         if (tv.TabItems().IndexOf(item, idx)) {

--- a/App/Tabs/PressedTab.h
+++ b/App/Tabs/PressedTab.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <utility>
+
+namespace winrt::GhosttyWin32::implementation {
+
+// The most recent pointer press on a tab header — a single slot,
+// deliberately separate from the drag lifecycle (BasicTabDrag).
+//
+// The press is the only trustworthy identity of a grabbed tab:
+// pressing a non-selected tab starts a drag WITHOUT moving the
+// selection (ListView commits selection on release), and TabView's
+// own drag event args are broken in this app (see BasicTabDrag).
+// Every drag starts with a press, so TabDragStarting takes the slot
+// and feeds it to TabDrag::Begin.
+//
+// Living outside TabDrag also gives the slot its own lifetime rule:
+// a press that never became a drag would otherwise pin the
+// TabViewItem until the next press, so the close paths Forget the
+// item and release the reference immediately.
+template <class TItem>
+class BasicPressedTab {
+public:
+    void Record(TItem item) { m_item = std::move(item); }
+
+    // One press feeds at most one drag.
+    TItem Take() { return std::exchange(m_item, TItem{ nullptr }); }
+
+    // Drops the slot if it names `item` — a closed tab must not be
+    // kept alive by a stale press record.
+    void Forget(TItem const& item) {
+        if (m_item == item) m_item = TItem{ nullptr };
+    }
+
+private:
+    TItem m_item{ nullptr };
+};
+
+}  // namespace winrt::GhosttyWin32::implementation

--- a/App/Tabs/TabDrag.h
+++ b/App/Tabs/TabDrag.h
@@ -1,0 +1,74 @@
+#pragma once
+
+#include <cassert>
+#include <utility>
+
+namespace winrt::GhosttyWin32::implementation {
+
+// The process-wide tab drag. At most one exists at a time: tab
+// drag-and-drop rides OLE's DoDragDrop, which runs a modal loop on
+// the UI thread all windows share, so a second drag cannot start
+// before the first ends. Begin() asserts that assumption.
+//
+// One drag carries two lifetimes, which is why this is a type and
+// not a bare field:
+//
+//  - InFlight() / DraggedTab() are live only between Begin and End.
+//    They gate TabStripDragOver / TabStripDrop so a foreign OLE drag
+//    (files, text) is never mistaken for one of our tabs.
+//  - TakeLastDraggedTab() consumes the identity kept past End.
+//    TabView raises TabDragCompleted BEFORE TabDroppedOutside
+//    (hardcoded order in its OnListViewDragItemsCompleted), so the
+//    tear-out handler runs after the in-flight window has already
+//    closed — it claims the tab from here instead.
+//
+// Begin receives its item from the press slot (BasicPressedTab)
+// because TabView's own event args can't identify the dragged tab
+// in this app: with TabViewItem elements stored directly in TabItems
+// (Content unset — see #77), TabView's FindTabViewItemFromDragItem
+// falls through to a Content()==item scan that matches the FIRST
+// tab no matter which one was grabbed. If microsoft-ui-xaml ever
+// fixes that, the press slot and TakeLastDraggedTab can be retired —
+// TabDroppedOutside could read args.Tab() directly. InFlight /
+// DraggedTab stay regardless: OLE cannot marshal the item across
+// windows, and the in-flight gate is what keeps foreign OLE drags
+// out of the tab-merge path.
+//
+// Templated on the item type so the lifecycle logic stays free of
+// the WinUI projection and unit-testable; production instantiates
+// it with TabViewItem (see App).
+template <class TItem>
+class BasicTabDrag {
+public:
+    // A null item is allowed: it means a drag started but the tab
+    // could not be identified. The drag then stays NOT in flight
+    // (the merge gate stays closed) and the kept identity is
+    // cleared, so a stale one can't leak into this drag's tear-out.
+    void Begin(TItem item) {
+        assert(!m_inFlight && "TabDrag::Begin while a drag is in flight");
+        m_item = std::move(item);
+        m_inFlight = static_cast<bool>(m_item);
+    }
+
+    // Deliberately leaves m_item alone — see TakeLastDraggedTab.
+    void End() noexcept { m_inFlight = false; }
+
+    bool InFlight() const noexcept { return m_inFlight; }
+
+    // The dragged item while the drag is in flight; null otherwise.
+    TItem DraggedTab() const { return m_inFlight ? m_item : TItem{ nullptr }; }
+
+    // Claims the most recently dragged item — one-shot: a second
+    // call returns null. Taking mid-flight would rip the identity
+    // out from under DraggedTab, so that's a caller bug.
+    TItem TakeLastDraggedTab() {
+        assert(!m_inFlight && "TakeLastDraggedTab during a drag");
+        return std::exchange(m_item, TItem{ nullptr });
+    }
+
+private:
+    TItem m_item{ nullptr };
+    bool m_inFlight{ false };
+};
+
+}  // namespace winrt::GhosttyWin32::implementation

--- a/Tests/Tests.vcxproj
+++ b/Tests/Tests.vcxproj
@@ -140,6 +140,7 @@
     <ClCompile Include="test_fullscreen.cpp" />
     <ClCompile Include="test_key_event_translator.cpp" />
     <ClCompile Include="test_window_decorations.cpp" />
+    <ClCompile Include="test_tab_drag.cpp" />
     <ClCompile Include="test_pressed_tab.cpp" />
   </ItemGroup>
   <ItemGroup>

--- a/Tests/Tests.vcxproj
+++ b/Tests/Tests.vcxproj
@@ -140,6 +140,7 @@
     <ClCompile Include="test_fullscreen.cpp" />
     <ClCompile Include="test_key_event_translator.cpp" />
     <ClCompile Include="test_window_decorations.cpp" />
+    <ClCompile Include="test_pressed_tab.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="MockMainWindowView.h" />

--- a/Tests/test_pressed_tab.cpp
+++ b/Tests/test_pressed_tab.cpp
@@ -1,0 +1,45 @@
+#include "pch.h"
+#include "../App/Tabs/PressedTab.h"
+
+// Same int* instantiation trick as test_tab_drag.cpp.
+using winrt::GhosttyWin32::implementation::BasicPressedTab;
+
+namespace {
+int a = 0, b = 0;
+}
+
+TEST(PressedTabTest, StartsEmpty) {
+    BasicPressedTab<int*> p;
+    EXPECT_EQ(p.Take(), nullptr);
+}
+
+TEST(PressedTabTest, TakeReturnsTheRecordedItemOnce) {
+    // One press feeds at most one drag.
+    BasicPressedTab<int*> p;
+    p.Record(&a);
+    EXPECT_EQ(p.Take(), &a);
+    EXPECT_EQ(p.Take(), nullptr);
+}
+
+TEST(PressedTabTest, NextRecordOverwrites) {
+    BasicPressedTab<int*> p;
+    p.Record(&a);
+    p.Record(&b);
+    EXPECT_EQ(p.Take(), &b);
+}
+
+TEST(PressedTabTest, ForgetClearsAMatchingItem) {
+    // Closing a tab must release the reference a stale press holds.
+    BasicPressedTab<int*> p;
+    p.Record(&a);
+    p.Forget(&a);
+    EXPECT_EQ(p.Take(), nullptr);
+}
+
+TEST(PressedTabTest, ForgetIgnoresANonMatchingItem) {
+    // Closing some other tab must not disturb a live press record.
+    BasicPressedTab<int*> p;
+    p.Record(&a);
+    p.Forget(&b);
+    EXPECT_EQ(p.Take(), &a);
+}

--- a/Tests/test_tab_drag.cpp
+++ b/Tests/test_tab_drag.cpp
@@ -1,0 +1,94 @@
+#include "pch.h"
+#include "../App/Tabs/TabDrag.h"
+
+// Instantiated with int* — the template only needs a null-testable,
+// assignable item type, which is exactly what lets these tests run
+// without the WinUI projection. Production uses TabViewItem.
+using winrt::GhosttyWin32::implementation::BasicTabDrag;
+
+namespace {
+int a = 0, b = 0;
+}
+
+// ----- lifecycle: Begin / End -----
+
+TEST(TabDragTest, StartsIdle) {
+    BasicTabDrag<int*> d;
+    EXPECT_FALSE(d.InFlight());
+    EXPECT_EQ(d.DraggedTab(), nullptr);
+    EXPECT_EQ(d.TakeLastDraggedTab(), nullptr);
+}
+
+TEST(TabDragTest, BeginEntersFlightAndExposesItem) {
+    BasicTabDrag<int*> d;
+    d.Begin(&a);
+    EXPECT_TRUE(d.InFlight());
+    EXPECT_EQ(d.DraggedTab(), &a);
+}
+
+TEST(TabDragTest, EndLeavesFlightButKeepsIdentityForTake) {
+    // The tear-out consumer runs after TabDragCompleted — the
+    // identity must survive End.
+    BasicTabDrag<int*> d;
+    d.Begin(&a);
+    d.End();
+    EXPECT_FALSE(d.InFlight());
+    EXPECT_EQ(d.DraggedTab(), nullptr);
+    EXPECT_EQ(d.TakeLastDraggedTab(), &a);
+}
+
+TEST(TabDragTest, TakeIsOneShot) {
+    // One drag tears out at most one tab; a second take must not
+    // hand the same identity out again.
+    BasicTabDrag<int*> d;
+    d.Begin(&a);
+    d.End();
+    EXPECT_EQ(d.TakeLastDraggedTab(), &a);
+    EXPECT_EQ(d.TakeLastDraggedTab(), nullptr);
+}
+
+// ----- null Begin: unidentified drag -----
+
+TEST(TabDragTest, BeginWithNullDoesNotEnterFlight) {
+    // The merge gate (InFlight) must stay closed when the dragged
+    // tab could not be identified.
+    BasicTabDrag<int*> d;
+    d.Begin(nullptr);
+    EXPECT_FALSE(d.InFlight());
+    EXPECT_EQ(d.DraggedTab(), nullptr);
+    EXPECT_EQ(d.TakeLastDraggedTab(), nullptr);
+}
+
+TEST(TabDragTest, BeginWithNullClearsPreviousIdentity) {
+    // A stale identity from the previous drag must not leak into a
+    // new drag whose tab is unknown.
+    BasicTabDrag<int*> d;
+    d.Begin(&a);
+    d.End();
+    d.Begin(nullptr);
+    EXPECT_EQ(d.TakeLastDraggedTab(), nullptr);
+}
+
+// ----- successive drags -----
+
+TEST(TabDragTest, NextBeginOverwritesIdentity) {
+    BasicTabDrag<int*> d;
+    d.Begin(&a);
+    d.End();
+    d.Begin(&b);
+    EXPECT_TRUE(d.InFlight());
+    EXPECT_EQ(d.DraggedTab(), &b);
+    d.End();
+    EXPECT_EQ(d.TakeLastDraggedTab(), &b);
+}
+
+TEST(TabDragTest, EndIsIdempotent) {
+    // TabDragCompleted could in principle fire on paths we don't
+    // anticipate; a second End must not disturb the kept identity.
+    BasicTabDrag<int*> d;
+    d.Begin(&a);
+    d.End();
+    d.End();
+    EXPECT_FALSE(d.InFlight());
+    EXPECT_EQ(d.TakeLastDraggedTab(), &a);
+}


### PR DESCRIPTION
## Why

Dragging a tab outside the window tore out the wrong tab. Two independent wrong-identity sources, uncovered in sequence:

1. **`args.Tab()` always names the first tab.** With `TabViewItem` elements stored directly in `TabItems` and `Content` unset (#77 keeps SplitPanels under AppContent because TabView's ContentPresenter unloads non-selected content, which breaks SwapChainPanel), WinUI's `FindTabViewItemFromDragItem` falls through to a `Content()==item` scan whose null==null comparison matches the **first** tab. Both `TabDragStarting` and `TabDroppedOutside` args are affected, and `args.Item()` is not a `TabViewItem` at all.
2. **`SelectedItem` misses non-selected tabs.** ListView commits selection on *release*, so press-and-drag on a non-selected tab starts the drag with the old selection intact — a SelectedItem-based fix tore out the active tab instead.

The only trustworthy identity is the **pointer press on the header** that every drag starts with.

Also fixed on the way: the App dragged-tab slot was already cleared when `TabDroppedOutside` ran, because `TabDragCompleted` fires **before** it (back-to-back in `OnListViewDragItemsCompleted`, hardcoded).

## What

Two small value types replace the scattered slot + ad-hoc state (unit-tested via an `int*` instantiation, no WinUI projection needed):

- **`BasicPressedTab`** (`Record` / `Take` / `Forget`) — single slot recording the last header press. `CreateTab` wires every `TabViewItem`'s `PointerPressed` (handledEventsToo; the handler travels with the item across tear-out windows). The close paths `Forget` the item so a stale press can't keep a closed tab alive.
- **`BasicTabDrag`** (`Begin` / `End` / `InFlight` / `DraggedTab` / `TakeLastDraggedTab`) — the process-wide drag lifecycle. `Begin` asserts the platform invariant (OLE's modal loop on the shared UI thread means at most one drag). `InFlight`/`DraggedTab` gate the merge path against foreign OLE drags; `TakeLastDraggedTab` is the one-shot claim for the tear-out handler, which runs after `End`.

Event wiring:

```
PointerPressed    → PressedTab().Record(tab)
TabDragStarting   → TabDrag().Begin(PressedTab().Take())
TabStripDragOver  → TabDrag().InFlight()
TabStripDrop      → TabDrag().DraggedTab()          (merge; drag still in flight)
TabDragCompleted  → TabDrag().End()
TabDroppedOutside → TabDrag().TakeLastDraggedTab()  (tear-out; after End)
```

No fallbacks to `SelectedItem` or `args.Tab()` — each returns a wrong-but-plausible tab (the active one / the first one). An unidentified drag now tears out nothing, which beats tearing out the wrong tab.

Upstream note: the `Content()==item` null false-positive is worth a microsoft-ui-xaml issue/PR (skip null Contents in the fallback scan). Tracked in local notes.

## Verification

- [x] Non-active tab dragged outside → the grabbed tab tears out (the core repro)
- [x] Active tab dragged outside → unchanged
- [x] 3 tabs, drag tab 3 outside → tab 3 tears out (content-labeled repro)
- [x] Drag onto another window's strip (merge) → correct tab moves
- [x] Drag the only tab of a window outside → window just moves (no tear-out)
- [x] Reorder within the strip → unaffected

<details>
<summary>日本語</summary>

## 症状と原因

タブを window の外に drag すると、掴んだタブではないタブが tear-out されていた。原因は 2 段階で見つかった。

1. **`args.Tab()` が常に先頭タブを返す。** この app は `TabViewItem.Content` を使わない構成なので (SwapChainPanel は TabView の ContentPresenter unload で壊れるため、#77 で AppContent 直下に置いた)、WinUI の `FindTabViewItemFromDragItem` は最後の手段の `Content()==item` 走査に落ちる。全タブの Content が null なので、null 同士の比較が先頭タブに false positive でマッチする。
2. **`SelectedItem` は非選択タブの drag で外れる。** ListView は選択を release 時に確定するので、非選択タブを press してそのまま drag すると選択は古いまま残る。SelectedItem を使った版は、非アクティブなタブを掴むとアクティブなタブを tear-out してしまった。

信頼できる唯一の情報は「drag の直前に必ず起きるヘッダへの pointer press」だった。

あわせて、App の dragged-tab slot が `TabDroppedOutside` の時点で空になる問題も直した。slot をクリアする `TabDragCompleted` は `TabDroppedOutside` より先に fire する (WinUI のソースにハードコードされた順序)。

## 変更

散らばっていた状態を 2 つの小さな型に集約した (どちらも `int*` で instantiate して WinUI 無しで unit test できる)。

- **`BasicPressedTab`** (`Record` / `Take` / `Forget`) — 最後にヘッダを press されたタブを 1 個だけ持つ slot。`CreateTab` が全 `TabViewItem` の `PointerPressed` に記録を wire する。タブを閉じる経路では `Forget` を呼ぶので、drag にならなかった press が閉じたタブを掴み続けることはない。
- **`BasicTabDrag`** (`Begin` / `End` / `InFlight` / `DraggedTab` / `TakeLastDraggedTab`) — プロセス内で高々 1 個の drag lifecycle。`Begin` はその前提を assert する。`InFlight` / `DraggedTab` は外部 OLE drag を merge 経路から弾く gate で、`TakeLastDraggedTab` は End の後に走る tear-out handler のための one-shot claim。

`SelectedItem` / `args.Tab()` への fallback は置かない。どちらも「もっともらしく間違ったタブ」を返すので、特定できない drag は何も tear-out しない方が安全。

</details>