### PR TITLE
Show the shell-reported working directory as the tab tooltip

### DIFF
--- a/App/MainWindow.xaml.cpp
+++ b/App/MainWindow.xaml.cpp
@@ -1622,6 +1622,18 @@ namespace winrt::GhosttyWin32::implementation
         }
     }
 
+    void MainWindow::SetPwdForSurface(ghostty_surface_t surface, std::wstring pwd)
+    {
+        // Tab-level, not pane-level: the tooltip hangs off the
+        // TabViewItem. With splits the last pane to report wins —
+        // "the directory the user last worked in".
+        auto* t = m_tabs.FindBySurface(surface);
+        if (!t) return;
+        Microsoft::UI::Xaml::Controls::ToolTipService::SetToolTip(
+            t->Item(),
+            pwd.empty() ? nullptr : box_value(winrt::hstring{ pwd }));
+    }
+
     // KEY_SEQUENCE / KEY_TABLE: owning-leaf routing like the other
     // pane-visual actions; the four operations share the lookup and
     // differ only in which TerminalControl mutator they call.

--- a/App/MainWindow.xaml.h
+++ b/App/MainWindow.xaml.h
@@ -140,6 +140,8 @@ namespace winrt::GhosttyWin32::implementation
                                           bool visible) override;
         void SetSecureInputForSurface(ghostty_surface_t surface,
                                       ghostty_action_secure_input_e mode) override;
+        void SetPwdForSurface(ghostty_surface_t surface,
+                              std::wstring pwd) override;
         void AppendKeySequenceForSurface(ghostty_surface_t surface,
                                          std::wstring triggerLabel) override;
         void ClearKeySequenceForSurface(ghostty_surface_t surface) override;

--- a/Core/Ghostty/Actions/Actions.cpp
+++ b/Core/Ghostty/Actions/Actions.cpp
@@ -373,6 +373,19 @@ bool Actions::OnSecureInput(ghostty_surface_t surface,
     return true;
 }
 
+bool Actions::OnPwd(ghostty_surface_t surface, const char* utf8Pwd) {
+    if (!surface) return true;
+    // Unlike most string payloads, pwd IS NUL-terminated (matches
+    // the macOS apprt's String(cString:) usage). An empty string is
+    // dispatched through so the view can clear the tooltip.
+    std::wstring wide = utf8Pwd ? interop::Encoding::toUtf16(utf8Pwd)
+                                : std::wstring{};
+    DispatchToView([this, surface, wide = std::move(wide)]() mutable {
+        m_view.SetPwdForSurface(surface, std::move(wide));
+    });
+    return true;
+}
+
 bool Actions::OnKeySequence(ghostty_surface_t surface,
                             ghostty_action_key_sequence_s seq) {
     if (!surface) return true;

--- a/Core/Ghostty/Actions/Actions.h
+++ b/Core/Ghostty/Actions/Actions.h
@@ -136,6 +136,8 @@ public:
     // SECURE_INPUT (surface-targeted): password-prompt indicator.
     bool OnSecureInput(ghostty_surface_t surface,
                        ghostty_action_secure_input_e mode);
+    // PWD: shell-reported working directory (OSC 7).
+    bool OnPwd(ghostty_surface_t surface, const char* utf8Pwd);
     // KEY_SEQUENCE: pending-chord progress. Formats the trigger via
     // TriggerLabel on the renderer thread so the view only sees text.
     bool OnKeySequence(ghostty_surface_t surface,

--- a/Core/Ghostty/CallbackDispatcher.cpp
+++ b/Core/Ghostty/CallbackDispatcher.cpp
@@ -100,6 +100,13 @@ bool CallbackDispatcher::DispatchAction(ghostty_target_s target, ghostty_action_
                 return m_actions.OnMouseVisibility(target.target.surface,
                                                    action.action.mouse_visibility);
             return false;
+        // PWD: shell-reported working directory. Upstream treats the
+        // app-targeted variant as a no-op (logged warning) — ack.
+        case GHOSTTY_ACTION_PWD:
+            if (target.tag == GHOSTTY_TARGET_SURFACE)
+                return m_actions.OnPwd(target.target.surface,
+                                       action.action.pwd.pwd);
+            return true;
         // KEY_SEQUENCE / KEY_TABLE: modal keyboard state indicators.
         // Upstream treats the app-targeted variants as no-ops (logged
         // warnings), so those ack rather than refuse.
@@ -179,10 +186,9 @@ bool CallbackDispatcher::DispatchAction(ghostty_target_s target, ghostty_action_
         //
         // Informational actions whose UI surfaces this port
         // doesn't have yet (read-only banner, shell-supplied title
-        // source flag, PWD breadcrumb, post-command summary):
+        // source flag, post-command summary):
         case GHOSTTY_ACTION_READONLY:
         case GHOSTTY_ACTION_PROMPT_TITLE:
-        case GHOSTTY_ACTION_PWD:
         case GHOSTTY_ACTION_COMMAND_FINISHED:
         // Feature surfaces intentionally not on this port's plate
         // (search bar, ImGui inspector, tab overview, quick

--- a/Core/Host/IWindow.h
+++ b/Core/Host/IWindow.h
@@ -197,6 +197,13 @@ struct IWindow {
     virtual void SetSecureInputForSurface(ghostty_surface_t surface,
                                           ghostty_action_secure_input_e mode) = 0;
 
+    // PWD: the shell reported its working directory (OSC 7). Shown
+    // as the tooltip of the tab containing `surface` — with splits,
+    // the last pane to report wins, which matches "the directory
+    // the user last worked in". An empty pwd clears the tooltip.
+    virtual void SetPwdForSurface(ghostty_surface_t surface,
+                                  std::wstring pwd) = 0;
+
     // ----- key-state indicator (KEY_SEQUENCE / KEY_TABLE) -----
     // Both actions are surface-targeted progress reports about
     // modal keyboard state; the pane owns the accumulated state

--- a/Tests/MockMainWindowView.h
+++ b/Tests/MockMainWindowView.h
@@ -183,6 +183,15 @@ struct MockMainWindowView : core::host::IWindow {
         lastSecureInputMode = mode;
     }
 
+    int setPwdCalls = 0;
+    ghostty_surface_t lastPwdSurface = nullptr;
+    std::wstring lastPwd;
+    void SetPwdForSurface(ghostty_surface_t s, std::wstring pwd) override {
+        ++setPwdCalls;
+        lastPwdSurface = s;
+        lastPwd = std::move(pwd);
+    }
+
     int appendKeySequenceCalls = 0;
     ghostty_surface_t lastKeySequenceSurface = nullptr;
     std::wstring lastKeySequenceLabel;

--- a/Tests/test_ghostty_actions.cpp
+++ b/Tests/test_ghostty_actions.cpp
@@ -358,6 +358,35 @@ TEST(GhosttyActionsTest, OnSecureInputIgnoresNullSurface) {
     EXPECT_EQ(view.setSecureInputCalls, 0);
 }
 
+TEST(GhosttyActionsTest, OnPwdForwardsUtf16Path) {
+    MockMainWindowView view;
+    Actions actions(view);
+    auto surface = FakeSurface(0x9D);
+    EXPECT_TRUE(actions.OnPwd(surface, "C:/Users/dev/repos"));
+    EXPECT_EQ(view.setPwdCalls, 1);
+    EXPECT_EQ(view.lastPwdSurface, surface);
+    EXPECT_EQ(view.lastPwd, L"C:/Users/dev/repos");
+}
+
+TEST(GhosttyActionsTest, OnPwdEmptyOrNullClearsTooltip) {
+    // Both reach the view as an empty string — the view clears the
+    // tooltip; dropping them would leave a stale path displayed.
+    MockMainWindowView view;
+    Actions actions(view);
+    auto surface = FakeSurface(0x9D);
+    EXPECT_TRUE(actions.OnPwd(surface, ""));
+    EXPECT_TRUE(actions.OnPwd(surface, nullptr));
+    EXPECT_EQ(view.setPwdCalls, 2);
+    EXPECT_TRUE(view.lastPwd.empty());
+}
+
+TEST(GhosttyActionsTest, OnPwdIgnoresNullSurface) {
+    MockMainWindowView view;
+    Actions actions(view);
+    EXPECT_TRUE(actions.OnPwd(nullptr, "C:/x"));
+    EXPECT_EQ(view.setPwdCalls, 0);
+}
+
 TEST(GhosttyActionsTest, OnKeySequenceAppendsFormattedTrigger) {
     MockMainWindowView view;
     Actions actions(view);

--- a/Tests/test_ghostty_callback_dispatcher.cpp
+++ b/Tests/test_ghostty_callback_dispatcher.cpp
@@ -132,6 +132,26 @@ TEST(GhosttyCallbackDispatcherTest, MouseVisibilityRoutesToTheOwningSurface) {
     EXPECT_FALSE(DispatchTag(*d, GHOSTTY_ACTION_MOUSE_VISIBILITY));
 }
 
+TEST(GhosttyCallbackDispatcherTest, PwdRoutesToTheOwningSurface) {
+    MockMainWindowView view;
+    auto d = CallbackDispatcher::Create(view);
+
+    ghostty_target_s target{};
+    target.tag = GHOSTTY_TARGET_SURFACE;
+    target.target.surface = reinterpret_cast<ghostty_surface_t>(0xBEEF);
+    ghostty_action_s action{};
+    action.tag = GHOSTTY_ACTION_PWD;
+    action.action.pwd.pwd = "C:/Users/dev";
+
+    EXPECT_TRUE(d->DispatchAction(target, action));
+    EXPECT_EQ(view.setPwdCalls, 1);
+    EXPECT_EQ(view.lastPwd, L"C:/Users/dev");
+
+    // App-targeted PWD: upstream logs and ignores — acked.
+    EXPECT_TRUE(DispatchTag(*d, GHOSTTY_ACTION_PWD));
+    EXPECT_EQ(view.setPwdCalls, 1);
+}
+
 TEST(GhosttyCallbackDispatcherTest, KeyStateActionsRouteToTheOwningSurface) {
     MockMainWindowView view;
     auto d = CallbackDispatcher::Create(view);


### PR DESCRIPTION
## Summary

Third of the "informational" coverage batch (#57): `PWD` — the working directory the shell reports via OSC 7 — now shows as the tab's tooltip. Hovering a tab tells you where that session lives.

<details>
<summary>日本語</summary>

#57 の「informational」カバレッジ埋めの第 3 弾。shell が OSC 7 で報告する作業ディレクトリ (`PWD`) をタブの tooltip に出す。タブに hover すると、そのセッションがどこにいるか分かる。

</details>

## Design

- **Tab-level, not pane-level**: the tooltip hangs off the `TabViewItem`. With splits the last pane to report wins — that reads naturally as "the directory the user last worked in". Noted in code.
- **Empty report clears** the tooltip instead of leaving a stale path.
- Payload note: unlike most ghostty string payloads, `pwd` **is** NUL-terminated (the macOS apprt consumes it with `String(cString:)`), so no length plumbing is needed.
- App-targeted delivery acks — upstream logs a warning and ignores it.
- macOS additionally drives its titlebar proxy icon from pwd; Windows has no equivalent affordance, so the tooltip is the whole feature here.

<details>
<summary>日本語</summary>

- **pane 単位ではなく tab 単位**: tooltip は `TabViewItem` に付く。split 中は最後に報告した pane が勝つ — 「ユーザーが最後に作業したディレクトリ」として自然な意味になる。コードにも明記
- **空の報告で tooltip をクリア** — 古いパスを残さない
- payload 補足: ghostty の文字列 payload では珍しく `pwd` は NUL 終端**あり** (macOS apprt が `String(cString:)` で消費している) なので、長さの配管は不要
- app 宛は ack — 本家も warning ログを出して無視する
- macOS は pwd をタイトルバーの proxy icon にも使うが、Windows に相当する UI はないので、ここでは tooltip がこの機能のすべて

</details>

## Changes

- `Core/Ghostty/CallbackDispatcher.cpp` — `PWD` leaves the informational ack list; surface routes, app acks.
- `Core/Ghostty/Actions/Actions.{h,cpp}` — `OnPwd` (UTF-8 → UTF-16 on the renderer thread; empty/null flows through as empty so the view clears).
- `Core/Host/IWindow.h` — new `SetPwdForSurface(surface, pwd)`.
- `App/MainWindow.xaml.cpp` — `FindBySurface` → `ToolTipService::SetToolTip` on the tab item; empty pwd sets a null tooltip.
- Tests — dispatcher (surface routes, app-target acks without touching the view); Actions (forward, empty/null clear, null-surface guard).

<details>
<summary>日本語</summary>

- `Core/Ghostty/CallbackDispatcher.cpp` — `PWD` を informational ack リストから外し、surface 宛は routing、app 宛は ack
- `Core/Ghostty/Actions/Actions.{h,cpp}` — `OnPwd` (renderer スレッドで UTF-8 → UTF-16。空/null は空文字列として流し view がクリアする)
- `Core/Host/IWindow.h` — `SetPwdForSurface(surface, pwd)` を追加
- `App/MainWindow.xaml.cpp` — `FindBySurface` → tab item に `ToolTipService::SetToolTip`。空 pwd は tooltip を null に
- テスト — dispatcher (surface 宛 routing、app 宛は view 不干渉の ack)、Actions (転送、空/null でクリア、null surface ガード)

</details>

## Verification

Shell integration is disabled in this environment, but OSC 7 is a plain escape sequence any process can emit — no integration needed. Note the hostname: ghostty validates it (rejects non-local hosts, and a host-less file:/// URI fails with UriMissingHost), so use file://localhost/...:

```powershell
Write-Host -NoNewline "`e]7;file://localhost/C:/Windows`e\"
```

- [x] Tests.exe green (new dispatcher/Actions tests included)
- [x] Run the command above, then hover the tab — a tooltip with the reported path appears
- [x] Emit it again with a different path — the tooltip updates
- [x] Splits: emit from the other pane — the same tab's tooltip updates (last reporter wins)
- [x] A fresh tab (no OSC 7 yet) shows the default header tooltip (WinUI TabViewItem standard behavior — the tab title), never another tab's pwd

<details>
<summary>日本語</summary>

shell integration はこの環境では無効だが、OSC 7 はただのエスケープシーケンスなので integration なしで撃てる (上の PowerShell コマンド)。

- Tests.exe が green (新規 dispatcher / Actions テスト含む)
- 上のコマンド実行後、タブに hover — 報告したパスの tooltip が出る
- 別のパスでもう一度実行 — tooltip が更新される
- split: もう片方の pane から実行 — 同じタブの tooltip が更新される (最後の報告者が勝つ)
- 新規タブ (OSC 7 未送信) の tooltip は既定のタブタイトル (WinUI TabViewItem の標準挙動)。他タブの pwd が漏れて出ることはない

</details>
