### PR TITLE
Add a dedicated ASan build configuration

### DIFF
--- a/App/App.vcxproj
+++ b/App/App.vcxproj
@@ -66,6 +66,11 @@
       <Configuration>Release</Configuration>
       <Platform>ARM64</Platform>
     </ProjectConfiguration>
+    <!-- ASan = Debug + /fsanitize=address; see Directory.Build.props. -->
+    <ProjectConfiguration Include="ASan|x64">
+      <Configuration>ASan</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
@@ -76,6 +81,11 @@
   <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">
     <UseDebugLibraries>true</UseDebugLibraries>
     <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)'=='ASan'" Label="Configuration">
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <!-- ASan does not support incremental linking. -->
+    <LinkIncremental>false</LinkIncremental>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Release'" Label="Configuration">
     <UseDebugLibraries>false</UseDebugLibraries>
@@ -112,7 +122,7 @@
       <AdditionalDependencies>ghostty-internal.lib;d3d11.lib;dxgi.lib;comctl32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">
+  <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug' or '$(Configuration)'=='ASan'">
     <ClCompile>
       <!--
         DISABLE_XAML_GENERATED_MAIN suppresses the wWinMain stub
@@ -232,6 +242,18 @@
     -->
     <None Include="..\external\ghostty\zig-out\lib\ghostty-internal.dll">
       <Link>ghostty.dll</Link>
+      <DeploymentContent>true</DeploymentContent>
+    </None>
+  </ItemGroup>
+  <ItemGroup Condition="'$(Configuration)'=='ASan'">
+    <!--
+      The ASan runtime is a DLL and the loader must find it next to
+      the EXE. VS copies it into OutDir for plain desktop apps, but
+      the MSIX layout only picks up declared content — an F5 packaged
+      run would die at startup with STATUS_DLL_NOT_FOUND without this.
+      x64 hardcoded: the ASan configuration only exists for x64.
+    -->
+    <None Include="$(VCToolsInstallDir)bin\Hostx64\x64\clang_rt.asan_dynamic-x86_64.dll">
       <DeploymentContent>true</DeploymentContent>
     </None>
   </ItemGroup>

--- a/Core/Core.vcxproj
+++ b/Core/Core.vcxproj
@@ -9,6 +9,11 @@
       <Configuration>Release</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
+    <!-- ASan = Debug + /fsanitize=address; see Directory.Build.props. -->
+    <ProjectConfiguration Include="ASan|x64">
+      <Configuration>ASan</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <VCProjectVersion>17.0</VCProjectVersion>
@@ -24,7 +29,7 @@
     <PlatformToolset>v145</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' or '$(Configuration)|$(Platform)'=='ASan|x64'" Label="Configuration">
     <UseDebugLibraries>true</UseDebugLibraries>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
@@ -62,7 +67,7 @@
       <PreprocessorDefinitions>_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' or '$(Configuration)|$(Platform)'=='ASan|x64'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <!--
+    The ASan configuration (Debug + /fsanitize=address) is defined
+    by exactly one property, here, so every project in the solution
+    agrees on it — mixing instrumented and uninstrumented objects of
+    our own code is what the ASan docs warn against, and per-config
+    IntDir/OutDir keep the instrumented tree (x64\ASan\) fully
+    separate from the daily Debug tree. See docs/ASAN.md.
+
+    Everything else about the configuration (debug libraries, /RTC
+    removal, gtest wiring, MSIX manifest choice) lives in the
+    projects that own those concerns.
+  -->
+  <PropertyGroup Condition="'$(Configuration)'=='ASan'">
+    <EnableASAN>true</EnableASAN>
+  </PropertyGroup>
+</Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <!--
+    Flag repairs for the ASan configuration (see
+    Directory.Build.props). This file is evaluated after each
+    project's own ItemDefinitionGroups, so these settings win the
+    metadata merge over the Debug settings the ASan configuration
+    inherits by or-condition:
+
+    - /RTC1 (Tests sets EnableFastChecks in Debug) is a hard
+      compiler error together with ASan (D8016).
+    - /ZI (edit-and-continue) is unsupported under ASan; /Zi keeps
+      full PDB info so reports resolve to file:line.
+  -->
+  <ItemDefinitionGroup Condition="'$(Configuration)'=='ASan'">
+    <ClCompile>
+      <BasicRuntimeChecks>Default</BasicRuntimeChecks>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+    </ClCompile>
+  </ItemDefinitionGroup>
+</Project>

--- a/GhosttyWin32.slnx
+++ b/GhosttyWin32.slnx
@@ -1,5 +1,14 @@
 <Solution>
   <Configurations>
+    <!--
+      ASan = Debug + /fsanitize=address, x64 only (defined in the
+      vcxprojs; the switch lives in Directory.Build.props). Declaring
+      any BuildType replaces the implicit Debug/Release pair, so all
+      three are spelled out.
+    -->
+    <BuildType Name="ASan" />
+    <BuildType Name="Debug" />
+    <BuildType Name="Release" />
     <Platform Name="ARM64" />
     <Platform Name="x64" />
     <Platform Name="x86" />

--- a/Package/Package.wapproj
+++ b/Package/Package.wapproj
@@ -28,6 +28,11 @@
       <Configuration>Release</Configuration>
       <Platform>ARM64</Platform>
     </ProjectConfiguration>
+    <!-- ASan = Debug + /fsanitize=address; see Directory.Build.props. -->
+    <ProjectConfiguration Include="ASan|x64">
+      <Configuration>ASan</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup>
     <WapProjPath Condition="'$(WapProjPath)'==''">$(MSBuildExtensionsPath)\Microsoft\DesktopBridge\</WapProjPath>
@@ -48,30 +53,33 @@
   <!--
     Manifest per configuration.
 
-    Debug|* → Package.Debug.appxmanifest (Identity Name ends in ".Dev",
-      distinct DisplayName + toast CLSID). Lets an F5-registered debug
-      loose install coexist with an installed production MSIX on the
-      same machine instead of tripping 0x80073cfb every round.
-
     Release|* → Package.appxmanifest (the production identity CI signs
       and ships). Every CI channel — dev-build / RC / production —
       builds Release, so this is what ends up in every MSIX we publish.
 
+    Everything else (Debug, ASan) → Package.Debug.appxmanifest
+      (Identity Name ends in ".Dev", distinct DisplayName + toast
+      CLSID). Lets an F5-registered loose install coexist with an
+      installed production MSIX on the same machine instead of
+      tripping 0x80073cfb every round. Keyed on "not Release" rather
+      than listing dev configurations so a future local-only
+      configuration can't silently pick up the production identity.
+
     See the comment at the top of Package.Debug.appxmanifest for the
     fuller rationale and the two-file maintenance cost.
   -->
-  <ItemGroup Condition="'$(Configuration)'!='Debug'">
+  <ItemGroup Condition="'$(Configuration)'=='Release'">
     <AppxManifest Include="Package.appxmanifest">
       <SubType>Designer</SubType>
     </AppxManifest>
   </ItemGroup>
-  <ItemGroup Condition="'$(Configuration)'=='Debug'">
+  <ItemGroup Condition="'$(Configuration)'!='Release'">
     <AppxManifest Include="Package.Debug.appxmanifest">
       <SubType>Designer</SubType>
     </AppxManifest>
     <None Include="Package.appxmanifest" />
   </ItemGroup>
-  <ItemGroup Condition="'$(Configuration)'!='Debug'">
+  <ItemGroup Condition="'$(Configuration)'=='Release'">
     <None Include="Package.Debug.appxmanifest" />
   </ItemGroup>
   <ItemGroup>

--- a/Tests/Tests.vcxproj
+++ b/Tests/Tests.vcxproj
@@ -17,6 +17,11 @@
       <Configuration>Release</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
+    <!-- ASan = Debug + /fsanitize=address; see Directory.Build.props. -->
+    <ProjectConfiguration Include="ASan|x64">
+      <Configuration>ASan</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{265c76cb-58a2-4632-b6fe-ec5093b04d10}</ProjectGuid>
@@ -59,7 +64,7 @@
       <SubSystem>Console</SubSystem>
     </Link>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' or '$(Configuration)|$(Platform)'=='ASan|x64'">
     <ClCompile>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
@@ -83,6 +88,28 @@
       -->
       <AdditionalLibraryDirectories>$(ProjectDir)..\external\ghostty\zig-out\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalDependencies>ghostty-internal.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <PropertyGroup Condition="'$(Configuration)'=='ASan'">
+    <!-- ASan does not support incremental linking. -->
+    <LinkIncremental>false</LinkIncremental>
+    <!--
+      The googletest package targets pick the gtest flavor by
+      configuration NAME ('Debug' vs everything else), so under
+      "ASan" they would inject the Release gtest (/MD) into our
+      /MDd build and the link would fail with runtime-library
+      mismatches. Force the package's injection off and hand-wire
+      the Debug flavor below instead.
+    -->
+    <Force-Disable-Microsoft-googletest-v140-windesktop-msvcstl-static-rt-dyn>true</Force-Disable-Microsoft-googletest-v140-windesktop-msvcstl-static-rt-dyn>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='ASan|x64'">
+    <ClCompile>
+      <!-- Hand-wired replacement for the disabled gtest targets. -->
+      <AdditionalIncludeDirectories>$(ProjectDir)..\packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.1.8.1.8\build\native\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies>$(ProjectDir)..\packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.1.8.1.8\lib\native\v140\windesktop\msvcstl\static\rt-dyn\x64\Debug\gtestd.lib;$(ProjectDir)..\packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.1.8.1.8\lib\native\v140\windesktop\msvcstl\static\rt-dyn\x64\Debug\gtest_maind.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -129,6 +156,7 @@
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='ASan|x64'">Create</PrecompiledHeader>
     </ClCompile>
     <ClCompile Include="test_ime_buffer.cpp" />
     <ClCompile Include="test_key_modifiers.cpp" />
@@ -171,6 +199,19 @@
     next to the test EXE after every build so direct execution
     (and Test Explorer's runner) finds it.
   -->
+  <!--
+    The ASan runtime is a DLL and the loader must find it next to
+    the EXE, but the build does NOT copy it to OutDir automatically
+    (verified: Tests.exe failed to start with "clang_rt.asan_
+    dynamic-x86_64.dll not found", which also left Test Explorer's
+    discovery silently empty). Copy it ourselves, same pattern as
+    the ghostty.dll copy below.
+  -->
+  <Target Name="CopyAsanRuntimeToOutput" AfterTargets="Build" Condition="'$(Configuration)'=='ASan'">
+    <Copy SourceFiles="$(VCToolsInstallDir)bin\Hostx64\x64\clang_rt.asan_dynamic-x86_64.dll"
+          DestinationFolder="$(OutDir)"
+          SkipUnchangedFiles="true" />
+  </Target>
   <Target Name="CopyGhosttyDllToOutput" AfterTargets="Build">
     <!--
       The on-disk artifact is ghostty-internal.dll but the import

--- a/docs/ASAN.md
+++ b/docs/ASAN.md
@@ -1,0 +1,69 @@
+# AddressSanitizer builds
+
+The `ASan` solution configuration is Debug plus `/fsanitize=address`, for local stress verification. The bug classes that have actually bitten this port — use-after-free around config replacement (#133), heap over-reads at the Zig/C boundary (i999rri/ghostty#38) — are runtime lifetime/size bugs. Without instrumentation they only crash when the bad access happens to cross an unmapped page; under ASan the first bad access stops the debugger at the exact allocation, free, and access stacks.
+
+<details>
+<summary>日本語</summary>
+
+`ASan` ソリューション構成は Debug + `/fsanitize=address`。ローカルの stress 検証用。この port で実際に踏んできたバグ — config 差し替え周りの use-after-free (#133)、Zig/C 境界の heap over-read (i999rri/ghostty#38) — は実行時の lifetime / サイズ契約のバグで、非計装ビルドでは不正アクセスが未マップページを跨いだときしかクラッシュしない。ASan なら最初の不正アクセスの時点で、確保・解放・アクセスそれぞれのスタック付きでデバッガが止まる。
+
+</details>
+
+## Using it
+
+1. Pick **`ASan | x64`** in the VS configuration dropdown.
+2. Build and run as usual — F5 (Package project) for the app, `Tests.exe` / Test Explorer for the tests.
+
+Reports appear on stderr and in the VS Output window; under the debugger, execution breaks at the faulting access with full stacks. ASan is silent while nothing is wrong — no output means no bad access on the paths you exercised.
+
+Outputs live in their own tree (`x64\ASan\`), fully separate from `x64\Debug\`, so switching back and forth is just the dropdown — no Rebuild discipline, and instrumented objects can never mix into a normal build. Expect roughly 2x slowdown and higher memory use, and one full build the first time.
+
+<details>
+<summary>日本語</summary>
+
+1. VS の構成ドロップダウンで **`ASan | x64`** を選ぶ。
+2. あとはいつも通りビルド・実行 — アプリは F5 (Package プロジェクト)、テストは `Tests.exe` / Test Explorer。
+
+レポートは stderr と VS の出力ウインドウに出る。デバッガ接続中は問題のアクセスの箇所でフルスタック付きでブレークする。ASan は問題がない間は完全に沈黙する — 何も出ない = 実行した経路に不正アクセスがなかった、ということ。
+
+成果物は専用ツリー (`x64\ASan\`) に入り `x64\Debug\` とは完全に分離されるので、切り替えはドロップダウンだけ — Rebuild の運用規律は不要で、計装済み obj が通常ビルドに混ざることは構造的に起きない。速度はおよそ 2 倍遅く、メモリも増える。初回だけフルビルドが走る。
+
+</details>
+
+## What it does / doesn't cover
+
+- Covered: all heap accesses made by our own code (App, Core, Tests) — use-after-free, buffer over/under-flow, double-free.
+- Not covered: `ghostty.dll` internals. The DLL is built by Zig and is not instrumented; allocations made inside it are not shadow-tracked. Host-side misuse of pointers the DLL hands out is still caught at the access site.
+- Not covered: memory leaks. MSVC's ASan does not support leak detection (LSan); the D3D debug layer's live-object dump at exit is the only leak-ish signal in this build.
+- Not covered: data races — that is TSan territory, which MSVC does not ship.
+
+<details>
+<summary>日本語</summary>
+
+- カバーされる: 自前コード (App / Core / Tests) の全ヒープアクセス — use-after-free、buffer over/under-flow、double-free。
+- カバーされない: `ghostty.dll` の内部。DLL は Zig ビルドで非計装なので、DLL 内部の確保は shadow 追跡されない。ただし DLL が返したポインタをホスト側で誤用した場合は、アクセスの時点で捕まる。
+- カバーされない: メモリリーク。MSVC の ASan は leak 検出 (LSan) 非対応。このビルドでリークらしき兆候が見えるのは終了時の D3D debug layer の live-object ダンプだけ。
+- カバーされない: データ競合。それは TSan の領分で、MSVC には無い。
+
+</details>
+
+## How it's wired
+
+- `Directory.Build.props` sets `EnableASAN` for the `ASan` configuration — the single place that defines what the configuration means. `Directory.Build.targets` removes `/RTC1` and forces `/Zi`, which conflict with ASan.
+- The projects declare `ASan|x64` as a twin of `Debug|x64` (or-conditions on the Debug groups), so ASan inherits Debug semantics (`/MDd`, `_DEBUG`, asserts) automatically.
+- The ASan runtime DLL (`clang_rt.asan_dynamic-x86_64.dll`) is deployed explicitly: as MSIX content in `App.vcxproj`, and by a copy target in `Tests.vcxproj` — the build does not put it next to the EXE on its own, and without it the EXE dies at startup (Test Explorer discovery then shows an empty list with no error).
+- `Tests.vcxproj` hand-wires the Debug gtest libs because the googletest package targets pick the flavor by configuration name (`'Debug'` vs everything else) and would inject the Release ones.
+- `Package.wapproj` keys the production appxmanifest on `Release` only, so ASan F5 runs use the `.Dev` identity like Debug does.
+- Release and CI are untouched; the ASan configuration is never built there.
+
+<details>
+<summary>日本語</summary>
+
+- `Directory.Build.props` が `ASan` 構成に `EnableASAN` を設定する — 構成の意味を定義する唯一の場所。`Directory.Build.targets` は ASan と衝突する `/RTC1` を外し `/Zi` を強制する。
+- 各プロジェクトは `ASan|x64` を `Debug|x64` の双子として宣言 (Debug グループへの or 条件) しているので、Debug の意味論 (`/MDd`、`_DEBUG`、assert 有効) を自動で引き継ぐ。
+- ASan ランタイム DLL (`clang_rt.asan_dynamic-x86_64.dll`) は明示的に配置している: `App.vcxproj` では MSIX content として、`Tests.vcxproj` では copy target で。ビルドは自動では EXE の隣に置いてくれず、ないと EXE が起動時に死ぬ (そのとき Test Explorer の discovery はエラーなしの空一覧になる)。
+- `Tests.vcxproj` は Debug 版 gtest を手動配線している。googletest package の targets は構成名 (`'Debug'` かそれ以外か) で lib を選ぶため、ASan 構成には Release 版が注入されてしまうから。
+- `Package.wapproj` は production appxmanifest を `Release` のみに限定したので、ASan の F5 実行は Debug と同じ `.Dev` identity を使う。
+- Release と CI には一切影響しない。ASan 構成がそこでビルドされることはない。
+
+</details>


### PR DESCRIPTION
## Why

The bug classes that have actually bitten this port — the config-replace use-after-free (#133) and the heap over-read at the Zig/C boundary (i999rri/ghostty#38) — are runtime lifetime/size bugs. Static analysis can't see them, and an uninstrumented build only crashes when the bad access happens to cross an unmapped page, which is why both took long stress sessions to even reproduce. This replaces the "introduce /analyze" backlog item with something aimed at the bugs we actually get.

<details>
<summary>日本語</summary>

この port で実際に踏んだバグ — config 差し替えの use-after-free (#133)、Zig/C 境界の heap over-read (i999rri/ghostty#38) — は実行時の lifetime / サイズ契約バグ。静的解析には見えないし、非計装ビルドでは不正アクセスが未マップページを跨いだときしか落ちないから、再現だけで長い stress セッションが必要だった。バックログの「/analyze 導入」をこれに置き換える。

</details>

## What

A dedicated **`ASan | x64`** solution configuration: Debug + `/fsanitize=address`. Pick it in the dropdown, build, F5 — that's the whole workflow (see `docs/ASAN.md`).

- `Directory.Build.props` (new) — the single place that defines what the configuration means: `EnableASAN=true` when `Configuration=='ASan'`.
- `Directory.Build.targets` (new) — evaluated after each project's own settings; drops `/RTC1` (hard compiler error D8016 together with ASan; Tests sets it in Debug) and forces `/Zi`.
- `App` / `Core` / `Tests` vcxproj — declare `ASan|x64` as a twin of `Debug|x64` via or-conditions on the existing Debug groups, so ASan inherits Debug semantics (`/MDd`, `_DEBUG`, asserts) without duplicating them.
- `App.vcxproj` — under ASan, deploys `clang_rt.asan_dynamic-x86_64.dll` as MSIX content so a packaged F5 run doesn't die at startup with STATUS_DLL_NOT_FOUND.
- `Tests.vcxproj` — a copy target puts the same runtime DLL next to `Tests.exe`. The build does not deploy it on its own (verified: without it the EXE can't start, and Test Explorer's discovery comes up silently empty).
- `GhosttyWin32.slnx` — declares the three BuildTypes (declaring any replaces the implicit Debug/Release pair).
- `docs/ASAN.md` — usage, coverage notes (ghostty.dll is Zig-built and uninstrumented; host-side misuse of its pointers is still caught), wiring notes.

<details>
<summary>日本語</summary>

専用ソリューション構成 **`ASan | x64`** を追加: Debug + `/fsanitize=address`。ドロップダウンで選んでビルドして F5、それだけ (`docs/ASAN.md` 参照)。

- `Directory.Build.props` (新規) — 構成の意味を定義する唯一の場所: `Configuration=='ASan'` のとき `EnableASAN=true`
- `Directory.Build.targets` (新規) — 各プロジェクト自身の設定より後に評価され、ASan と衝突する `/RTC1` (D8016 でコンパイルエラー。Tests が Debug で設定) を落とし `/Zi` を強制
- `App` / `Core` / `Tests` の vcxproj — 既存 Debug グループへの or 条件で `ASan|x64` を `Debug|x64` の双子として宣言。Debug の意味論 (`/MDd`、`_DEBUG`、assert 有効) を重複なしで引き継ぐ
- `App.vcxproj` — ASan では `clang_rt.asan_dynamic-x86_64.dll` を MSIX content として配置。これがないと packaged F5 が起動時に STATUS_DLL_NOT_FOUND で死ぬ
- `Tests.vcxproj` — 同じランタイム DLL を `Tests.exe` の隣に置く copy target を追加。ビルドは自動では配置してくれない (実測: ないと EXE が起動できず、Test Explorer の discovery が静かに空になる)
- `GhosttyWin32.slnx` — BuildType 3 つを宣言 (1 つでも宣言すると暗黙の Debug/Release ペアが置き換わるため)
- `docs/ASAN.md` — 使い方、カバー範囲 (ghostty.dll は Zig ビルドで非計装。ただしホスト側での誤用はアクセス時点で捕まる)、配線メモ

</details>

## Technical Decisions

Two package-side branches key on the configuration *name* `'Debug'` and needed explicit handling — these are exactly why the first iteration of this PR avoided a dedicated configuration; handling them head-on is the correct fix:

- **googletest targets** pick the gtest flavor by `'$(Configuration)'=='Debug'`, so under `ASan` they would inject the Release gtest (/MD) into our /MDd build and the link would fail with runtime-library mismatches. `Tests.vcxproj` force-disables the package's injection for ASan and hand-wires the Debug `gtestd.lib` / `gtest_maind.lib` + include dir.
- **`Package.wapproj`** chose the production appxmanifest for everything that isn't `'Debug'`, which would give ASan F5 runs the production identity and collide with an installed MSIX (0x80073cfb). The conditions are now keyed on `Release` only — production identity ships exclusively from Release (which is all CI ever builds), everything else gets the `.Dev` identity.

Why a configuration instead of the earlier env-var toggle: per-config IntDir/OutDir put instrumented artifacts in their own `x64\ASan\` tree, so they can never mix into a normal build, no Rebuild discipline is needed, and the active state is visible in the dropdown instead of hiding in the environment.

CI and Release are unaffected — the ASan configuration is simply never built there.

<details>
<summary>日本語</summary>

構成*名* `'Debug'` で分岐する package 側の箇所が 2 つあり、明示対応した — この 2 つがまさに最初の案で専用構成を避けた理由で、正面から対処するのが正しい修正:

- **googletest の targets** は `'$(Configuration)'=='Debug'` で gtest の flavor を選ぶため、`ASan` 構成には Release 版 gtest (/MD) が注入され、/MDd ビルドとランタイム不一致でリンクが失敗する。`Tests.vcxproj` で ASan のときだけ package の注入を force-disable し、Debug 版 `gtestd.lib` / `gtest_maind.lib` と include dir を手動配線した
- **`Package.wapproj`** は `'Debug'` 以外すべてに production appxmanifest を選んでいたので、ASan の F5 が production identity になり、インストール済み MSIX と衝突する (0x80073cfb)。条件を `Release` のみに変更 — production identity は Release (CI がビルドするのはこれだけ) 専用になり、それ以外は `.Dev` identity を使う

env var トグル案から構成に変えた理由: 構成ごとの IntDir/OutDir で計装済み成果物が専用の `x64\ASan\` ツリーに分離されるため、通常ビルドへの混入が構造的に起きず、Rebuild の運用規律も不要で、いま何をビルドしているかがドロップダウンに見える。

CI と Release には影響なし — ASan 構成がそこでビルドされることはない。

</details>

## Verification (build is on you, per usual)

- [x] `Debug | x64`: builds and runs exactly as before
- [x] `ASan | x64`: full build succeeds (first build of the new tree)
- [x] `Tests.exe` (from `x64\ASan\`) runs green under ASan — verified locally, 125/125 passed
- [x] F5 (Package) on `ASan | x64`: app starts with the `.Dev` identity, opens a couple of tabs/splits, no startup DLL error
- [x] Optional sanity check that ASan is alive: any known-bad access should break in the debugger with alloc/free/access stacks
- [x] `Release | x64` still builds (manifest-condition change is the only thing that touches it)

<details>
<summary>日本語</summary>

検証 (ビルドはいつも通りそちらで):

- `Debug | x64`: 従来通りビルド・動作する
- `ASan | x64`: フルビルドが通る (新ツリーの初回ビルド)
- `x64\ASan\` の `Tests.exe` が ASan 下で green — ローカル確認済み、125/125 pass
- `ASan | x64` で F5 (Package): `.Dev` identity で起動し、タブ / split をいくつか開ける。起動時 DLL エラーなし
- 任意: ASan が生きている確認として、既知の不正アクセスを踏むと alloc / free / access のスタック付きでブレークする
- `Release | x64` のビルドが通る (触っているのはマニフェスト条件の変更だけ)

</details>
