### PR TITLE
Anchor release notes at the newest ancestor tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,16 +97,29 @@ jobs:
           "msix_path=$renamed" >> $env:GITHUB_OUTPUT
 
       # Pick the previous tag to anchor the auto-generated changelog
-      # against. GitHub's default is "most recent semver tag", which
-      # bundles RC iteration noise into the production release notes
-      # and ignores production lineage when the next release skips a
-      # version. Make the choice explicit instead:
+      # against: the highest-versioned release tag that is an ANCESTOR
+      # of the commit being released.
       #
-      #   vX.Y.Z-rc1     -> latest production tag (e.g. v0.2.2)
-      #   vX.Y.Z-rcN>1   -> previous RC of the same base (vX.Y.Z-rc(N-1))
-      #   vX.Y.Z         -> latest production tag (excluding self)
+      # Ancestry is the property that actually matters. GitHub's
+      # changelog generation lists the PRs attached to commits the
+      # anchor cannot reach, so an anchor that only exists on `main`
+      # (a production tag that was never ours-merged back into `dev`)
+      # can't reach any of dev's PR-merge history and the notes
+      # explode to every PR since the branches diverged — issue #139;
+      # v0.5.0-rc1 anchored at v0.4.2 listed 58 PRs instead of 13,
+      # and the v0.4.x production notes were silently wrong the same
+      # way. Version order alone can't distinguish the good anchors
+      # (tags reachable from the release commit) from the bad ones.
       #
-      # If no suitable baseline exists, leave it empty and let GitHub
+      # The ancestor rule reproduces the intent of the old per-case
+      # rules by construction:
+      #   vX.Y.Z-rcN  -> previous RC on dev, or a production tag that
+      #                  the post-release sync recorded into dev
+      #   vX.Y.Z      -> previous production tag (RC tags live on dev
+      #                  and are not ancestors of main, so they're
+      #                  skipped without a special case)
+      #
+      # If no ancestor tag exists, leave it empty and let GitHub
       # decide (first-release bootstrap case).
       - name: Determine previous tag for changelog
         id: prev
@@ -116,41 +129,22 @@ jobs:
           REF_NAME: ${{ github.ref_name }}
         run: |
           set -euo pipefail
+          # The checkout above is shallow and tagless; ancestry checks
+          # need the full graph.
+          git fetch --quiet --unshallow --tags origin 2>/dev/null \
+            || git fetch --quiet --tags origin
           prev=""
-          if [[ "$REF_NAME" =~ ^v([0-9]+\.[0-9]+\.[0-9]+)-rc([0-9]+)$ ]]; then
-            base="${BASH_REMATCH[1]}"
-            rc_num="${BASH_REMATCH[2]}"
-            if [[ "$rc_num" -gt 1 ]]; then
-              # RC2+ of the same base: anchor at the previous RC of that
-              # same base so the diff covers only the RC-to-RC delta.
-              prev=$(gh release list --limit 100 --json tagName \
-                --jq ".[] | .tagName | select(startswith(\"v${base}-rc\"))" \
-                | grep -vx "$REF_NAME" | sort -V | tail -1 || true)
+          while read -r tag; do
+            if git merge-base --is-ancestor "$tag" HEAD 2>/dev/null; then
+              prev="$tag"
+              break
             fi
-            if [[ -z "$prev" ]]; then
-              # RC1 (or no earlier RC of the same base): anchor at the
-              # tag immediately before this one in version order,
-              # regardless of whether it's an RC or production tag.
-              # Anchoring blindly at the latest production tag loses
-              # every RC tag that landed in between (e.g. v0.3.1-rc1
-              # against v0.2.2 instead of v0.3.0-rcN — the v0.3.1-rc1
-              # release notes regression).
-              #
-              # Implementation: collect all release tags, splice in the
-              # current ref name so sort -V positions it correctly,
-              # then walk forward and remember the line that immediately
-              # precedes it.
-              prev=$(
-                (gh release list --limit 100 --json tagName --jq '.[] | .tagName'; echo "$REF_NAME") \
-                | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+(-rc[0-9]+)?$' \
-                | sort -V \
-                | awk -v cur="$REF_NAME" '$0 == cur { exit } { last = $0 } END { print last }'
-              )
-            fi
-          elif [[ "$REF_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            prev=$(gh release list --limit 100 --json tagName,isPrerelease \
-              --jq "[.[] | select(.isPrerelease == false and .tagName != \"$REF_NAME\") | .tagName] | first // \"\"")
-          fi
+          done < <(
+            gh release list --limit 100 --json tagName --jq '.[] | .tagName' \
+              | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+(-rc[0-9]+)?$' \
+              | grep -vx "$REF_NAME" \
+              | sort -V -r
+          )
           echo "tag=$prev" >> "$GITHUB_OUTPUT"
           echo "Previous tag selected: ${prev:-<none>}"
 


### PR DESCRIPTION
Closes #139.

## Why

The changelog anchor was picked by version order alone, so it could land on a tag that only exists on `main` (a production tag never ours-merged back into `dev`). GitHub's changelog generation lists the PRs the anchor cannot reach, and a main-only anchor reaches none of dev's PR-merge history — so the notes exploded to every PR since the branches diverged. Evidence matrix in #139: v0.5.0-rc1 listed 58 PRs instead of 13, and the v0.4.x production notes were silently wrong the same way, while every dev-anchored release was clean.

## What

One rule replaces the three per-case rules: walk released tags in descending version order and take the **first one that is an ancestor of the commit being released**.

- RC tags anchor at the previous RC on dev, or at a production tag the post-release sync (#121) recorded into dev — whichever is reachable.
- Production tags skip dev-only RC tags naturally (they are not ancestors of main), landing on the previous production tag with no special case.
- No ancestor tag at all → empty anchor, GitHub decides (bootstrap).

The step now fetches tags and unshallows the checkout, because ancestry checks need the graph the shallow clone lacks.

## Verification plan

Exercised by the next release (v0.5.1 per plan):

- [ ] RC tag on dev → anchor resolves to the previous ancestor tag (log line `Previous tag selected:`), notes list only the delta
- [ ] Production tag on main → anchor resolves to the previous production tag, RC tags skipped
- [ ] Notes contain no PRs that shipped in earlier releases

<details>
<summary>日本語</summary>

## 原因

changelog の anchor を version 順だけで選んでいたので、`main` にしか存在しないタグ (dev に ours-merge されていない production タグ) が anchor になることがあった。GitHub のノート生成は「anchor から辿れないコミット」の PR を列挙するため、main 専用の anchor からは dev の PR マージ履歴が一切辿れず、分岐以来の全 PR がノートに出ていた。v0.5.0-rc1 は 13 PR のはずが 58 PR、v0.4.x の production ノートも同じ形で壊れていた (dev 上のタグを anchor にしたリリースだけが正常だった)。

## 変更

3 つの場合分けを 1 つのルールに置き換えた: リリース済みタグを version 降順に走査して、**リリース対象コミットの祖先である最初のタグ**を anchor にする。

- RC は dev 上の直前 RC、または post-release sync (#121) で dev に記録された production タグに落ちる
- production は dev 専用の RC タグを自然にスキップして直前の production に落ちる (main の祖先ではないため。特別扱い不要)
- 祖先タグが 1 つも無ければ空にして GitHub 任せ (bootstrap)

shallow checkout には祖先判定に必要な履歴が無いので、このステップで tags 込みの fetch + unshallow を行うようにした。

検証は次のリリース (v0.5.1 予定) で実施する。

</details>