### PR TITLE
Show pending key sequences and active key tables on the pane

### DIFF
--- a/App/MainWindow.xaml.cpp
+++ b/App/MainWindow.xaml.cpp
@@ -1622,6 +1622,47 @@ namespace winrt::GhosttyWin32::implementation
         }
     }
 
+    // KEY_SEQUENCE / KEY_TABLE: owning-leaf routing like the other
+    // pane-visual actions; the four operations share the lookup and
+    // differ only in which TerminalControl mutator they call.
+    void MainWindow::AppendKeySequenceForSurface(ghostty_surface_t surface,
+                                                 std::wstring triggerLabel)
+    {
+        auto lookup = m_tabs.FindPaneBySurface(surface);
+        if (!lookup.pane) return;
+        if (auto* tc = Tab::PaneToTerminalControl(*lookup.pane)) {
+            tc->AppendKeySequence(winrt::hstring{ triggerLabel });
+        }
+    }
+
+    void MainWindow::ClearKeySequenceForSurface(ghostty_surface_t surface)
+    {
+        auto lookup = m_tabs.FindPaneBySurface(surface);
+        if (!lookup.pane) return;
+        if (auto* tc = Tab::PaneToTerminalControl(*lookup.pane)) {
+            tc->ClearKeySequence();
+        }
+    }
+
+    void MainWindow::PushKeyTableForSurface(ghostty_surface_t surface,
+                                            std::wstring name)
+    {
+        auto lookup = m_tabs.FindPaneBySurface(surface);
+        if (!lookup.pane) return;
+        if (auto* tc = Tab::PaneToTerminalControl(*lookup.pane)) {
+            tc->PushKeyTable(winrt::hstring{ name });
+        }
+    }
+
+    void MainWindow::PopKeyTableForSurface(ghostty_surface_t surface, bool all)
+    {
+        auto lookup = m_tabs.FindPaneBySurface(surface);
+        if (!lookup.pane) return;
+        if (auto* tc = Tab::PaneToTerminalControl(*lookup.pane)) {
+            tc->PopKeyTable(all);
+        }
+    }
+
     void MainWindow::SetMouseVisibilityForSurface(ghostty_surface_t surface,
                                                   bool visible)
     {

--- a/App/MainWindow.xaml.h
+++ b/App/MainWindow.xaml.h
@@ -140,6 +140,12 @@ namespace winrt::GhosttyWin32::implementation
                                           bool visible) override;
         void SetSecureInputForSurface(ghostty_surface_t surface,
                                       ghostty_action_secure_input_e mode) override;
+        void AppendKeySequenceForSurface(ghostty_surface_t surface,
+                                         std::wstring triggerLabel) override;
+        void ClearKeySequenceForSurface(ghostty_surface_t surface) override;
+        void PushKeyTableForSurface(ghostty_surface_t surface,
+                                    std::wstring name) override;
+        void PopKeyTableForSurface(ghostty_surface_t surface, bool all) override;
         void ReplaceConfig(ghostty_config_t cloned) override;
         void ReloadConfig(bool soft) override;
         void ShowDesktopNotification(ghostty_surface_t surface,

--- a/App/TerminalControl.xaml
+++ b/App/TerminalControl.xaml
@@ -56,6 +56,27 @@
                        Text="&#x1F512;"
                        Foreground="{ThemeResource TextFillColorPrimaryBrush}" />
         </Border>
+        <!--
+          Key-state badge (KEY_SEQUENCE / KEY_TABLE). Shows the
+          active key-table stack and/or the pending multi-chord
+          triggers so a user mid-sequence can see why their keys
+          aren't typing. Bottom-right, so all three overlays keep
+          distinct corners (link banner bottom-left, secure input
+          top-right). Same in-tree hit-test-transparent pattern.
+        -->
+        <Border x:Name="KeyStateBadge"
+                IsHitTestVisible="False"
+                Visibility="Collapsed"
+                HorizontalAlignment="Right"
+                VerticalAlignment="Bottom"
+                CornerRadius="6,0,0,0"
+                Padding="8,4,8,4"
+                Background="{ThemeResource SolidBackgroundFillColorSecondaryBrush}">
+            <TextBlock x:Name="KeyStateBadgeText"
+                       FontSize="12"
+                       TextTrimming="CharacterEllipsis"
+                       Foreground="{ThemeResource TextFillColorPrimaryBrush}" />
+        </Border>
         <Border x:Name="LinkBanner"
                 IsHitTestVisible="False"
                 Visibility="Collapsed"

--- a/App/TerminalControl.xaml.cpp
+++ b/App/TerminalControl.xaml.cpp
@@ -309,6 +309,63 @@ namespace winrt::GhosttyWin32::implementation
         }
     }
 
+    void TerminalControl::AppendKeySequence(winrt::hstring const& label)
+    {
+        m_keySequence.push_back(label);
+        UpdateKeyStateBadge();
+    }
+
+    void TerminalControl::ClearKeySequence()
+    {
+        if (m_keySequence.empty()) return;
+        m_keySequence.clear();
+        UpdateKeyStateBadge();
+    }
+
+    void TerminalControl::PushKeyTable(winrt::hstring const& name)
+    {
+        m_keyTables.push_back(name);
+        UpdateKeyStateBadge();
+    }
+
+    void TerminalControl::PopKeyTable(bool all)
+    {
+        if (m_keyTables.empty()) return;
+        if (all) {
+            m_keyTables.clear();
+        } else {
+            m_keyTables.pop_back();
+        }
+        UpdateKeyStateBadge();
+    }
+
+    void TerminalControl::UpdateKeyStateBadge()
+    {
+        // Table stack first ("resize"), pending chord second
+        // ("ctrl+a …"), separated when both are live. Mirrors the
+        // information upstream's KeyStateIndicator carries, minus
+        // its popover chrome.
+        std::wstring text;
+        for (auto const& name : m_keyTables) {
+            if (!text.empty()) text += L" · ";
+            text += name;
+        }
+        if (!m_keySequence.empty()) {
+            if (!text.empty()) text += L" · ";
+            for (auto const& label : m_keySequence) {
+                text += label;
+                text += L' ';
+            }
+            text += L'…';
+        }
+        if (text.empty()) {
+            KeyStateBadge().Visibility(winrt::Microsoft::UI::Xaml::Visibility::Collapsed);
+            return;
+        }
+        KeyStateBadgeText().Text(text);
+        KeyStateBadge().Visibility(winrt::Microsoft::UI::Xaml::Visibility::Visible);
+    }
+
     void TerminalControl::SetSecureInput(ghostty_action_secure_input_e mode)
     {
         const bool on = mode == GHOSTTY_SECURE_INPUT_ON    ? true

--- a/App/TerminalControl.xaml.h
+++ b/App/TerminalControl.xaml.h
@@ -11,6 +11,7 @@
 #include <atomic>
 #include <functional>
 #include <memory>
+#include <vector>
 
 namespace winrt::GhosttyWin32::implementation
 {
@@ -174,6 +175,15 @@ namespace winrt::GhosttyWin32::implementation
         // borders, etc.
         void SetCursorShape(ghostty_action_mouse_shape_e shape);
 
+        // ----- key-state badge (KEY_SEQUENCE / KEY_TABLE) -----
+        // The pane owns the accumulated state (pending chord labels,
+        // key-table name stack) because the actions only carry
+        // deltas. All UI thread only.
+        void AppendKeySequence(winrt::hstring const& label);
+        void ClearKeySequence();
+        void PushKeyTable(winrt::hstring const& name);
+        void PopKeyTable(bool all);
+
         // Reflect SECURE_INPUT on this pane's badge. ON/OFF set the
         // state directly; TOGGLE flips it here because the pane owns
         // the indicator state (ghostty's toggle keybind carries no
@@ -285,6 +295,13 @@ namespace winrt::GhosttyWin32::implementation
         // SECURE_INPUT indicator state; owned here so TOGGLE can
         // flip without the dispatcher tracking anything.
         bool m_secureInput = false;
+
+        // Key-state badge state. Rebuilds the badge text from both
+        // lists on every change — the lists are tiny (a table stack
+        // is 1-2 deep, a chord is 2-3 keys).
+        void UpdateKeyStateBadge();
+        std::vector<winrt::hstring> m_keyTables;
+        std::vector<winrt::hstring> m_keySequence;
     };
 }
 

--- a/Core/Core.vcxproj
+++ b/Core/Core.vcxproj
@@ -87,6 +87,7 @@
     <ClInclude Include="Ghostty\Actions\Actions.h" />
     <ClInclude Include="Ghostty\Actions\Tags\Fullscreen.h" />
     <ClInclude Include="Ghostty\Actions\Tags\SizeLimit.h" />
+    <ClInclude Include="Ghostty\Actions\Tags\TriggerLabel.h" />
     <ClInclude Include="Ghostty\Actions\Tags\WindowDecorations.h" />
     <ClInclude Include="Ghostty\App.h" />
     <ClInclude Include="Ghostty\CallbackDispatcher.h" />
@@ -106,6 +107,7 @@
     <ClCompile Include="Ghostty\Actions\Actions.cpp" />
     <ClCompile Include="Ghostty\Actions\Tags\Fullscreen.cpp" />
     <ClCompile Include="Ghostty\Actions\Tags\SizeLimit.cpp" />
+    <ClCompile Include="Ghostty\Actions\Tags\TriggerLabel.cpp" />
     <ClCompile Include="Ghostty\CallbackDispatcher.cpp" />
     <ClCompile Include="Ghostty\RuntimeConfigFactory.cpp" />
     <ClCompile Include="Win32\SEHGuard.cpp" />

--- a/Core/Ghostty/Actions/Actions.cpp
+++ b/Core/Ghostty/Actions/Actions.cpp
@@ -1,4 +1,5 @@
 #include "Actions.h"
+#include "Tags/TriggerLabel.h"
 #include "Interop/Encoding.h"
 #include <windows.h>
 #include <shellapi.h>
@@ -369,6 +370,51 @@ bool Actions::OnSecureInput(ghostty_surface_t surface,
     DispatchToView([this, surface, mode]() {
         m_view.SetSecureInputForSurface(surface, mode);
     });
+    return true;
+}
+
+bool Actions::OnKeySequence(ghostty_surface_t surface,
+                            ghostty_action_key_sequence_s seq) {
+    if (!surface) return true;
+    if (!seq.active) {
+        DispatchToView([this, surface]() {
+            m_view.ClearKeySequenceForSurface(surface);
+        });
+        return true;
+    }
+    std::wstring label = TriggerLabel(seq.trigger);
+    DispatchToView([this, surface, label = std::move(label)]() mutable {
+        m_view.AppendKeySequenceForSurface(surface, std::move(label));
+    });
+    return true;
+}
+
+bool Actions::OnKeyTable(ghostty_surface_t surface,
+                         ghostty_action_key_table_s table) {
+    if (!surface) return true;
+    switch (table.tag) {
+        case GHOSTTY_KEY_TABLE_ACTIVATE: {
+            // The name is length-bounded, not NUL-terminated.
+            std::wstring name;
+            if (table.value.activate.name && table.value.activate.len > 0) {
+                name = interop::Encoding::toUtf16(
+                    table.value.activate.name,
+                    static_cast<int>(table.value.activate.len));
+            }
+            DispatchToView([this, surface, name = std::move(name)]() mutable {
+                m_view.PushKeyTableForSurface(surface, std::move(name));
+            });
+            return true;
+        }
+        case GHOSTTY_KEY_TABLE_DEACTIVATE:
+        case GHOSTTY_KEY_TABLE_DEACTIVATE_ALL: {
+            const bool all = table.tag == GHOSTTY_KEY_TABLE_DEACTIVATE_ALL;
+            DispatchToView([this, surface, all]() {
+                m_view.PopKeyTableForSurface(surface, all);
+            });
+            return true;
+        }
+    }
     return true;
 }
 

--- a/Core/Ghostty/Actions/Actions.h
+++ b/Core/Ghostty/Actions/Actions.h
@@ -136,6 +136,13 @@ public:
     // SECURE_INPUT (surface-targeted): password-prompt indicator.
     bool OnSecureInput(ghostty_surface_t surface,
                        ghostty_action_secure_input_e mode);
+    // KEY_SEQUENCE: pending-chord progress. Formats the trigger via
+    // TriggerLabel on the renderer thread so the view only sees text.
+    bool OnKeySequence(ghostty_surface_t surface,
+                       ghostty_action_key_sequence_s seq);
+    // KEY_TABLE: named modal key-table activate/deactivate stack ops.
+    bool OnKeyTable(ghostty_surface_t surface,
+                    ghostty_action_key_table_s table);
     bool OnReloadConfig(bool soft);
     bool OnConfigChange(ghostty_config_t newCfg);
     bool OnDesktopNotification(ghostty_surface_t surface,

--- a/Core/Ghostty/Actions/Tags/TriggerLabel.cpp
+++ b/Core/Ghostty/Actions/Tags/TriggerLabel.cpp
@@ -1,0 +1,231 @@
+#include "TriggerLabel.h"
+
+namespace core::ghostty::actions {
+
+namespace {
+
+// Generated from the ghostty_input_key_e enum in
+// external/ghostty/include/ghostty.h (GHOSTTY_KEY_X -> "x").
+// Regenerate mechanically if the submodule adds keys; an unknown
+// value falls back to "unidentified" rather than breaking.
+const wchar_t* KeyName(ghostty_input_key_e key) {
+    switch (key) {
+        case GHOSTTY_KEY_UNIDENTIFIED: return L"unidentified";
+        case GHOSTTY_KEY_BACKQUOTE: return L"backquote";
+        case GHOSTTY_KEY_BACKSLASH: return L"backslash";
+        case GHOSTTY_KEY_BRACKET_LEFT: return L"bracket_left";
+        case GHOSTTY_KEY_BRACKET_RIGHT: return L"bracket_right";
+        case GHOSTTY_KEY_COMMA: return L"comma";
+        case GHOSTTY_KEY_DIGIT_0: return L"digit_0";
+        case GHOSTTY_KEY_DIGIT_1: return L"digit_1";
+        case GHOSTTY_KEY_DIGIT_2: return L"digit_2";
+        case GHOSTTY_KEY_DIGIT_3: return L"digit_3";
+        case GHOSTTY_KEY_DIGIT_4: return L"digit_4";
+        case GHOSTTY_KEY_DIGIT_5: return L"digit_5";
+        case GHOSTTY_KEY_DIGIT_6: return L"digit_6";
+        case GHOSTTY_KEY_DIGIT_7: return L"digit_7";
+        case GHOSTTY_KEY_DIGIT_8: return L"digit_8";
+        case GHOSTTY_KEY_DIGIT_9: return L"digit_9";
+        case GHOSTTY_KEY_EQUAL: return L"equal";
+        case GHOSTTY_KEY_INTL_BACKSLASH: return L"intl_backslash";
+        case GHOSTTY_KEY_INTL_RO: return L"intl_ro";
+        case GHOSTTY_KEY_INTL_YEN: return L"intl_yen";
+        case GHOSTTY_KEY_A: return L"a";
+        case GHOSTTY_KEY_B: return L"b";
+        case GHOSTTY_KEY_C: return L"c";
+        case GHOSTTY_KEY_D: return L"d";
+        case GHOSTTY_KEY_E: return L"e";
+        case GHOSTTY_KEY_F: return L"f";
+        case GHOSTTY_KEY_G: return L"g";
+        case GHOSTTY_KEY_H: return L"h";
+        case GHOSTTY_KEY_I: return L"i";
+        case GHOSTTY_KEY_J: return L"j";
+        case GHOSTTY_KEY_K: return L"k";
+        case GHOSTTY_KEY_L: return L"l";
+        case GHOSTTY_KEY_M: return L"m";
+        case GHOSTTY_KEY_N: return L"n";
+        case GHOSTTY_KEY_O: return L"o";
+        case GHOSTTY_KEY_P: return L"p";
+        case GHOSTTY_KEY_Q: return L"q";
+        case GHOSTTY_KEY_R: return L"r";
+        case GHOSTTY_KEY_S: return L"s";
+        case GHOSTTY_KEY_T: return L"t";
+        case GHOSTTY_KEY_U: return L"u";
+        case GHOSTTY_KEY_V: return L"v";
+        case GHOSTTY_KEY_W: return L"w";
+        case GHOSTTY_KEY_X: return L"x";
+        case GHOSTTY_KEY_Y: return L"y";
+        case GHOSTTY_KEY_Z: return L"z";
+        case GHOSTTY_KEY_MINUS: return L"minus";
+        case GHOSTTY_KEY_PERIOD: return L"period";
+        case GHOSTTY_KEY_QUOTE: return L"quote";
+        case GHOSTTY_KEY_SEMICOLON: return L"semicolon";
+        case GHOSTTY_KEY_SLASH: return L"slash";
+        case GHOSTTY_KEY_ALT_LEFT: return L"alt_left";
+        case GHOSTTY_KEY_ALT_RIGHT: return L"alt_right";
+        case GHOSTTY_KEY_BACKSPACE: return L"backspace";
+        case GHOSTTY_KEY_CAPS_LOCK: return L"caps_lock";
+        case GHOSTTY_KEY_CONTEXT_MENU: return L"context_menu";
+        case GHOSTTY_KEY_CONTROL_LEFT: return L"control_left";
+        case GHOSTTY_KEY_CONTROL_RIGHT: return L"control_right";
+        case GHOSTTY_KEY_ENTER: return L"enter";
+        case GHOSTTY_KEY_META_LEFT: return L"meta_left";
+        case GHOSTTY_KEY_META_RIGHT: return L"meta_right";
+        case GHOSTTY_KEY_SHIFT_LEFT: return L"shift_left";
+        case GHOSTTY_KEY_SHIFT_RIGHT: return L"shift_right";
+        case GHOSTTY_KEY_SPACE: return L"space";
+        case GHOSTTY_KEY_TAB: return L"tab";
+        case GHOSTTY_KEY_CONVERT: return L"convert";
+        case GHOSTTY_KEY_KANA_MODE: return L"kana_mode";
+        case GHOSTTY_KEY_NON_CONVERT: return L"non_convert";
+        case GHOSTTY_KEY_DELETE: return L"delete";
+        case GHOSTTY_KEY_END: return L"end";
+        case GHOSTTY_KEY_HELP: return L"help";
+        case GHOSTTY_KEY_HOME: return L"home";
+        case GHOSTTY_KEY_INSERT: return L"insert";
+        case GHOSTTY_KEY_PAGE_DOWN: return L"page_down";
+        case GHOSTTY_KEY_PAGE_UP: return L"page_up";
+        case GHOSTTY_KEY_ARROW_DOWN: return L"arrow_down";
+        case GHOSTTY_KEY_ARROW_LEFT: return L"arrow_left";
+        case GHOSTTY_KEY_ARROW_RIGHT: return L"arrow_right";
+        case GHOSTTY_KEY_ARROW_UP: return L"arrow_up";
+        case GHOSTTY_KEY_NUM_LOCK: return L"num_lock";
+        case GHOSTTY_KEY_NUMPAD_0: return L"numpad_0";
+        case GHOSTTY_KEY_NUMPAD_1: return L"numpad_1";
+        case GHOSTTY_KEY_NUMPAD_2: return L"numpad_2";
+        case GHOSTTY_KEY_NUMPAD_3: return L"numpad_3";
+        case GHOSTTY_KEY_NUMPAD_4: return L"numpad_4";
+        case GHOSTTY_KEY_NUMPAD_5: return L"numpad_5";
+        case GHOSTTY_KEY_NUMPAD_6: return L"numpad_6";
+        case GHOSTTY_KEY_NUMPAD_7: return L"numpad_7";
+        case GHOSTTY_KEY_NUMPAD_8: return L"numpad_8";
+        case GHOSTTY_KEY_NUMPAD_9: return L"numpad_9";
+        case GHOSTTY_KEY_NUMPAD_ADD: return L"numpad_add";
+        case GHOSTTY_KEY_NUMPAD_BACKSPACE: return L"numpad_backspace";
+        case GHOSTTY_KEY_NUMPAD_CLEAR: return L"numpad_clear";
+        case GHOSTTY_KEY_NUMPAD_CLEAR_ENTRY: return L"numpad_clear_entry";
+        case GHOSTTY_KEY_NUMPAD_COMMA: return L"numpad_comma";
+        case GHOSTTY_KEY_NUMPAD_DECIMAL: return L"numpad_decimal";
+        case GHOSTTY_KEY_NUMPAD_DIVIDE: return L"numpad_divide";
+        case GHOSTTY_KEY_NUMPAD_ENTER: return L"numpad_enter";
+        case GHOSTTY_KEY_NUMPAD_EQUAL: return L"numpad_equal";
+        case GHOSTTY_KEY_NUMPAD_MEMORY_ADD: return L"numpad_memory_add";
+        case GHOSTTY_KEY_NUMPAD_MEMORY_CLEAR: return L"numpad_memory_clear";
+        case GHOSTTY_KEY_NUMPAD_MEMORY_RECALL: return L"numpad_memory_recall";
+        case GHOSTTY_KEY_NUMPAD_MEMORY_STORE: return L"numpad_memory_store";
+        case GHOSTTY_KEY_NUMPAD_MEMORY_SUBTRACT: return L"numpad_memory_subtract";
+        case GHOSTTY_KEY_NUMPAD_MULTIPLY: return L"numpad_multiply";
+        case GHOSTTY_KEY_NUMPAD_PAREN_LEFT: return L"numpad_paren_left";
+        case GHOSTTY_KEY_NUMPAD_PAREN_RIGHT: return L"numpad_paren_right";
+        case GHOSTTY_KEY_NUMPAD_SUBTRACT: return L"numpad_subtract";
+        case GHOSTTY_KEY_NUMPAD_SEPARATOR: return L"numpad_separator";
+        case GHOSTTY_KEY_NUMPAD_UP: return L"numpad_up";
+        case GHOSTTY_KEY_NUMPAD_DOWN: return L"numpad_down";
+        case GHOSTTY_KEY_NUMPAD_RIGHT: return L"numpad_right";
+        case GHOSTTY_KEY_NUMPAD_LEFT: return L"numpad_left";
+        case GHOSTTY_KEY_NUMPAD_BEGIN: return L"numpad_begin";
+        case GHOSTTY_KEY_NUMPAD_HOME: return L"numpad_home";
+        case GHOSTTY_KEY_NUMPAD_END: return L"numpad_end";
+        case GHOSTTY_KEY_NUMPAD_INSERT: return L"numpad_insert";
+        case GHOSTTY_KEY_NUMPAD_DELETE: return L"numpad_delete";
+        case GHOSTTY_KEY_NUMPAD_PAGE_UP: return L"numpad_page_up";
+        case GHOSTTY_KEY_NUMPAD_PAGE_DOWN: return L"numpad_page_down";
+        case GHOSTTY_KEY_ESCAPE: return L"escape";
+        case GHOSTTY_KEY_F1: return L"f1";
+        case GHOSTTY_KEY_F2: return L"f2";
+        case GHOSTTY_KEY_F3: return L"f3";
+        case GHOSTTY_KEY_F4: return L"f4";
+        case GHOSTTY_KEY_F5: return L"f5";
+        case GHOSTTY_KEY_F6: return L"f6";
+        case GHOSTTY_KEY_F7: return L"f7";
+        case GHOSTTY_KEY_F8: return L"f8";
+        case GHOSTTY_KEY_F9: return L"f9";
+        case GHOSTTY_KEY_F10: return L"f10";
+        case GHOSTTY_KEY_F11: return L"f11";
+        case GHOSTTY_KEY_F12: return L"f12";
+        case GHOSTTY_KEY_F13: return L"f13";
+        case GHOSTTY_KEY_F14: return L"f14";
+        case GHOSTTY_KEY_F15: return L"f15";
+        case GHOSTTY_KEY_F16: return L"f16";
+        case GHOSTTY_KEY_F17: return L"f17";
+        case GHOSTTY_KEY_F18: return L"f18";
+        case GHOSTTY_KEY_F19: return L"f19";
+        case GHOSTTY_KEY_F20: return L"f20";
+        case GHOSTTY_KEY_F21: return L"f21";
+        case GHOSTTY_KEY_F22: return L"f22";
+        case GHOSTTY_KEY_F23: return L"f23";
+        case GHOSTTY_KEY_F24: return L"f24";
+        case GHOSTTY_KEY_F25: return L"f25";
+        case GHOSTTY_KEY_FN: return L"fn";
+        case GHOSTTY_KEY_FN_LOCK: return L"fn_lock";
+        case GHOSTTY_KEY_PRINT_SCREEN: return L"print_screen";
+        case GHOSTTY_KEY_SCROLL_LOCK: return L"scroll_lock";
+        case GHOSTTY_KEY_PAUSE: return L"pause";
+        case GHOSTTY_KEY_BROWSER_BACK: return L"browser_back";
+        case GHOSTTY_KEY_BROWSER_FAVORITES: return L"browser_favorites";
+        case GHOSTTY_KEY_BROWSER_FORWARD: return L"browser_forward";
+        case GHOSTTY_KEY_BROWSER_HOME: return L"browser_home";
+        case GHOSTTY_KEY_BROWSER_REFRESH: return L"browser_refresh";
+        case GHOSTTY_KEY_BROWSER_SEARCH: return L"browser_search";
+        case GHOSTTY_KEY_BROWSER_STOP: return L"browser_stop";
+        case GHOSTTY_KEY_EJECT: return L"eject";
+        case GHOSTTY_KEY_LAUNCH_APP_1: return L"launch_app_1";
+        case GHOSTTY_KEY_LAUNCH_APP_2: return L"launch_app_2";
+        case GHOSTTY_KEY_LAUNCH_MAIL: return L"launch_mail";
+        case GHOSTTY_KEY_MEDIA_PLAY_PAUSE: return L"media_play_pause";
+        case GHOSTTY_KEY_MEDIA_SELECT: return L"media_select";
+        case GHOSTTY_KEY_MEDIA_STOP: return L"media_stop";
+        case GHOSTTY_KEY_MEDIA_TRACK_NEXT: return L"media_track_next";
+        case GHOSTTY_KEY_MEDIA_TRACK_PREVIOUS: return L"media_track_previous";
+        case GHOSTTY_KEY_POWER: return L"power";
+        case GHOSTTY_KEY_SLEEP: return L"sleep";
+        case GHOSTTY_KEY_AUDIO_VOLUME_DOWN: return L"audio_volume_down";
+        case GHOSTTY_KEY_AUDIO_VOLUME_MUTE: return L"audio_volume_mute";
+        case GHOSTTY_KEY_AUDIO_VOLUME_UP: return L"audio_volume_up";
+        case GHOSTTY_KEY_WAKE_UP: return L"wake_up";
+        case GHOSTTY_KEY_COPY: return L"copy";
+        case GHOSTTY_KEY_CUT: return L"cut";
+        case GHOSTTY_KEY_PASTE: return L"paste";
+        default: return L"unidentified";
+    }
+}
+
+// Append the UTF-16 encoding of a Unicode codepoint (keybinds can
+// name astral-plane characters, so surrogate pairs are handled).
+void AppendCodepoint(std::wstring& out, uint32_t cp) {
+    if (cp <= 0xFFFF) {
+        out.push_back(static_cast<wchar_t>(cp));
+        return;
+    }
+    cp -= 0x10000;
+    out.push_back(static_cast<wchar_t>(0xD800 + (cp >> 10)));
+    out.push_back(static_cast<wchar_t>(0xDC00 + (cp & 0x3FF)));
+}
+
+}  // namespace
+
+std::wstring TriggerLabel(ghostty_input_trigger_s trigger) {
+    std::wstring out;
+    // Same modifier order ghostty's docs use in keybind examples.
+    if (trigger.mods & GHOSTTY_MODS_CTRL)  out += L"ctrl+";
+    if (trigger.mods & GHOSTTY_MODS_ALT)   out += L"alt+";
+    if (trigger.mods & GHOSTTY_MODS_SHIFT) out += L"shift+";
+    if (trigger.mods & GHOSTTY_MODS_SUPER) out += L"super+";
+    switch (trigger.tag) {
+        case GHOSTTY_TRIGGER_PHYSICAL:
+            // "physical:" prefix mirrors the config syntax for
+            // scancode-addressed bindings.
+            out += L"physical:";
+            out += KeyName(trigger.key.physical);
+            break;
+        case GHOSTTY_TRIGGER_UNICODE:
+            AppendCodepoint(out, trigger.key.unicode);
+            break;
+        case GHOSTTY_TRIGGER_CATCH_ALL:
+            out += L"any";
+            break;
+    }
+    return out;
+}
+
+}  // namespace core::ghostty::actions

--- a/Core/Ghostty/Actions/Tags/TriggerLabel.h
+++ b/Core/Ghostty/Actions/Tags/TriggerLabel.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "ghostty.h"
+#include <string>
+
+namespace core::ghostty::actions {
+
+// Human-readable label for a keybind trigger, in ghostty's own
+// keybind config syntax (e.g. "ctrl+shift+a", "ctrl+bracket_left").
+// Used by the KEY_SEQUENCE indicator so the pending chord on screen
+// reads exactly like the line the user wrote in their config.
+//
+// Pure function — no WinUI, no state — so the mods ordering and the
+// physical-key name table are unit-testable without a window.
+std::wstring TriggerLabel(ghostty_input_trigger_s trigger);
+
+}  // namespace core::ghostty::actions

--- a/Core/Ghostty/CallbackDispatcher.cpp
+++ b/Core/Ghostty/CallbackDispatcher.cpp
@@ -100,6 +100,19 @@ bool CallbackDispatcher::DispatchAction(ghostty_target_s target, ghostty_action_
                 return m_actions.OnMouseVisibility(target.target.surface,
                                                    action.action.mouse_visibility);
             return false;
+        // KEY_SEQUENCE / KEY_TABLE: modal keyboard state indicators.
+        // Upstream treats the app-targeted variants as no-ops (logged
+        // warnings), so those ack rather than refuse.
+        case GHOSTTY_ACTION_KEY_SEQUENCE:
+            if (target.tag == GHOSTTY_TARGET_SURFACE)
+                return m_actions.OnKeySequence(target.target.surface,
+                                               action.action.key_sequence);
+            return true;
+        case GHOSTTY_ACTION_KEY_TABLE:
+            if (target.tag == GHOSTTY_TARGET_SURFACE)
+                return m_actions.OnKeyTable(target.target.surface,
+                                            action.action.key_table);
+            return true;
         case GHOSTTY_ACTION_SECURE_INPUT:
             if (target.tag == GHOSTTY_TARGET_SURFACE)
                 return m_actions.OnSecureInput(target.target.surface,
@@ -165,12 +178,9 @@ bool CallbackDispatcher::DispatchAction(ghostty_target_s target, ghostty_action_
         // quiet without inventing empty GhosttyActions methods.
         //
         // Informational actions whose UI surfaces this port
-        // doesn't have yet (read-only banner, pending chord,
-        // modal-key-table label, shell-supplied title source flag,
-        // PWD breadcrumb, post-command summary):
+        // doesn't have yet (read-only banner, shell-supplied title
+        // source flag, PWD breadcrumb, post-command summary):
         case GHOSTTY_ACTION_READONLY:
-        case GHOSTTY_ACTION_KEY_SEQUENCE:
-        case GHOSTTY_ACTION_KEY_TABLE:
         case GHOSTTY_ACTION_PROMPT_TITLE:
         case GHOSTTY_ACTION_PWD:
         case GHOSTTY_ACTION_COMMAND_FINISHED:

--- a/Core/Host/IWindow.h
+++ b/Core/Host/IWindow.h
@@ -197,6 +197,29 @@ struct IWindow {
     virtual void SetSecureInputForSurface(ghostty_surface_t surface,
                                           ghostty_action_secure_input_e mode) = 0;
 
+    // ----- key-state indicator (KEY_SEQUENCE / KEY_TABLE) -----
+    // Both actions are surface-targeted progress reports about
+    // modal keyboard state; the pane owns the accumulated state
+    // (pending chord list, key-table stack) because that is where
+    // the indicator renders. Labels arrive pre-formatted from the
+    // Core side (TriggerLabel) so the view never touches ghostty
+    // trigger structs.
+
+    // KEY_SEQUENCE active=true: one more trigger was consumed by a
+    // pending multi-chord binding — append its label to the pane's
+    // pending display.
+    virtual void AppendKeySequenceForSurface(ghostty_surface_t surface,
+                                             std::wstring triggerLabel) = 0;
+    // KEY_SEQUENCE active=false: the sequence completed or aborted —
+    // clear the pane's pending display.
+    virtual void ClearKeySequenceForSurface(ghostty_surface_t surface) = 0;
+    // KEY_TABLE ACTIVATE: push a named table onto the pane's stack.
+    virtual void PushKeyTableForSurface(ghostty_surface_t surface,
+                                        std::wstring name) = 0;
+    // KEY_TABLE DEACTIVATE (all=false) / DEACTIVATE_ALL (all=true).
+    virtual void PopKeyTableForSurface(ghostty_surface_t surface,
+                                       bool all) = 0;
+
     // Show or clear the hovered-link banner on the pane owning
     // `surface`. MOUSE_OVER_LINK fires with the URL while the pointer
     // is on a link and with an empty payload when it leaves, so an

--- a/Tests/MockMainWindowView.h
+++ b/Tests/MockMainWindowView.h
@@ -183,6 +183,38 @@ struct MockMainWindowView : core::host::IWindow {
         lastSecureInputMode = mode;
     }
 
+    int appendKeySequenceCalls = 0;
+    ghostty_surface_t lastKeySequenceSurface = nullptr;
+    std::wstring lastKeySequenceLabel;
+    void AppendKeySequenceForSurface(ghostty_surface_t s, std::wstring label) override {
+        ++appendKeySequenceCalls;
+        lastKeySequenceSurface = s;
+        lastKeySequenceLabel = std::move(label);
+    }
+
+    int clearKeySequenceCalls = 0;
+    void ClearKeySequenceForSurface(ghostty_surface_t s) override {
+        ++clearKeySequenceCalls;
+        lastKeySequenceSurface = s;
+    }
+
+    int pushKeyTableCalls = 0;
+    ghostty_surface_t lastKeyTableSurface = nullptr;
+    std::wstring lastKeyTableName;
+    void PushKeyTableForSurface(ghostty_surface_t s, std::wstring name) override {
+        ++pushKeyTableCalls;
+        lastKeyTableSurface = s;
+        lastKeyTableName = std::move(name);
+    }
+
+    int popKeyTableCalls = 0;
+    bool lastPopKeyTableAll = false;
+    void PopKeyTableForSurface(ghostty_surface_t s, bool all) override {
+        ++popKeyTableCalls;
+        lastKeyTableSurface = s;
+        lastPopKeyTableAll = all;
+    }
+
     int setMouseVisibilityCalls = 0;
     ghostty_surface_t lastMouseVisibilitySurface = nullptr;
     bool lastMouseVisible = true;

--- a/Tests/Tests.vcxproj
+++ b/Tests/Tests.vcxproj
@@ -170,6 +170,7 @@
     <ClCompile Include="test_window_decorations.cpp" />
     <ClCompile Include="test_tab_drag.cpp" />
     <ClCompile Include="test_pressed_tab.cpp" />
+    <ClCompile Include="test_trigger_label.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="MockMainWindowView.h" />

--- a/Tests/test_ghostty_actions.cpp
+++ b/Tests/test_ghostty_actions.cpp
@@ -358,6 +358,76 @@ TEST(GhosttyActionsTest, OnSecureInputIgnoresNullSurface) {
     EXPECT_EQ(view.setSecureInputCalls, 0);
 }
 
+TEST(GhosttyActionsTest, OnKeySequenceAppendsFormattedTrigger) {
+    MockMainWindowView view;
+    Actions actions(view);
+    auto surface = FakeSurface(0x5E9);
+    ghostty_action_key_sequence_s seq{};
+    seq.active = true;
+    seq.trigger.tag = GHOSTTY_TRIGGER_UNICODE;
+    seq.trigger.key.unicode = U'a';
+    seq.trigger.mods = GHOSTTY_MODS_CTRL;
+    EXPECT_TRUE(actions.OnKeySequence(surface, seq));
+    EXPECT_EQ(view.appendKeySequenceCalls, 1);
+    EXPECT_EQ(view.lastKeySequenceSurface, surface);
+    EXPECT_EQ(view.lastKeySequenceLabel, L"ctrl+a");
+    EXPECT_EQ(view.clearKeySequenceCalls, 0);
+}
+
+TEST(GhosttyActionsTest, OnKeySequenceInactiveClears) {
+    MockMainWindowView view;
+    Actions actions(view);
+    auto surface = FakeSurface(0x5E9);
+    ghostty_action_key_sequence_s seq{};
+    seq.active = false;
+    EXPECT_TRUE(actions.OnKeySequence(surface, seq));
+    EXPECT_EQ(view.clearKeySequenceCalls, 1);
+    EXPECT_EQ(view.appendKeySequenceCalls, 0);
+}
+
+TEST(GhosttyActionsTest, OnKeyTableActivatePushesLengthBoundedName) {
+    MockMainWindowView view;
+    Actions actions(view);
+    auto surface = FakeSurface(0x7AB);
+    // Longer buffer than len — the name is not NUL-terminated.
+    const char buf[] = "resizeTRAILING";
+    ghostty_action_key_table_s kt{};
+    kt.tag = GHOSTTY_KEY_TABLE_ACTIVATE;
+    kt.value.activate = { buf, 6 };
+    EXPECT_TRUE(actions.OnKeyTable(surface, kt));
+    EXPECT_EQ(view.pushKeyTableCalls, 1);
+    EXPECT_EQ(view.lastKeyTableSurface, surface);
+    EXPECT_EQ(view.lastKeyTableName, L"resize");
+}
+
+TEST(GhosttyActionsTest, OnKeyTableDeactivateVariantsPop) {
+    MockMainWindowView view;
+    Actions actions(view);
+    auto surface = FakeSurface(0x7AB);
+    ghostty_action_key_table_s kt{};
+    kt.tag = GHOSTTY_KEY_TABLE_DEACTIVATE;
+    EXPECT_TRUE(actions.OnKeyTable(surface, kt));
+    EXPECT_EQ(view.popKeyTableCalls, 1);
+    EXPECT_FALSE(view.lastPopKeyTableAll);
+    kt.tag = GHOSTTY_KEY_TABLE_DEACTIVATE_ALL;
+    EXPECT_TRUE(actions.OnKeyTable(surface, kt));
+    EXPECT_EQ(view.popKeyTableCalls, 2);
+    EXPECT_TRUE(view.lastPopKeyTableAll);
+}
+
+TEST(GhosttyActionsTest, KeyStateHandlersIgnoreNullSurface) {
+    MockMainWindowView view;
+    Actions actions(view);
+    ghostty_action_key_sequence_s seq{};
+    seq.active = true;
+    EXPECT_TRUE(actions.OnKeySequence(nullptr, seq));
+    ghostty_action_key_table_s kt{};
+    kt.tag = GHOSTTY_KEY_TABLE_DEACTIVATE;
+    EXPECT_TRUE(actions.OnKeyTable(nullptr, kt));
+    EXPECT_EQ(view.appendKeySequenceCalls, 0);
+    EXPECT_EQ(view.popKeyTableCalls, 0);
+}
+
 TEST(GhosttyActionsTest, OnMouseOverLinkIgnoresNullSurface) {
     MockMainWindowView view;
     Actions actions(view);

--- a/Tests/test_ghostty_callback_dispatcher.cpp
+++ b/Tests/test_ghostty_callback_dispatcher.cpp
@@ -37,8 +37,13 @@ TEST(GhosttyCallbackDispatcherTest, InformationalAcksReturnTrue) {
     // surface-targeted variant routes (see the routing tests below).
     EXPECT_TRUE(DispatchTag(*d, GHOSTTY_ACTION_SECURE_INPUT));
     EXPECT_EQ(view.setSecureInputCalls, 0);
+    // KEY_SEQUENCE / KEY_TABLE with an app target: upstream logs a
+    // warning and ignores them — acked here. Surface-targeted
+    // delivery routes (see the routing tests below).
     EXPECT_TRUE(DispatchTag(*d, GHOSTTY_ACTION_KEY_SEQUENCE));
     EXPECT_TRUE(DispatchTag(*d, GHOSTTY_ACTION_KEY_TABLE));
+    EXPECT_EQ(view.appendKeySequenceCalls + view.clearKeySequenceCalls +
+              view.pushKeyTableCalls + view.popKeyTableCalls, 0);
     EXPECT_TRUE(DispatchTag(*d, GHOSTTY_ACTION_PROMPT_TITLE));
     EXPECT_TRUE(DispatchTag(*d, GHOSTTY_ACTION_PWD));
     EXPECT_TRUE(DispatchTag(*d, GHOSTTY_ACTION_COMMAND_FINISHED));
@@ -125,6 +130,32 @@ TEST(GhosttyCallbackDispatcherTest, MouseVisibilityRoutesToTheOwningSurface) {
 
     // App-targeted delivery has no owning pane — refuse.
     EXPECT_FALSE(DispatchTag(*d, GHOSTTY_ACTION_MOUSE_VISIBILITY));
+}
+
+TEST(GhosttyCallbackDispatcherTest, KeyStateActionsRouteToTheOwningSurface) {
+    MockMainWindowView view;
+    auto d = CallbackDispatcher::Create(view);
+
+    ghostty_target_s target{};
+    target.tag = GHOSTTY_TARGET_SURFACE;
+    target.target.surface = reinterpret_cast<ghostty_surface_t>(0xBEEF);
+
+    ghostty_action_s action{};
+    action.tag = GHOSTTY_ACTION_KEY_SEQUENCE;
+    action.action.key_sequence.active = true;
+    action.action.key_sequence.trigger.tag = GHOSTTY_TRIGGER_UNICODE;
+    action.action.key_sequence.trigger.key.unicode = U'a';
+    action.action.key_sequence.trigger.mods = GHOSTTY_MODS_CTRL;
+    EXPECT_TRUE(d->DispatchAction(target, action));
+    EXPECT_EQ(view.appendKeySequenceCalls, 1);
+    EXPECT_EQ(view.lastKeySequenceLabel, L"ctrl+a");
+
+    ghostty_action_s tableAction{};
+    tableAction.tag = GHOSTTY_ACTION_KEY_TABLE;
+    tableAction.action.key_table.tag = GHOSTTY_KEY_TABLE_DEACTIVATE_ALL;
+    EXPECT_TRUE(d->DispatchAction(target, tableAction));
+    EXPECT_EQ(view.popKeyTableCalls, 1);
+    EXPECT_TRUE(view.lastPopKeyTableAll);
 }
 
 TEST(GhosttyCallbackDispatcherTest, SecureInputRoutesToTheOwningSurface) {

--- a/Tests/test_trigger_label.cpp
+++ b/Tests/test_trigger_label.cpp
@@ -1,0 +1,59 @@
+#include "pch.h"
+#include "../Core/Ghostty/Actions/Tags/TriggerLabel.h"
+
+using core::ghostty::actions::TriggerLabel;
+
+namespace {
+
+ghostty_input_trigger_s UnicodeTrigger(uint32_t cp, int mods) {
+    ghostty_input_trigger_s t{};
+    t.tag = GHOSTTY_TRIGGER_UNICODE;
+    t.key.unicode = cp;
+    t.mods = static_cast<ghostty_input_mods_e>(mods);
+    return t;
+}
+
+}  // namespace
+
+TEST(TriggerLabelTest, UnicodeKeyWithMods) {
+    EXPECT_EQ(TriggerLabel(UnicodeTrigger(U'a', GHOSTTY_MODS_CTRL)),
+              L"ctrl+a");
+    EXPECT_EQ(TriggerLabel(UnicodeTrigger(U'b',
+                                          GHOSTTY_MODS_CTRL | GHOSTTY_MODS_SHIFT)),
+              L"ctrl+shift+b");
+}
+
+TEST(TriggerLabelTest, ModOrderIsCtrlAltShiftSuper) {
+    EXPECT_EQ(TriggerLabel(UnicodeTrigger(U'x',
+                                          GHOSTTY_MODS_SUPER | GHOSTTY_MODS_SHIFT |
+                                          GHOSTTY_MODS_ALT | GHOSTTY_MODS_CTRL)),
+              L"ctrl+alt+shift+super+x");
+}
+
+TEST(TriggerLabelTest, NoModsIsBareKey) {
+    EXPECT_EQ(TriggerLabel(UnicodeTrigger(U'g', GHOSTTY_MODS_NONE)), L"g");
+}
+
+TEST(TriggerLabelTest, PhysicalKeyUsesConfigSyntaxName) {
+    ghostty_input_trigger_s t{};
+    t.tag = GHOSTTY_TRIGGER_PHYSICAL;
+    t.key.physical = GHOSTTY_KEY_BRACKET_LEFT;
+    t.mods = GHOSTTY_MODS_CTRL;
+    EXPECT_EQ(TriggerLabel(t), L"ctrl+physical:bracket_left");
+}
+
+TEST(TriggerLabelTest, UnknownPhysicalKeyFallsBack) {
+    ghostty_input_trigger_s t{};
+    t.tag = GHOSTTY_TRIGGER_PHYSICAL;
+    t.key.physical = static_cast<ghostty_input_key_e>(9999);
+    EXPECT_EQ(TriggerLabel(t), L"physical:unidentified");
+}
+
+TEST(TriggerLabelTest, AstralCodepointBecomesSurrogatePair) {
+    // U+1F512 (the padlock) needs a UTF-16 surrogate pair; a naive
+    // single-wchar cast would produce a garbage character.
+    auto label = TriggerLabel(UnicodeTrigger(0x1F512, GHOSTTY_MODS_NONE));
+    ASSERT_EQ(label.size(), 2u);
+    EXPECT_EQ(label[0], wchar_t{0xD83D});
+    EXPECT_EQ(label[1], wchar_t{0xDD12});
+}


### PR DESCRIPTION
## Summary

Second of the "informational" coverage batch (#57): `KEY_SEQUENCE` and `KEY_TABLE` now feed a pane badge. Mid-chord (`ctrl+g>…`) the bottom-right corner shows the keys pressed so far; while a modal key table is active it shows the table name — so the keyboard "going silent" always has an explanation on screen.

<details>
<summary>日本語</summary>

#57 の「informational」カバレッジ埋めの第 2 弾。`KEY_SEQUENCE` と `KEY_TABLE` を pane バッジに反映する。chord の途中 (`ctrl+g>…`) は右下にここまで押したキーが出て、modal な key table が有効な間はテーブル名が出る — 「キーボードが急に文字を打たなくなる」状態に、必ず画面上の説明が付くようになる。

</details>

## Design

- **Third corner overlay**: link banner bottom-left (#142), secure-input badge top-right (#145), key state bottom-right. Same in-tree, hit-test-transparent pattern; the three can never collide.
- **State lives on the pane**: both actions only carry deltas (KEY_SEQUENCE appends one trigger / clears; KEY_TABLE pushes a name / pops / clears), so `TerminalControl` owns the chord list and the table-name stack, mirroring upstream's `surfaceView.keySequence` / `keyTables`.
- **Trigger formatting is a Core pure function**: `TriggerLabel` (`Core/Ghostty/Actions/Tags/TriggerLabel.{h,cpp}`) renders ghostty's own keybind syntax (`ctrl+shift+a`, `ctrl+physical:bracket_left`), so what appears on screen reads exactly like the user's config line. The 176-entry physical-key name table is generated mechanically from the `ghostty_input_key_e` enum in `ghostty.h`; unknown values fall back to `unidentified`. Unicode triggers handle astral codepoints via surrogate pairs. Being winrt-free, all of it is unit-tested.
- **App-targeted delivery acks** — upstream logs a warning and ignores it, so refusing would be noisier than the reference behavior.
- Upstream's `KeyStateIndicator` extras (draggable position, click-for-popover listing the table's bindings) are deliberately out of scope for v1.

<details>
<summary>日本語</summary>

- **3 つ目のコーナーオーバーレイ**: link banner が左下 (#142)、secure-input バッジが右上 (#145)、key state は右下。同じ in-tree・hit-test 透過パターンで、3 つは構造上衝突しない
- **状態は pane が持つ**: 両 action とも差分しか運ばない (KEY_SEQUENCE は trigger を 1 個追加 / クリア、KEY_TABLE は名前を push / pop / 全クリア) ので、chord のリストとテーブル名スタックは `TerminalControl` が所有。本家の `surfaceView.keySequence` / `keyTables` と同じ置き方
- **trigger の整形は Core の pure function**: `TriggerLabel` (`Core/Ghostty/Actions/Tags/TriggerLabel.{h,cpp}`) が ghostty 自身の keybind 構文 (`ctrl+shift+a`、`ctrl+physical:bracket_left`) で描画するので、画面の表示が config に書いた行とそのまま一致する。176 個の物理キー名テーブルは `ghostty.h` の `ghostty_input_key_e` enum から機械生成、未知の値は `unidentified` にフォールバック。Unicode trigger は astral 面もサロゲートペアで処理。winrt 非依存なので全部ユニットテスト済み
- **app 宛は ack** — 本家も warning ログを出して無視する挙動なので、拒否 (false) にすると参照実装より騒がしくなる
- 本家 `KeyStateIndicator` の付加機能 (ドラッグでの位置変更、クリックでテーブル内 binding 一覧の popover) は v1 では意図的に対象外

</details>

## Changes

- `Core/Ghostty/Actions/Tags/TriggerLabel.{h,cpp}` (new) — trigger → label, generated key-name table included.
- `Core/Ghostty/CallbackDispatcher.cpp` — `KEY_SEQUENCE` / `KEY_TABLE` leave the informational ack list; surface routes, app acks.
- `Core/Ghostty/Actions/Actions.{h,cpp}` — `OnKeySequence` (formats on the renderer thread, view only sees text) / `OnKeyTable` (ACTIVATE name is length-bounded, not NUL-terminated).
- `Core/Host/IWindow.h` — `AppendKeySequenceForSurface` / `ClearKeySequenceForSurface` / `PushKeyTableForSurface` / `PopKeyTableForSurface`.
- `App/TerminalControl.xaml{,.h,.cpp}` — `KeyStateBadge` + the four mutators + `UpdateKeyStateBadge()` composing "table · ctrl+a …".
- `App/MainWindow.xaml.cpp` — owning-leaf routing for the four operations.
- Tests — `test_trigger_label.cpp` (mod order, physical names, fallback, surrogate pairs); Actions (append/clear, length-bounded table name, pop variants, null-surface); dispatcher (surface routes, app-target touches nothing).

<details>
<summary>日本語</summary>

- `Core/Ghostty/Actions/Tags/TriggerLabel.{h,cpp}` (新規) — trigger → ラベル。生成したキー名テーブル込み
- `Core/Ghostty/CallbackDispatcher.cpp` — `KEY_SEQUENCE` / `KEY_TABLE` を informational ack リストから外し、surface 宛は routing、app 宛は ack
- `Core/Ghostty/Actions/Actions.{h,cpp}` — `OnKeySequence` (renderer スレッドで整形し view にはテキストだけ渡す) / `OnKeyTable` (ACTIVATE の name は NUL 終端ではないので len で制限)
- `Core/Host/IWindow.h` — `AppendKeySequenceForSurface` / `ClearKeySequenceForSurface` / `PushKeyTableForSurface` / `PopKeyTableForSurface`
- `App/TerminalControl.xaml{,.h,.cpp}` — `KeyStateBadge` と 4 つのミューテータ、「table · ctrl+a …」を組み立てる `UpdateKeyStateBadge()`
- `App/MainWindow.xaml.cpp` — 4 操作の所有 leaf routing
- テスト — `test_trigger_label.cpp` (mod の順序、物理キー名、フォールバック、サロゲートペア)、Actions (append/clear、len 制限の table 名、pop の 2 種、null surface)、dispatcher (surface 宛 routing、app 宛は view 不干渉)

</details>

## Verification

Config (already added to the local config):

```
keybind = ctrl+g>n=new_tab
keybind = ctrl+g>t=activate_key_table:demo
keybind = demo/n=new_tab
keybind = demo/escape=deactivate_key_table
```

- [x] Tests.exe green (TriggerLabel + new dispatcher/Actions tests)
- [x] Press `Ctrl+G` — bottom-right badge shows `ctrl+g …`
- [x] Then `n` — a new tab opens and the badge disappears (sequence completed)
- [x] Press `Ctrl+G` then an unbound key (e.g. `x`) — badge disappears (sequence aborted)
- [x] `Ctrl+G` then `t` — badge shows `demo` (key table active); `n` inside opens a tab and `demo` stays; `Esc` clears the badge
- [x] Splits: the badge appears on the pane you typed in
- [x] Light/dark theme: badge colors follow the theme

<details>
<summary>日本語</summary>

config (ローカル config に追加済み):

- Tests.exe が green (TriggerLabel + 新規 dispatcher / Actions テスト)
- `Ctrl+G` を押す — 右下バッジに `ctrl+g …` が出る
- 続けて `n` — 新しいタブが開き、バッジが消える (sequence 完了)
- `Ctrl+G` のあと未割り当てキー (`x` 等) — バッジが消える (sequence 中断)
- `Ctrl+G` → `t` — バッジに `demo` (key table 有効)。table 内の `n` でタブが開いても `demo` は残り、`Esc` でバッジが消える
- split: バッジはタイプした pane に出る
- ライト / ダークテーマ: バッジの色がテーマに追従する

</details>
