### PR TITLE
Show the hovered link URL in a pane-corner banner

### DIFF
--- a/App/MainWindow.xaml.cpp
+++ b/App/MainWindow.xaml.cpp
@@ -1610,6 +1610,19 @@ namespace winrt::GhosttyWin32::implementation
         }
     }
 
+    void MainWindow::SetHoveredLinkForSurface(ghostty_surface_t surface,
+                                              std::wstring url)
+    {
+        // Same owning-leaf routing as SetCursorShapeForSurface: the
+        // pointer can hover a link in a non-active pane, and the
+        // banner belongs to the pane the link lives in.
+        auto lookup = m_tabs.FindPaneBySurface(surface);
+        if (!lookup.pane) return;
+        if (auto* tc = Tab::PaneToTerminalControl(*lookup.pane)) {
+            tc->SetHoveredLink(winrt::hstring{ url });
+        }
+    }
+
     void MainWindow::ReplaceConfig(ghostty_config_t cloned)
     {
         m_ghosttyApp->ReplaceConfig(cloned);

--- a/App/MainWindow.xaml.h
+++ b/App/MainWindow.xaml.h
@@ -134,6 +134,8 @@ namespace winrt::GhosttyWin32::implementation
         void ApplyBackgroundColor(uint8_t r, uint8_t g, uint8_t b) override;
         void SetCursorShapeForSurface(ghostty_surface_t surface,
                                       ghostty_action_mouse_shape_e shape) override;
+        void SetHoveredLinkForSurface(ghostty_surface_t surface,
+                                      std::wstring url) override;
         void ReplaceConfig(ghostty_config_t cloned) override;
         void ReloadConfig(bool soft) override;
         void ShowDesktopNotification(ghostty_surface_t surface,

--- a/App/TerminalControl.xaml
+++ b/App/TerminalControl.xaml
@@ -28,5 +28,26 @@
         <Rectangle x:Name="UnfocusedDim"
                    IsHitTestVisible="False"
                    Visibility="Collapsed" />
+        <!--
+          Hovered-link banner (issue #61). Mirrors upstream's bottom-
+          corner URL display (macOS URLHoverBanner / GTK mouse-hover-url
+          label) instead of a popup: the original Win32 TOPMOST tooltip
+          over the DComp surface crashed the process on URL click, while
+          an in-tree, hit-test-transparent sibling cannot interfere with
+          input routing by construction.
+        -->
+        <Border x:Name="LinkBanner"
+                IsHitTestVisible="False"
+                Visibility="Collapsed"
+                HorizontalAlignment="Left"
+                VerticalAlignment="Bottom"
+                CornerRadius="0,6,0,0"
+                Padding="8,4,8,4"
+                Background="{ThemeResource SolidBackgroundFillColorSecondaryBrush}">
+            <TextBlock x:Name="LinkBannerText"
+                       FontSize="12"
+                       TextTrimming="CharacterEllipsis"
+                       Foreground="{ThemeResource TextFillColorPrimaryBrush}" />
+        </Border>
     </Grid>
 </UserControl>

--- a/App/TerminalControl.xaml.cpp
+++ b/App/TerminalControl.xaml.cpp
@@ -320,6 +320,18 @@ namespace winrt::GhosttyWin32::implementation
         }
     }
 
+    void TerminalControl::SetHoveredLink(winrt::hstring const& url)
+    {
+        auto banner = LinkBanner();
+        if (!banner) return;
+        if (url.empty()) {
+            banner.Visibility(winrt::Microsoft::UI::Xaml::Visibility::Collapsed);
+            return;
+        }
+        LinkBannerText().Text(url);
+        banner.Visibility(winrt::Microsoft::UI::Xaml::Visibility::Visible);
+    }
+
     void TerminalControl::ApplyFocusVisual(bool focused)
     {
         auto dim = UnfocusedDim();

--- a/App/TerminalControl.xaml.h
+++ b/App/TerminalControl.xaml.h
@@ -174,6 +174,12 @@ namespace winrt::GhosttyWin32::implementation
         // borders, etc.
         void SetCursorShape(ghostty_action_mouse_shape_e shape);
 
+        // Show the hovered-link banner with `url`, or hide it when
+        // `url` is empty. UI thread only — the caller dispatches from
+        // the renderer thread. See the LinkBanner comment in the XAML
+        // for why this is an in-tree overlay and not a popup (#61).
+        void SetHoveredLink(winrt::hstring const& url);
+
         // Set the callback that fires when this control receives
         // keyboard focus. Passed the underlying ghostty surface so
         // the host can update its "currently focused surface"

--- a/Core/Ghostty/Actions/Actions.cpp
+++ b/Core/Ghostty/Actions/Actions.cpp
@@ -351,6 +351,21 @@ bool Actions::OnMouseShape(ghostty_surface_t surface,
     return true;
 }
 
+bool Actions::OnMouseOverLink(ghostty_surface_t surface,
+                              ghostty_action_mouse_over_link_s link) {
+    if (!surface) return true;
+    // The url field is NOT NUL-terminated — len bounds it. len == 0
+    // means the pointer left the link; the empty string flows through
+    // so the view hides the banner.
+    std::wstring wide;
+    if (link.url && link.len > 0)
+        wide = interop::Encoding::toUtf16(link.url, static_cast<int>(link.len));
+    DispatchToView([this, surface, wide = std::move(wide)]() mutable {
+        m_view.SetHoveredLinkForSurface(surface, std::move(wide));
+    });
+    return true;
+}
+
 bool Actions::OnReloadConfig(bool soft) {
     // The view-side implementation handles thread placement
     // (soft re-uses UI thread, hard spins a 4MB-stack worker

--- a/Core/Ghostty/Actions/Actions.h
+++ b/Core/Ghostty/Actions/Actions.h
@@ -126,6 +126,10 @@ public:
     bool OnColorChange(ghostty_action_color_change_s cc);
     bool OnMouseShape(ghostty_surface_t surface,
                       ghostty_action_mouse_shape_e shape);
+    // MOUSE_OVER_LINK: url/len payload while hovering a link, empty
+    // payload when the pointer leaves (clears the banner).
+    bool OnMouseOverLink(ghostty_surface_t surface,
+                         ghostty_action_mouse_over_link_s link);
     bool OnReloadConfig(bool soft);
     bool OnConfigChange(ghostty_config_t newCfg);
     bool OnDesktopNotification(ghostty_surface_t surface,

--- a/Core/Ghostty/CallbackDispatcher.cpp
+++ b/Core/Ghostty/CallbackDispatcher.cpp
@@ -90,6 +90,11 @@ bool CallbackDispatcher::DispatchAction(ghostty_target_s target, ghostty_action_
                 return m_actions.OnMouseShape(target.target.surface,
                                               action.action.mouse_shape);
             return false;
+        case GHOSTTY_ACTION_MOUSE_OVER_LINK:
+            if (target.tag == GHOSTTY_TARGET_SURFACE)
+                return m_actions.OnMouseOverLink(target.target.surface,
+                                                 action.action.mouse_over_link);
+            return false;
         case GHOSTTY_ACTION_RELOAD_CONFIG:
             return m_actions.OnReloadConfig(action.action.reload_config.soft);
         case GHOSTTY_ACTION_CONFIG_CHANGE:
@@ -181,11 +186,6 @@ bool CallbackDispatcher::DispatchAction(ghostty_target_s target, ghostty_action_
         case GHOSTTY_ACTION_QUIT_TIMER:
         // Cell metrics — no host-side consumer today:
         case GHOSTTY_ACTION_CELL_SIZE:
-        // MOUSE_OVER_LINK is acked while the TOOLTIPS popup is
-        // disabled (issue #61: a TTM_TRACKACTIVATE / SetWindowPos
-        // interaction with the DComp surface crashed the process
-        // on URL click); the URL click path itself still works.
-        case GHOSTTY_ACTION_MOUSE_OVER_LINK:
         // TOGGLE_BACKGROUND_OPACITY: dispatched but not yet
         // implemented — tracked in #69. (The layered-alpha approach
         // sketched in the issue body doesn't work over a flip-model

--- a/Core/Host/IWindow.h
+++ b/Core/Host/IWindow.h
@@ -176,6 +176,16 @@ struct IWindow {
     virtual void SetCursorShapeForSurface(ghostty_surface_t surface,
                                           ghostty_action_mouse_shape_e shape) = 0;
 
+    // Show or clear the hovered-link banner on the pane owning
+    // `surface`. MOUSE_OVER_LINK fires with the URL while the pointer
+    // is on a link and with an empty payload when it leaves, so an
+    // empty `url` means hide. The banner mirrors upstream's bottom-
+    // corner URL display (macOS URLHoverBanner / GTK mouse-hover-url
+    // label); issue #61 ruled out a Win32 tooltip popup — a TOPMOST
+    // window over the DComp surface crashed the process on URL click.
+    virtual void SetHoveredLinkForSurface(ghostty_surface_t surface,
+                                          std::wstring url) = 0;
+
     // Replace the GhosttyApp's stored config with `cloned`. Takes
     // ownership: the implementation is responsible for freeing it
     // when superseded. Pass a clone from CONFIG_CHANGE (ghostty

--- a/Tests/MockMainWindowView.h
+++ b/Tests/MockMainWindowView.h
@@ -164,6 +164,15 @@ struct MockMainWindowView : core::host::IWindow {
         lastCursorShape = shape;
     }
 
+    int setHoveredLinkCalls = 0;
+    ghostty_surface_t lastHoveredLinkSurface = nullptr;
+    std::wstring lastHoveredLinkUrl;
+    void SetHoveredLinkForSurface(ghostty_surface_t s, std::wstring url) override {
+        ++setHoveredLinkCalls;
+        lastHoveredLinkSurface = s;
+        lastHoveredLinkUrl = std::move(url);
+    }
+
     int replaceConfigCalls = 0;
     // Records whether the clone passed in differed from the
     // original. The production view takes ownership; the mock

--- a/Tests/test_ghostty_actions.cpp
+++ b/Tests/test_ghostty_actions.cpp
@@ -294,6 +294,41 @@ TEST(GhosttyActionsTest, OnMouseShapeIgnoresNullSurface) {
     EXPECT_EQ(view.setCursorShapeCalls, 0);
 }
 
+TEST(GhosttyActionsTest, OnMouseOverLinkForwardsLengthBoundedUrl) {
+    MockMainWindowView view;
+    Actions actions(view);
+    auto surface = FakeSurface(0xBEEF);
+    // Buffer deliberately longer than len: the url field is not
+    // NUL-terminated, so len must bound the conversion — reading to
+    // the buffer's NUL would leak the trailing bytes into the banner.
+    const char buf[] = "https://example.com/aaaaTRAILING";
+    ghostty_action_mouse_over_link_s link{ buf, 24 };
+    EXPECT_TRUE(actions.OnMouseOverLink(surface, link));
+    EXPECT_EQ(view.setHoveredLinkCalls, 1);
+    EXPECT_EQ(view.lastHoveredLinkSurface, surface);
+    EXPECT_EQ(view.lastHoveredLinkUrl, L"https://example.com/aaaa");
+}
+
+TEST(GhosttyActionsTest, OnMouseOverLinkEmptyPayloadClearsTheBanner) {
+    // len == 0 is how ghostty says "the pointer left the link" — the
+    // empty string must still reach the view so the banner hides.
+    MockMainWindowView view;
+    Actions actions(view);
+    auto surface = FakeSurface(0xBEEF);
+    ghostty_action_mouse_over_link_s link{ nullptr, 0 };
+    EXPECT_TRUE(actions.OnMouseOverLink(surface, link));
+    EXPECT_EQ(view.setHoveredLinkCalls, 1);
+    EXPECT_TRUE(view.lastHoveredLinkUrl.empty());
+}
+
+TEST(GhosttyActionsTest, OnMouseOverLinkIgnoresNullSurface) {
+    MockMainWindowView view;
+    Actions actions(view);
+    ghostty_action_mouse_over_link_s link{ "https://x", 9 };
+    EXPECT_TRUE(actions.OnMouseOverLink(nullptr, link));
+    EXPECT_EQ(view.setHoveredLinkCalls, 0);
+}
+
 // ----- config -----
 
 TEST(GhosttyActionsTest, OnReloadConfigPassesSoftFlagThrough) {

--- a/Tests/test_ghostty_callback_dispatcher.cpp
+++ b/Tests/test_ghostty_callback_dispatcher.cpp
@@ -73,13 +73,35 @@ TEST(GhosttyCallbackDispatcherTest, DisabledFeaturesAckedNotDropped) {
     MockMainWindowView view;
     auto d = CallbackDispatcher::Create(view);
 
-    // MOUSE_OVER_LINK: TOOLTIPS popup disabled per #61.
-    EXPECT_TRUE(DispatchTag(*d, GHOSTTY_ACTION_MOUSE_OVER_LINK));
     // FLOAT_WINDOW: dispatch path not understood yet, but tag
     // routes to ack so the future re-enable doesn't surprise us.
     EXPECT_TRUE(DispatchTag(*d, GHOSTTY_ACTION_FLOAT_WINDOW));
     // MOUSE_VISIBILITY: disabled per #60.
     EXPECT_TRUE(DispatchTag(*d, GHOSTTY_ACTION_MOUSE_VISIBILITY));
+}
+
+// ----- surface-targeted routing -----
+
+TEST(GhosttyCallbackDispatcherTest, MouseOverLinkRoutesToTheOwningSurface) {
+    MockMainWindowView view;
+    auto d = CallbackDispatcher::Create(view);
+
+    const char url[] = "https://example.com/x";
+    ghostty_target_s target{};
+    target.tag = GHOSTTY_TARGET_SURFACE;
+    target.target.surface = reinterpret_cast<ghostty_surface_t>(0xBEEF);
+    ghostty_action_s action{};
+    action.tag = GHOSTTY_ACTION_MOUSE_OVER_LINK;
+    action.action.mouse_over_link = { url, sizeof(url) - 1 };
+
+    EXPECT_TRUE(d->DispatchAction(target, action));
+    EXPECT_EQ(view.setHoveredLinkCalls, 1);
+    EXPECT_EQ(view.lastHoveredLinkSurface, target.target.surface);
+    EXPECT_EQ(view.lastHoveredLinkUrl, L"https://example.com/x");
+
+    // App-targeted MOUSE_OVER_LINK has no owning pane — refuse
+    // (return false) rather than silently ack.
+    EXPECT_FALSE(DispatchTag(*d, GHOSTTY_ACTION_MOUSE_OVER_LINK));
 }
 
 // ----- view-free live handlers -----


### PR DESCRIPTION
Closes #61.

## Summary

Re-enables `MOUSE_OVER_LINK` with an upstream-style banner instead of fixing the Win32 tooltip. Hovering a link shows the URL in a small rounded chip at the pane's bottom-left corner (same UX as Chrome/Edge and upstream ghostty); leaving the link hides it.

<details>
<summary>日本語</summary>

`MOUSE_OVER_LINK` を、Win32 tooltip の修正ではなく本家スタイルのバナーで再有効化する。リンクを hover すると pane 左下の小さな角丸チップに URL が出て (Chrome/Edge や本家 ghostty と同じ UX)、リンクから離れると消える。

</details>

## Why a banner, not a tooltip

The original #61 crash came from a Win32 `TOOLTIPS_CLASS` TOPMOST popup floating over the DComp surface — URL click killed the process with exit code 3. Upstream never uses a popup for this: macOS renders `URLHoverBanner` and GTK binds a `mouse-hover-url` label, both as bottom-corner overlays inside the surface. This port now does the same: the banner is an in-tree, `IsHitTestVisible="False"` sibling of the SwapChainPanel, so it cannot interfere with input routing by construction — the crash class is structurally unreachable.

Two upstream niceties are deliberately deferred: the corner-dodge (the banner hops to the bottom-right when the mouse nears it) needs the banner hit-testable, which reintroduces routing risk — worth a separate look after this lands. And WinUI has no middle-ellipsis `TextTrimming`, so long URLs truncate at the end instead of the middle.

<details>
<summary>日本語</summary>

#61 の元のクラッシュは、DComp surface の上に浮かべた Win32 `TOOLTIPS_CLASS` の TOPMOST popup が原因 (URL クリックで exit code 3)。本家はそもそも popup を使っていない — macOS は `URLHoverBanner`、GTK は `mouse-hover-url` label を、どちらも surface 内の下隅オーバーレイとして描く。この port も同じにした: バナーは SwapChainPanel の兄弟要素で `IsHitTestVisible="False"` なので、構造上 input routing に干渉できず、このクラッシュ類型には到達不能。

本家の小技 2 つは意図的に見送り: コーナー退避 (マウスが近づくとバナーが右下に逃げる) はバナーの hit-test 有効化が必要で routing リスクが戻るため、マージ後に別途検討。また WinUI の `TextTrimming` に中央省略がないため、長い URL は末尾省略になる。

</details>

## Changes

- `Core/Ghostty/CallbackDispatcher.cpp` — `MOUSE_OVER_LINK` moves from the ack list to the surface-targeted routing block (app-targeted delivery returns false; there is no owning pane).
- `Core/Ghostty/Actions/Actions.{h,cpp}` — `OnMouseOverLink`: the `url` field is **not** NUL-terminated, so the UTF-16 conversion is bounded by `len`; `len == 0` (pointer left the link) flows through as an empty string so the view hides the banner.
- `Core/Host/IWindow.h` — new `SetHoveredLinkForSurface(surface, url)`.
- `App/MainWindow.xaml.cpp` — routes to the owning leaf via `FindPaneBySurface`, same as `SetCursorShapeForSurface` (#65 lesson: the pointer can hover a non-active pane).
- `App/TerminalControl.xaml{,.h,.cpp}` — `LinkBanner` Border + `SetHoveredLink()`.
- Tests — dispatcher routing (length-bounded URL reaches the mock, app-targeted returns false), Actions (len-bounded conversion with a longer-than-len buffer, empty payload clears, null surface ignored). `DisabledFeaturesAckedNotDropped` no longer lists `MOUSE_OVER_LINK`.

<details>
<summary>日本語</summary>

- `Core/Ghostty/CallbackDispatcher.cpp` — `MOUSE_OVER_LINK` を ack リストから surface 宛 routing ブロックへ移動 (app 宛は所有 pane が存在しないので false)
- `Core/Ghostty/Actions/Actions.{h,cpp}` — `OnMouseOverLink`: `url` は NUL 終端**ではない**ので UTF-16 変換は `len` で制限。`len == 0` (リンクから離れた) は空文字列としてそのまま流し、view 側でバナーを隠す
- `Core/Host/IWindow.h` — `SetHoveredLinkForSurface(surface, url)` を追加
- `App/MainWindow.xaml.cpp` — `FindPaneBySurface` で所有 leaf に routing。`SetCursorShapeForSurface` と同じ (#65 の教訓: ポインタは非アクティブ pane の上にもいる)
- `App/TerminalControl.xaml{,.h,.cpp}` — `LinkBanner` Border と `SetHoveredLink()`
- テスト — dispatcher routing (len 制限された URL が mock に届く、app 宛は false)、Actions (len より長いバッファでの len 制限変換、空 payload でクリア、null surface 無視)。`DisabledFeaturesAckedNotDropped` から `MOUSE_OVER_LINK` を削除

</details>

## Verification

Config note: link hover needs no special config; Ctrl+hover over any URL printed in the terminal (e.g. `echo https://example.com`).

- [x] Tests.exe green (new dispatcher/Actions tests included)
- [x] Ctrl+hover a URL: banner appears bottom-left with the URL; moving off hides it
- [x] **The original #61 repro**: Ctrl+click the URL — browser opens, process does NOT crash. Running this under the `ASan | x64` configuration is the strongest form of this check
- [x] Split panes: hover a link in the non-active pane — the banner appears on that pane, not the active one
- [x] Long URL: truncates with ellipsis instead of overflowing the pane
- [x] Light/dark theme: banner colors follow the theme

<details>
<summary>日本語</summary>

config 補足: 特別な設定は不要。terminal に出力した URL (`echo https://example.com` 等) を Ctrl+hover すればよい。

- Tests.exe が green (dispatcher / Actions の新規テスト含む)
- URL を Ctrl+hover: 左下にバナーが出て URL が表示され、離れると消える
- **#61 の元の再現手順**: URL を Ctrl+click — ブラウザが開き、プロセスがクラッシュ**しない**。`ASan | x64` 構成で実行するとこの確認が最も強くなる
- split 状態: 非アクティブ pane のリンクを hover — バナーがその pane に出る (アクティブ pane ではなく)
- 長い URL: pane からはみ出さず省略記号で切れる
- ライト / ダークテーマ: バナーの色がテーマに追従する

</details>