### PR TITLE
Disarm dispatched ghostty callbacks before the window dies

### DIFF
--- a/App/MainWindow.xaml.cpp
+++ b/App/MainWindow.xaml.cpp
@@ -662,6 +662,14 @@ namespace winrt::GhosttyWin32::implementation
 
     MainWindow::~MainWindow()
     {
+        // Disarm dispatched ghostty callbacks first: work already
+        // queued on the UI thread runs after this destructor and
+        // would touch the destroyed view (issue #131 — AV in a
+        // dispatched OnMouseShape after a fast Alt+F4 close). The
+        // destructor is the one point every close path passes
+        // through, including the direct Close() calls that skip
+        // RequestClose.
+        if (m_ghosttyDispatcher) m_ghosttyDispatcher->DetachActions();
         // Stop the foreground-pid poll before anything else in this
         // destructor runs — its Tick callback captures a weak_ref
         // that would return null at this point anyway, but Stopping

--- a/Core/Ghostty/Actions/Actions.cpp
+++ b/Core/Ghostty/Actions/Actions.cpp
@@ -57,7 +57,7 @@ bool Actions::OnRender() {
     // serialises ticks on the UI thread, so we go through the
     // same path. ghostty_app_tick is idempotent — calling it
     // when nothing is dirty is a cheap no-op.
-    m_view.Dispatch([this]() {
+    DispatchToView([this]() {
         m_view.Tick();
     });
     return true;
@@ -98,7 +98,7 @@ bool Actions::OnCloseWindow() {
     // else. Same intent as the X button — go through TryClose so
     // needs_confirm_quit prompts the user before we tear anything
     // down. Sibling windows survive either way.
-    m_view.Dispatch([this]() {
+    DispatchToView([this]() {
         m_view.TryClose();
     });
     return true;
@@ -110,7 +110,7 @@ bool Actions::OnCloseAllWindows() {
     if (!m_hooks.closeAllWindows) return OnCloseWindow();
     // UI-thread hop for the same reason as OnNewWindow: window
     // teardown is XAML work, and every window shares this thread.
-    m_view.Dispatch([this]() {
+    DispatchToView([this]() {
         m_hooks.closeAllWindows();
     });
     return true;
@@ -118,7 +118,7 @@ bool Actions::OnCloseAllWindows() {
 
 bool Actions::OnQuit() {
     if (!m_hooks.quit) return OnCloseWindow();
-    m_view.Dispatch([this]() {
+    DispatchToView([this]() {
         m_hooks.quit();
     });
     return true;
@@ -132,7 +132,7 @@ bool Actions::OnToggleVisibility() {
     // window with no taskbar entry can only be recovered by
     // relaunching. Minimizing keeps the window reachable via
     // taskbar click / alt-tab.
-    m_view.Dispatch([this]() {
+    DispatchToView([this]() {
         HWND hwnd = m_view.Hwnd();
         if (!hwnd) return;
         if (IsIconic(hwnd)) {
@@ -151,7 +151,7 @@ bool Actions::OnToggleMaximize() {
     // SendMessage runs on the UI thread; dispatch through
     // Dispatcher() because action_cb fires from the renderer
     // thread.
-    m_view.Dispatch([this]() {
+    DispatchToView([this]() {
         HWND hwnd = m_view.Hwnd();
         if (!hwnd) return;
         SendMessageW(hwnd, WM_SYSCOMMAND,
@@ -166,7 +166,7 @@ bool Actions::OnPresentTerminal() {
     // SetForegroundWindow alone would silently fail when our
     // window isn't already in the allowed-set per Win32's
     // foreground rules.
-    m_view.Dispatch([this]() {
+    DispatchToView([this]() {
         m_view.PresentTerminal();
     });
     return true;
@@ -176,7 +176,7 @@ bool Actions::OnFloatWindow(ghostty_action_float_window_e mode) {
     // Route through the view: the view owns the HWND and remembers
     // the current topmost state so TOGGLE can flip without the
     // dispatcher tracking it.
-    m_view.Dispatch([this, mode]() {
+    DispatchToView([this, mode]() {
         m_view.SetFloatOnTop(mode);
     });
     return true;
@@ -186,7 +186,7 @@ bool Actions::OnShowOnScreenKeyboard() {
     // Touch / pen users without a physical keyboard. The OSK is
     // its own top-level window; we just launch it and let the user
     // dismiss it normally.
-    m_view.Dispatch([this]() {
+    DispatchToView([this]() {
         m_view.ShowOnScreenKeyboard();
     });
     return true;
@@ -233,7 +233,7 @@ bool Actions::OnResetWindowSize() {
     // 80×24-ish terminal at common font sizes.
     uint32_t w = m_initialWidth;
     uint32_t h = m_initialHeight;
-    m_view.Dispatch([this, w, h]() {
+    DispatchToView([this, w, h]() {
         HWND hwnd = m_view.Hwnd();
         if (!hwnd) return;
         int width, height;
@@ -254,7 +254,7 @@ bool Actions::OnResetWindowSize() {
 // ===== tab lifecycle / navigation / title =====
 
 bool Actions::OnNewTab() {
-    m_view.Dispatch([this]() {
+    DispatchToView([this]() {
         m_view.CreateTab();
     });
     return true;
@@ -266,7 +266,7 @@ bool Actions::OnNewWindow() {
     // and every Xaml touch has to happen there. The `m_view`
     // dispatch is a UI-thread hop that any live window can provide;
     // we don't need our own dispatcher for this to arrive there.
-    m_view.Dispatch([this]() {
+    DispatchToView([this]() {
         m_hooks.newWindow();
     });
     return true;
@@ -276,7 +276,7 @@ bool Actions::OnGotoWindow(ghostty_action_goto_window_e direction) {
     if (!m_hooks.gotoWindow) return false;
     // Same UI-thread hop rationale as OnNewWindow — the hook calls
     // Xaml Window::Activate under the hood.
-    m_view.Dispatch([this, direction]() {
+    DispatchToView([this, direction]() {
         m_hooks.gotoWindow(direction);
     });
     return true;
@@ -284,14 +284,14 @@ bool Actions::OnGotoWindow(ghostty_action_goto_window_e direction) {
 
 bool Actions::OnCloseTab(ghostty_surface_t surface) {
     if (!surface) return true;
-    m_view.Dispatch([this, surface]() {
+    DispatchToView([this, surface]() {
         m_view.CloseTabBySurface(surface);
     });
     return true;
 }
 
 bool Actions::OnGotoTab(int requested) {
-    m_view.Dispatch([this, requested]() {
+    DispatchToView([this, requested]() {
         m_view.GoToTab(requested);
     });
     return true;
@@ -301,7 +301,7 @@ bool Actions::OnMoveTab(ghostty_action_move_tab_s move) {
     // ghostty hands us a signed offset; semantics are "shift the
     // currently selected tab by N positions, clamped to the
     // TabView's bounds" (no wrap-around — matches upstream).
-    m_view.Dispatch([this, move]() {
+    DispatchToView([this, move]() {
         m_view.MoveActiveTabBy(move.amount);
     });
     return true;
@@ -314,7 +314,7 @@ bool Actions::OnSetTitle(ghostty_surface_t surface, const char* utf8Title) {
     if (!surface || !utf8Title) return true;
     std::wstring wide = interop::Encoding::toUtf16(utf8Title);
     if (wide.empty()) return true;
-    m_view.Dispatch([this, surface, wide = std::move(wide)]() mutable {
+    DispatchToView([this, surface, wide = std::move(wide)]() mutable {
         m_view.SetTabTitleForSurface(surface, std::move(wide));
     });
     return true;
@@ -322,7 +322,7 @@ bool Actions::OnSetTitle(ghostty_surface_t surface, const char* utf8Title) {
 
 bool Actions::OnCopyTitleToClipboard(ghostty_surface_t surface) {
     if (!surface) return true;
-    m_view.Dispatch([this, surface]() {
+    DispatchToView([this, surface]() {
         m_view.CopyTabTitleForSurface(surface);
     });
     return true;
@@ -336,7 +336,7 @@ bool Actions::OnColorChange(ghostty_action_color_change_s cc) {
     // visible only and ghostty handles them internally.
     if (cc.kind != GHOSTTY_ACTION_COLOR_KIND_BACKGROUND) return true;
     uint8_t r = cc.r, g = cc.g, b = cc.b;
-    m_view.Dispatch([this, r, g, b]() {
+    DispatchToView([this, r, g, b]() {
         m_view.ApplyBackgroundColor(r, g, b);
     });
     return true;
@@ -345,7 +345,7 @@ bool Actions::OnColorChange(ghostty_action_color_change_s cc) {
 bool Actions::OnMouseShape(ghostty_surface_t surface,
                                   ghostty_action_mouse_shape_e shape) {
     if (!surface) return true;
-    m_view.Dispatch([this, surface, shape]() {
+    DispatchToView([this, surface, shape]() {
         m_view.SetCursorShapeForSurface(surface, shape);
     });
     return true;
@@ -366,7 +366,7 @@ bool Actions::OnConfigChange(ghostty_config_t newCfg) {
     if (!newCfg) return true;
     auto cloned = ghostty_config_clone(newCfg);
     if (!cloned) return true;
-    m_view.Dispatch([this, cloned]() {
+    DispatchToView([this, cloned]() {
         m_view.ReplaceConfig(cloned);
     });
     return true;
@@ -379,7 +379,7 @@ bool Actions::OnDesktopNotification(ghostty_surface_t surface,
     std::wstring title = (dn.title && dn.title[0]) ? interop::Encoding::toUtf16(dn.title) : L"";
     std::wstring body  = (dn.body  && dn.body[0])  ? interop::Encoding::toUtf16(dn.body)  : L"";
     if (title.empty() && body.empty()) return true;
-    m_view.Dispatch([this, surface, title = std::move(title),
+    DispatchToView([this, surface, title = std::move(title),
                                     body = std::move(body)]() mutable {
         m_view.ShowDesktopNotification(surface, std::move(title), std::move(body));
     });
@@ -387,7 +387,7 @@ bool Actions::OnDesktopNotification(ghostty_surface_t surface,
 }
 
 bool Actions::OnProgressReport(ghostty_action_progress_report_s pr) {
-    m_view.Dispatch([this, pr]() {
+    DispatchToView([this, pr]() {
         m_view.ReportProgress(pr);
     });
     return true;
@@ -396,7 +396,7 @@ bool Actions::OnProgressReport(ghostty_action_progress_report_s pr) {
 // ===== window state =====
 
 bool Actions::OnSizeLimit(ghostty_action_size_limit_s limit) {
-    m_view.Dispatch([this, limit]() {
+    DispatchToView([this, limit]() {
         m_view.ApplySizeLimit(limit);
     });
     return true;
@@ -408,7 +408,7 @@ bool Actions::OnToggleFullscreen() {
     // same borderless-fullscreen behaviour, so the value is
     // ignored here. The Fullscreen value on the view side
     // owns the placement/style snapshot for restore.
-    m_view.Dispatch([this]() {
+    DispatchToView([this]() {
         m_view.ToggleFullscreen();
     });
     return true;
@@ -420,7 +420,7 @@ bool Actions::OnToggleWindowDecorations() {
     // bounces the trigger through the UI dispatcher. action_cb fires
     // from the renderer thread, so the dispatcher hop is required
     // before touching XAML.
-    m_view.Dispatch([this]() {
+    DispatchToView([this]() {
         m_view.ToggleWindowDecorations();
     });
     return true;
@@ -434,7 +434,7 @@ bool Actions::OnToggleWindowDecorations() {
 bool Actions::OnNewSplit(ghostty_surface_t surface,
                                 ghostty_action_split_direction_e direction) {
     if (!surface) return true;
-    m_view.Dispatch([this, surface, direction]() {
+    DispatchToView([this, surface, direction]() {
         m_view.SplitActivePane(surface, direction);
     });
     return true;
@@ -443,7 +443,7 @@ bool Actions::OnNewSplit(ghostty_surface_t surface,
 bool Actions::OnResizeSplit(ghostty_surface_t surface,
                                    ghostty_action_resize_split_s resize) {
     if (!surface) return true;
-    m_view.Dispatch([this, surface, resize]() {
+    DispatchToView([this, surface, resize]() {
         m_view.ResizeSplitFromAction(surface, resize);
     });
     return true;
@@ -452,7 +452,7 @@ bool Actions::OnResizeSplit(ghostty_surface_t surface,
 bool Actions::OnGotoSplit(ghostty_surface_t surface,
                                  ghostty_action_goto_split_e direction) {
     if (!surface) return true;
-    m_view.Dispatch([this, surface, direction]() {
+    DispatchToView([this, surface, direction]() {
         m_view.GotoSplitFromAction(surface, direction);
     });
     return true;
@@ -460,7 +460,7 @@ bool Actions::OnGotoSplit(ghostty_surface_t surface,
 
 bool Actions::OnEqualizeSplits(ghostty_surface_t surface) {
     if (!surface) return true;
-    m_view.Dispatch([this, surface]() {
+    DispatchToView([this, surface]() {
         m_view.EqualizeSplitsForSurface(surface);
     });
     return true;
@@ -468,7 +468,7 @@ bool Actions::OnEqualizeSplits(ghostty_surface_t surface) {
 
 bool Actions::OnToggleSplitZoom(ghostty_surface_t surface) {
     if (!surface) return true;
-    m_view.Dispatch([this, surface]() {
+    DispatchToView([this, surface]() {
         m_view.ToggleSplitZoomForSurface(surface);
     });
     return true;

--- a/Core/Ghostty/Actions/Actions.h
+++ b/Core/Ghostty/Actions/Actions.h
@@ -2,8 +2,10 @@
 
 #include "Host/IWindow.h"
 #include "ghostty.h"
+#include <atomic>
 #include <cstdint>
 #include <functional>
+#include <memory>
 #include <utility>
 
 namespace core::ghostty::actions {
@@ -51,6 +53,17 @@ public:
     Actions(host::IWindow& view, AppHooks hooks = {}) noexcept
         : m_view(view)
         , m_hooks(std::move(hooks)) {}
+
+    // Severs the view before its teardown starts. Ghostty callbacks
+    // land on renderer/io threads and hop to the UI thread through
+    // m_view.Dispatch; work still queued when the window closes would
+    // otherwise run against a destroyed view (observed as an AV in a
+    // dispatched OnMouseShape lambda — issue #131). After Detach,
+    // queued and future dispatched work no-ops. Call on the UI thread
+    // before Window::Close(); idempotent.
+    void Detach() noexcept {
+        m_alive->store(false, std::memory_order_release);
+    }
 
     // ----- terminal events -----
     bool OnRingBell();
@@ -140,6 +153,29 @@ public:
 private:
     host::IWindow& m_view;
     AppHooks       m_hooks;
+
+    // Shared with every dispatched lambda so the liveness check stays
+    // readable even after this Actions object is gone with its
+    // window. Ordering is safe without further synchronisation: the
+    // flag is cleared on the UI thread and the lambdas run on the UI
+    // thread, so a lambda either ran before Detach or observes false.
+    std::shared_ptr<std::atomic<bool>> m_alive{
+        std::make_shared<std::atomic<bool>>(true) };
+
+    // Every UI-thread hop goes through here instead of calling
+    // m_view.Dispatch directly: the wrapper adds the liveness gate
+    // that keeps queued work from touching a destroyed view.
+    // mutable: several handlers pass mutable lambdas (they move
+    // captured strings out when they run), and a const call operator
+    // on this wrapper couldn't invoke them.
+    template <class F>
+    void DispatchToView(F&& work) {
+        m_view.Dispatch(
+            [alive = m_alive, work = std::forward<F>(work)]() mutable {
+                if (!alive->load(std::memory_order_acquire)) return;
+                work();
+            });
+    }
 
     // Initial window size from GHOSTTY_ACTION_INITIAL_SIZE
     // (physical pixels). Zero means "not yet received" —

--- a/Core/Ghostty/CallbackDispatcher.h
+++ b/Core/Ghostty/CallbackDispatcher.h
@@ -44,6 +44,11 @@ public:
     // "unhandled" telemetry on libghostty's side).
     bool DispatchAction(ghostty_target_s target, ghostty_action_s action);
 
+    // Forwarded to Actions::Detach — see there. The host calls this
+    // before closing its window so queued UI-thread work stops
+    // touching the view.
+    void DetachActions() noexcept { m_actions.Detach(); }
+
 private:
     CallbackDispatcher(host::IWindow& view,
                        actions::Actions::AppHooks hooks) noexcept

--- a/Tests/test_ghostty_actions.cpp
+++ b/Tests/test_ghostty_actions.cpp
@@ -409,3 +409,36 @@ TEST(GhosttyActionsTest, OnInitialSizeFollowedByResetIsSafe) {
     // integration tests where a real window exists.
     EXPECT_TRUE(actions.OnResetWindowSize());
 }
+
+// ----- Detach: dispatched work must not reach a closing view -----
+
+TEST(GhosttyActionsTest, DispatchedWorkReachesTheViewWhileAttached) {
+    MockMainWindowView view;
+    Actions actions(view);
+    EXPECT_TRUE(actions.OnMouseShape(FakeSurface(0x10),
+                                     GHOSTTY_MOUSE_SHAPE_TEXT));
+    EXPECT_EQ(view.setCursorShapeCalls, 1);
+}
+
+TEST(GhosttyActionsTest, DetachDisarmsDispatchedWork) {
+    // The mock runs Dispatch inline, so this models the issue #131
+    // ordering: work enqueued before the window died would run after
+    // it. With the liveness gate cleared, the lambda must no-op
+    // instead of touching the view.
+    MockMainWindowView view;
+    Actions actions(view);
+    actions.Detach();
+    EXPECT_TRUE(actions.OnMouseShape(FakeSurface(0x10),
+                                     GHOSTTY_MOUSE_SHAPE_TEXT));
+    EXPECT_EQ(view.setCursorShapeCalls, 0);
+}
+
+TEST(GhosttyActionsTest, DetachIsIdempotent) {
+    MockMainWindowView view;
+    Actions actions(view);
+    actions.Detach();
+    actions.Detach();
+    EXPECT_TRUE(actions.OnMouseShape(FakeSurface(0x10),
+                                     GHOSTTY_MOUSE_SHAPE_TEXT));
+    EXPECT_EQ(view.setCursorShapeCalls, 0);
+}


### PR DESCRIPTION
Closes #131.

## Why

Ghostty callbacks arrive on renderer/io threads and hop to the UI thread through `IWindow::Dispatch`. Work still queued when the window closed ran against the destroyed view — reproducibly an AV inside a dispatched `OnMouseShape` lambda after a fast Alt+F4 close with `confirm-close-surface = false` (any close that resolves without showing the confirmation dialog; the dialog's latency is what made prompted closes safe).

## What

- `Actions` routes every UI-thread hop through `DispatchToView`, which wraps the work in a liveness gate: a `shared_ptr<atomic<bool>>` captured by each lambda, so the check stays valid even after the `Actions` object is gone with its window.
- `Actions::Detach()` clears the flag; `CallbackDispatcher::DetachActions()` forwards it.
- `~MainWindow` calls it first thing — the one point every close path passes through, including the direct `Close()` calls that skip `RequestClose` (last-pane tab close, `CloseAllWindows`).
- No extra synchronisation: the flag is cleared on the UI thread and the gated lambdas run on the UI thread, so each one either ran while the window was alive or observes the cleared flag.

Unit tests cover attached routing, disarmed no-op, and idempotence (the mock's inline `Dispatch` models "queued work runs after the close").

## Verification

- [x] `confirm-close-surface = false`, wiggle the mouse over a pane and hit Alt+F4 repeatedly → no AV (previous repro crashed in `Actions::OnMouseShape`)
- [x] Same with the last tab's X button and `close_tab` on the last tab (direct-Close paths)
- [x] Normal use unaffected: cursor shape changes over panes, title updates, notifications still arrive

<details>
<summary>日本語</summary>

## 原因

ghostty の callback は renderer/io スレッドに届き、`IWindow::Dispatch` で UI スレッドへ移送される。window が閉じた時点でキューに残っていた仕事が、破棄済みの view に対して実行されていた。`confirm-close-surface = false` で Alt+F4 を押すと、dispatch 済みの `OnMouseShape` lambda の中で AV する形で再現していた (確認ダイアログが出る経路は、ダイアログの待ち時間のおかげでキューが掃けて偶然安全だった)。

## 変更

- `Actions` の UI スレッド移送を全部 `DispatchToView` 経由にした。各 lambda が `shared_ptr<atomic<bool>>` の生存フラグを掴むので、`Actions` 本体が window ごと消えた後でもチェック自体は安全に読める。
- フラグを下ろすのは `~MainWindow` の先頭。`RequestClose` を通らない直接 `Close()` の経路 (最後の pane の close、`CloseAllWindows`) も含めて、全 close 経路が必ず通る唯一の場所だから。
- 追加の同期は不要。フラグを下ろすのも gated lambda が走るのも UI スレッドなので、各 lambda は「window 生存中に実行済み」か「下りたフラグを見て no-op」のどちらかになる。

</details>
