### PR TITLE
Insert a dropped tab where it was dropped

### DIFF
--- a/App/MainWindow.xaml.cpp
+++ b/App/MainWindow.xaml.cpp
@@ -353,15 +353,27 @@ namespace winrt::GhosttyWin32::implementation
                 // Same-strip drops are reorders, which CanReorderTabs
                 // already handled natively.
                 if (!source || source == self.get()) return;
-                // Insert where the tab was dropped: before the first
-                // tab whose slot the pointer hasn't fully passed.
+                // Insert before the first tab whose midpoint lies
+                // right of the drop point. One coordinate space for
+                // everything: the drop position and each tab's origin
+                // are both expressed relative to the strip
+                // (TransformToVisual), instead of asking GetPosition
+                // for a fresh relative position per container — that
+                // per-container form resolved to index 0 regardless
+                // of where the drop landed, wedging the tab in first
+                // place. Past every midpoint means -1: append.
+                auto dropPos = e.GetPosition(strip);
                 int32_t index = -1;
                 auto items = strip.TabItems();
                 for (uint32_t i = 0; i < items.Size(); ++i) {
                     auto container = strip.ContainerFromIndex(i)
                         .template try_as<muxc::TabViewItem>();
                     if (!container) continue;
-                    if (e.GetPosition(container).X - container.ActualWidth() < 0) {
+                    auto origin = container.TransformToVisual(strip)
+                        .TransformPoint({ 0, 0 });
+                    float mid = origin.X
+                        + static_cast<float>(container.ActualWidth()) / 2.0f;
+                    if (dropPos.X < mid) {
                         index = static_cast<int32_t>(i);
                         break;
                     }


### PR DESCRIPTION
## Why

Dropping a tab onto another window's strip wedged it into **first place** no matter where the drop landed — dropping past the last tab did not append.

## Root cause

The insert index compared a fresh relative position per container: `e.GetPosition(container).X - container.ActualWidth() < 0`. That comparison resolved to index 0 on every drop (diagnostic logging confirmed it), so the tab always inserted at the front.

## What

The drop position and each tab's origin are now expressed in **one coordinate space — the strip's** (`e.GetPosition(strip)` once, `TransformToVisual(strip)` per tab), and the tab inserts before the first tab whose **midpoint** lies right of the drop point; past every midpoint means append. Midpoint instead of the old full-width test also means dropping on a tab's right half lands *after* it, matching how reorder previews behave.

Diagnostic-verified on hardware (drop X vs. computed index):

| drop | index | placement |
|---|---|---|
| right of a single tab | -1 | appended last |
| between two tabs | 1 | inserted between |
| right of everything | -1 | appended last |
| left half of the first tab | 0 | inserted first |

## Verification

- [x] Drop past the last tab → appended as the last tab
- [x] Drop between two tabs → inserted at that position
- [x] Drop on the first tab's left half → inserted first
- [x] Torn-out / merged tab keeps its content and input focus works

<details>
<summary>日本語</summary>

## 症状

別 window の tab strip にタブを drop すると、どこに落としても**先頭**に挿入されていた。最後のタブより右に落としても末尾に追加されない。

## 原因

挿入位置の計算が、タブごとに `e.GetPosition(container).X - ActualWidth() < 0` という「そのタブ相対の位置」を毎回取り直す形だった。この比較が drop 位置に関係なく index 0 で成立していた (診断ログで確認)。

## 変更

drop 位置とタブの位置を **strip 座標系ひとつ**に揃えた。drop 位置は `e.GetPosition(strip)` で 1 回だけ取り、各タブの原点は `TransformToVisual(strip)` で同じ空間に変換する。挿入先は「drop 点より右に**中点**がある最初のタブの前」。全部の中点を過ぎていたら末尾に追加する。全幅ではなく中点で判定するので、タブの右半分に落とすとその次に入る (reorder のプレビューと同じ感覚)。

</details>