### PR TITLE
Show a secure-input badge on the owning pane

### DIFF
--- a/App/MainWindow.xaml.cpp
+++ b/App/MainWindow.xaml.cpp
@@ -1610,6 +1610,18 @@ namespace winrt::GhosttyWin32::implementation
         }
     }
 
+    void MainWindow::SetSecureInputForSurface(ghostty_surface_t surface,
+                                              ghostty_action_secure_input_e mode)
+    {
+        // Owning-leaf routing: the password prompt lives in a
+        // specific pane, and the badge belongs there.
+        auto lookup = m_tabs.FindPaneBySurface(surface);
+        if (!lookup.pane) return;
+        if (auto* tc = Tab::PaneToTerminalControl(*lookup.pane)) {
+            tc->SetSecureInput(mode);
+        }
+    }
+
     void MainWindow::SetMouseVisibilityForSurface(ghostty_surface_t surface,
                                                   bool visible)
     {

--- a/App/MainWindow.xaml.h
+++ b/App/MainWindow.xaml.h
@@ -138,6 +138,8 @@ namespace winrt::GhosttyWin32::implementation
                                       std::wstring url) override;
         void SetMouseVisibilityForSurface(ghostty_surface_t surface,
                                           bool visible) override;
+        void SetSecureInputForSurface(ghostty_surface_t surface,
+                                      ghostty_action_secure_input_e mode) override;
         void ReplaceConfig(ghostty_config_t cloned) override;
         void ReloadConfig(bool soft) override;
         void ShowDesktopNotification(ghostty_surface_t surface,

--- a/App/TerminalControl.xaml
+++ b/App/TerminalControl.xaml
@@ -36,6 +36,26 @@
           an in-tree, hit-test-transparent sibling cannot interfere with
           input routing by construction.
         -->
+        <!--
+          Secure-input badge (SECURE_INPUT, surface-targeted).
+          ghostty's shell integration turns it on while a password
+          prompt is active; the badge tells the user why their
+          keystrokes deserve extra care. Top-right so it never
+          collides with the LinkBanner in the bottom-left; same
+          in-tree hit-test-transparent overlay pattern.
+        -->
+        <Border x:Name="SecureInputBadge"
+                IsHitTestVisible="False"
+                Visibility="Collapsed"
+                HorizontalAlignment="Right"
+                VerticalAlignment="Top"
+                CornerRadius="0,0,0,6"
+                Padding="8,4,8,4"
+                Background="{ThemeResource SolidBackgroundFillColorSecondaryBrush}">
+            <TextBlock FontSize="12"
+                       Text="&#x1F512;"
+                       Foreground="{ThemeResource TextFillColorPrimaryBrush}" />
+        </Border>
         <Border x:Name="LinkBanner"
                 IsHitTestVisible="False"
                 Visibility="Collapsed"

--- a/App/TerminalControl.xaml.cpp
+++ b/App/TerminalControl.xaml.cpp
@@ -309,6 +309,18 @@ namespace winrt::GhosttyWin32::implementation
         }
     }
 
+    void TerminalControl::SetSecureInput(ghostty_action_secure_input_e mode)
+    {
+        const bool on = mode == GHOSTTY_SECURE_INPUT_ON    ? true
+                      : mode == GHOSTTY_SECURE_INPUT_OFF   ? false
+                                                           : !m_secureInput;
+        if (on == m_secureInput) return;
+        m_secureInput = on;
+        SecureInputBadge().Visibility(on
+            ? winrt::Microsoft::UI::Xaml::Visibility::Visible
+            : winrt::Microsoft::UI::Xaml::Visibility::Collapsed);
+    }
+
     void TerminalControl::SetMouseVisibility(bool visible)
     {
         if (m_cursorHidden == !visible) return;

--- a/App/TerminalControl.xaml.h
+++ b/App/TerminalControl.xaml.h
@@ -174,6 +174,12 @@ namespace winrt::GhosttyWin32::implementation
         // borders, etc.
         void SetCursorShape(ghostty_action_mouse_shape_e shape);
 
+        // Reflect SECURE_INPUT on this pane's badge. ON/OFF set the
+        // state directly; TOGGLE flips it here because the pane owns
+        // the indicator state (ghostty's toggle keybind carries no
+        // absolute value). UI thread only.
+        void SetSecureInput(ghostty_action_secure_input_e mode);
+
         // Mirror ghostty's MOUSE_VISIBILITY on this pane: false hides
         // the pointer (mouse-hide-while-typing), true restores the
         // last MOUSE_SHAPE. UI thread only. ghostty drives both
@@ -275,6 +281,10 @@ namespace winrt::GhosttyWin32::implementation
         // hidden cursor. See SetMouseVisibility().
         bool m_cursorHidden = false;
         winrt::Microsoft::UI::Input::InputCursor m_visibleCursor{ nullptr };
+
+        // SECURE_INPUT indicator state; owned here so TOGGLE can
+        // flip without the dispatcher tracking anything.
+        bool m_secureInput = false;
     };
 }
 

--- a/Core/Ghostty/Actions/Actions.cpp
+++ b/Core/Ghostty/Actions/Actions.cpp
@@ -361,6 +361,17 @@ bool Actions::OnMouseVisibility(ghostty_surface_t surface,
     return true;
 }
 
+bool Actions::OnSecureInput(ghostty_surface_t surface,
+                            ghostty_action_secure_input_e mode) {
+    if (!surface) return true;
+    // TOGGLE resolution happens in the view: the indicator is
+    // per-pane visual state, so the pane owns the current value.
+    DispatchToView([this, surface, mode]() {
+        m_view.SetSecureInputForSurface(surface, mode);
+    });
+    return true;
+}
+
 bool Actions::OnMouseOverLink(ghostty_surface_t surface,
                               ghostty_action_mouse_over_link_s link) {
     if (!surface) return true;

--- a/Core/Ghostty/Actions/Actions.h
+++ b/Core/Ghostty/Actions/Actions.h
@@ -133,6 +133,9 @@ public:
     // MOUSE_VISIBILITY: HIDDEN while typing, VISIBLE on pointer move.
     bool OnMouseVisibility(ghostty_surface_t surface,
                            ghostty_action_mouse_visibility_e visibility);
+    // SECURE_INPUT (surface-targeted): password-prompt indicator.
+    bool OnSecureInput(ghostty_surface_t surface,
+                       ghostty_action_secure_input_e mode);
     bool OnReloadConfig(bool soft);
     bool OnConfigChange(ghostty_config_t newCfg);
     bool OnDesktopNotification(ghostty_surface_t surface,

--- a/Core/Ghostty/CallbackDispatcher.cpp
+++ b/Core/Ghostty/CallbackDispatcher.cpp
@@ -100,6 +100,15 @@ bool CallbackDispatcher::DispatchAction(ghostty_target_s target, ghostty_action_
                 return m_actions.OnMouseVisibility(target.target.surface,
                                                    action.action.mouse_visibility);
             return false;
+        case GHOSTTY_ACTION_SECURE_INPUT:
+            if (target.tag == GHOSTTY_TARGET_SURFACE)
+                return m_actions.OnSecureInput(target.target.surface,
+                                               action.action.secure_input);
+            // App-targeted SECURE_INPUT is macOS's
+            // EnableSecureEventInput (OS-level keylogger protection);
+            // Windows has no counterpart, so the app variant stays a
+            // deliberate ack.
+            return true;
         case GHOSTTY_ACTION_RELOAD_CONFIG:
             return m_actions.OnReloadConfig(action.action.reload_config.soft);
         case GHOSTTY_ACTION_CONFIG_CHANGE:
@@ -156,12 +165,10 @@ bool CallbackDispatcher::DispatchAction(ghostty_target_s target, ghostty_action_
         // quiet without inventing empty GhosttyActions methods.
         //
         // Informational actions whose UI surfaces this port
-        // doesn't have yet (read-only banner, secure-input
-        // padlock, pending chord, modal-key-table label, shell-
-        // supplied title source flag, PWD breadcrumb, post-
-        // command summary):
+        // doesn't have yet (read-only banner, pending chord,
+        // modal-key-table label, shell-supplied title source flag,
+        // PWD breadcrumb, post-command summary):
         case GHOSTTY_ACTION_READONLY:
-        case GHOSTTY_ACTION_SECURE_INPUT:
         case GHOSTTY_ACTION_KEY_SEQUENCE:
         case GHOSTTY_ACTION_KEY_TABLE:
         case GHOSTTY_ACTION_PROMPT_TITLE:

--- a/Core/Host/IWindow.h
+++ b/Core/Host/IWindow.h
@@ -186,6 +186,17 @@ struct IWindow {
     virtual void SetMouseVisibilityForSurface(ghostty_surface_t surface,
                                               bool visible) = 0;
 
+    // Reflect SECURE_INPUT on the pane owning `surface`: ghostty's
+    // shell integration fires ON when a password prompt is detected
+    // and OFF when it ends; the toggle_secure_input keybind fires
+    // TOGGLE. The view resolves TOGGLE against its own per-pane
+    // state (the indicator is pane-visual state, so the pane owns
+    // it). App-targeted SECURE_INPUT never reaches this — that
+    // variant is macOS's EnableSecureEventInput, which has no
+    // Windows counterpart and stays acked in the dispatcher.
+    virtual void SetSecureInputForSurface(ghostty_surface_t surface,
+                                          ghostty_action_secure_input_e mode) = 0;
+
     // Show or clear the hovered-link banner on the pane owning
     // `surface`. MOUSE_OVER_LINK fires with the URL while the pointer
     // is on a link and with an empty payload when it leaves, so an

--- a/Tests/MockMainWindowView.h
+++ b/Tests/MockMainWindowView.h
@@ -173,6 +173,16 @@ struct MockMainWindowView : core::host::IWindow {
         lastHoveredLinkUrl = std::move(url);
     }
 
+    int setSecureInputCalls = 0;
+    ghostty_surface_t lastSecureInputSurface = nullptr;
+    ghostty_action_secure_input_e lastSecureInputMode{};
+    void SetSecureInputForSurface(ghostty_surface_t s,
+                                  ghostty_action_secure_input_e mode) override {
+        ++setSecureInputCalls;
+        lastSecureInputSurface = s;
+        lastSecureInputMode = mode;
+    }
+
     int setMouseVisibilityCalls = 0;
     ghostty_surface_t lastMouseVisibilitySurface = nullptr;
     bool lastMouseVisible = true;

--- a/Tests/test_ghostty_actions.cpp
+++ b/Tests/test_ghostty_actions.cpp
@@ -341,6 +341,23 @@ TEST(GhosttyActionsTest, OnMouseVisibilityIgnoresNullSurface) {
     EXPECT_EQ(view.setMouseVisibilityCalls, 0);
 }
 
+TEST(GhosttyActionsTest, OnSecureInputForwardsSurfaceAndMode) {
+    MockMainWindowView view;
+    Actions actions(view);
+    auto surface = FakeSurface(0x5EC);
+    EXPECT_TRUE(actions.OnSecureInput(surface, GHOSTTY_SECURE_INPUT_TOGGLE));
+    EXPECT_EQ(view.setSecureInputCalls, 1);
+    EXPECT_EQ(view.lastSecureInputSurface, surface);
+    EXPECT_EQ(view.lastSecureInputMode, GHOSTTY_SECURE_INPUT_TOGGLE);
+}
+
+TEST(GhosttyActionsTest, OnSecureInputIgnoresNullSurface) {
+    MockMainWindowView view;
+    Actions actions(view);
+    EXPECT_TRUE(actions.OnSecureInput(nullptr, GHOSTTY_SECURE_INPUT_ON));
+    EXPECT_EQ(view.setSecureInputCalls, 0);
+}
+
 TEST(GhosttyActionsTest, OnMouseOverLinkIgnoresNullSurface) {
     MockMainWindowView view;
     Actions actions(view);

--- a/Tests/test_ghostty_callback_dispatcher.cpp
+++ b/Tests/test_ghostty_callback_dispatcher.cpp
@@ -32,7 +32,11 @@ TEST(GhosttyCallbackDispatcherTest, InformationalAcksReturnTrue) {
     auto d = CallbackDispatcher::Create(view);
 
     EXPECT_TRUE(DispatchTag(*d, GHOSTTY_ACTION_READONLY));
+    // SECURE_INPUT with an app target: macOS's EnableSecureEventInput
+    // concept, no Windows counterpart — deliberately acked. The
+    // surface-targeted variant routes (see the routing tests below).
     EXPECT_TRUE(DispatchTag(*d, GHOSTTY_ACTION_SECURE_INPUT));
+    EXPECT_EQ(view.setSecureInputCalls, 0);
     EXPECT_TRUE(DispatchTag(*d, GHOSTTY_ACTION_KEY_SEQUENCE));
     EXPECT_TRUE(DispatchTag(*d, GHOSTTY_ACTION_KEY_TABLE));
     EXPECT_TRUE(DispatchTag(*d, GHOSTTY_ACTION_PROMPT_TITLE));
@@ -121,6 +125,23 @@ TEST(GhosttyCallbackDispatcherTest, MouseVisibilityRoutesToTheOwningSurface) {
 
     // App-targeted delivery has no owning pane — refuse.
     EXPECT_FALSE(DispatchTag(*d, GHOSTTY_ACTION_MOUSE_VISIBILITY));
+}
+
+TEST(GhosttyCallbackDispatcherTest, SecureInputRoutesToTheOwningSurface) {
+    MockMainWindowView view;
+    auto d = CallbackDispatcher::Create(view);
+
+    ghostty_target_s target{};
+    target.tag = GHOSTTY_TARGET_SURFACE;
+    target.target.surface = reinterpret_cast<ghostty_surface_t>(0xBEEF);
+    ghostty_action_s action{};
+    action.tag = GHOSTTY_ACTION_SECURE_INPUT;
+    action.action.secure_input = GHOSTTY_SECURE_INPUT_ON;
+
+    EXPECT_TRUE(d->DispatchAction(target, action));
+    EXPECT_EQ(view.setSecureInputCalls, 1);
+    EXPECT_EQ(view.lastSecureInputSurface, target.target.surface);
+    EXPECT_EQ(view.lastSecureInputMode, GHOSTTY_SECURE_INPUT_ON);
 }
 
 // ----- view-free live handlers -----


### PR DESCRIPTION
## Summary

First of the "informational" coverage batch (#57): surface-targeted `SECURE_INPUT` now shows a padlock badge in the pane's top-right corner while secure input is active, using the same in-tree overlay pattern as the link banner (#142).

<details>
<summary>日本語</summary>

#57 の「informational」カバレッジ埋めの第 1 弾。surface 宛 `SECURE_INPUT` を、secure input が有効な間 pane 右上に 🔒 バッジとして表示する。link banner (#142) と同じ in-tree オーバーレイパターン。

</details>

## Semantics (from upstream)

`SECURE_INPUT` has two distinct targets, handled differently on purpose:

- **Surface-targeted** — ghostty's shell integration fires ON when a password prompt is detected and OFF when it ends; the `toggle_secure_input` keybind fires TOGGLE. This is the variant this PR implements: a per-pane indicator, with the pane owning the on/off state (TOGGLE carries no absolute value, so the state has to live where the badge lives).
- **App-targeted** — macOS's `EnableSecureEventInput` (OS-level keylogger protection). Windows has no counterpart, so this variant stays a deliberate ack, now with the reason recorded at the dispatch site.

<details>
<summary>日本語</summary>

`SECURE_INPUT` には性質の違う 2 つの target があり、意図的に別扱いにしている:

- **surface 宛** — shell integration がパスワードプロンプト検知で ON、終了で OFF を発火。`toggle_secure_input` keybind は TOGGLE を発火。本 PR が実装するのはこちら: pane 単位のインジケータで、on/off 状態は pane が保持する (TOGGLE は絶対値を運ばないので、状態はバッジのある場所に置くしかない)
- **app 宛** — macOS の `EnableSecureEventInput` (OS レベルのキーロガー防御)。Windows に対応物がないため、こちらは理由をディスパッチ箇所に記録した上で意図的 ack のまま

</details>

## Changes

- `Core/Ghostty/CallbackDispatcher.cpp` — `SECURE_INPUT` leaves the informational ack list; surface-targeted routes to the handler, app-targeted acks with the recorded reason.
- `Core/Ghostty/Actions/Actions.{h,cpp}` — `OnSecureInput` forwards surface + mode; TOGGLE resolution deliberately stays in the view.
- `Core/Host/IWindow.h` — new `SetSecureInputForSurface(surface, mode)`.
- `App/MainWindow.xaml.cpp` — owning-leaf routing via `FindPaneBySurface`.
- `App/TerminalControl.xaml{,.h,.cpp}` — `SecureInputBadge` (top-right, hit-test transparent, theme-aware) + `SetSecureInput()` with the per-pane `m_secureInput` state.
- Tests — dispatcher: surface-targeted routes, app-targeted acks without touching the view; Actions: forward + null-surface guard.

<details>
<summary>日本語</summary>

- `Core/Ghostty/CallbackDispatcher.cpp` — `SECURE_INPUT` を informational ack リストから外し、surface 宛は routing、app 宛は理由記録つき ack
- `Core/Ghostty/Actions/Actions.{h,cpp}` — `OnSecureInput` は surface + mode を転送。TOGGLE の解決は意図的に view 側
- `Core/Host/IWindow.h` — `SetSecureInputForSurface(surface, mode)` を追加
- `App/MainWindow.xaml.cpp` — `FindPaneBySurface` で所有 leaf に routing
- `App/TerminalControl.xaml{,.h,.cpp}` — `SecureInputBadge` (右上、hit-test 透過、テーマ追従) と pane 単位の `m_secureInput` 状態を持つ `SetSecureInput()`
- テスト — dispatcher: surface 宛は routing、app 宛は view を触らず ack。Actions: 転送と null surface ガード

</details>

## Verification

Config: `keybind = alt+shift+i=toggle_secure_input` is already added to the local config. The automatic ON/OFF path depends on shell integration, which is disabled in this environment ("no resources dir"), so the keybind exercises the same surface-targeted action path via TOGGLE.

- [x] Tests.exe green (new dispatcher/Actions tests included)
- [x] `Alt+Shift+I` — 🔒 badge appears top-right on the focused pane; pressing again hides it
- [x] Splits: toggling in one pane shows the badge only on that pane
- [x] Badge does not block clicks on the text under it (hit-test transparent)
- [x] Light/dark theme: badge colors follow the theme
- [x] Coexistence: Ctrl+hover a link while the badge is shown — link banner bottom-left and badge top-right render simultaneously without collision

<details>
<summary>日本語</summary>

config: `keybind = alt+shift+i=toggle_secure_input` はローカル config に追加済み。自動 ON/OFF は shell integration 依存でこの環境では無効 ("no resources dir") のため、keybind の TOGGLE で同じ surface 宛経路を叩く。

- Tests.exe が green (新規 dispatcher / Actions テスト含む)
- `Alt+Shift+I` — フォーカス中の pane 右上に 🔒 バッジが出る。もう一度押すと消える
- split: 片方の pane でトグルしたとき、バッジが出るのはその pane だけ
- バッジの真下の文字がクリックできる (hit-test 透過)
- ライト / ダークテーマ: バッジの色がテーマに追従する
- 共存: バッジ表示中に Ctrl+hover でリンクに乗る — 左下の link banner と右上のバッジが衝突せず同時に表示される

</details>
