### PR TITLE
Notify when a tracked command finishes

### DIFF
--- a/App/MainWindow.xaml.cpp
+++ b/App/MainWindow.xaml.cpp
@@ -2,6 +2,7 @@
 #include "MainWindow.xaml.h"
 #include "App.xaml.h"
 #include "Ghostty/CallbackDispatcher.h"
+#include "Ghostty/Config.h"
 #include "Host/KeyModifiers.h"
 #include "Interop/Encoding.h"
 #include "Display/PhysicalPixels.h"
@@ -1619,6 +1620,68 @@ namespace winrt::GhosttyWin32::implementation
         if (!lookup.pane) return;
         if (auto* tc = Tab::PaneToTerminalControl(*lookup.pane)) {
             tc->SetSecureInput(mode);
+        }
+    }
+
+    namespace {
+        // "2m 5s" / "12s" style, for the command-finished toast body.
+        // Sub-second commands rarely qualify (the default threshold
+        // is 5s), so second granularity is enough.
+        winrt::hstring FormatDurationNs(uint64_t ns) {
+            const uint64_t totalSec = ns / 1'000'000'000ull;
+            wchar_t buf[64];
+            if (totalSec >= 3600) {
+                swprintf_s(buf, L"%lluh %llum",
+                           totalSec / 3600, (totalSec % 3600) / 60);
+            } else if (totalSec >= 60) {
+                swprintf_s(buf, L"%llum %llus",
+                           totalSec / 60, totalSec % 60);
+            } else {
+                swprintf_s(buf, L"%llus", totalSec);
+            }
+            return winrt::hstring{ buf };
+        }
+    }
+
+    void MainWindow::NotifyCommandFinishedForSurface(ghostty_surface_t surface,
+                                                     int exitCode,
+                                                     uint64_t durationNs)
+    {
+        // Policy mirrors macOS commandFinished: config gate first
+        // (mode, then duration threshold), then the configured
+        // actions. Config is read fresh per event so a reload takes
+        // effect without replumbing.
+        core::ghostty::Config cfg{ m_ghosttyApp->ConfigHandle() };
+        using Notify = core::ghostty::Config::NotifyOnCommandFinish;
+        const auto mode = cfg.CommandFinishNotify();
+        if (mode == Notify::Never) return;
+        if (mode == Notify::Unfocused) {
+            // "Focused" means the pane is this window's active
+            // surface AND the window is in the foreground — a
+            // command finishing in a visible, focused pane needs no
+            // announcement.
+            const bool focused = surface == m_activeSurface &&
+                                 GetForegroundWindow() == m_hwnd;
+            if (focused) return;
+        }
+        if (durationNs < cfg.CommandFinishNotifyAfterNs()) return;
+
+        const auto actions = cfg.CommandFinishNotifyActions();
+        if (actions.bell) MessageBeep(MB_OK);
+        if (actions.notify) {
+            // Title wording matches upstream macOS; exitCode < 0
+            // means the shell didn't report one.
+            std::wstring title = exitCode < 0 ? L"Command Finished"
+                                : exitCode == 0 ? L"Command Succeeded"
+                                                : L"Command Failed";
+            std::wstring body = L"Finished in ";
+            body += FormatDurationNs(durationNs);
+            if (exitCode >= 0) {
+                body += L" (exit ";
+                body += std::to_wstring(exitCode);
+                body += L")";
+            }
+            ShowDesktopNotification(surface, std::move(title), std::move(body));
         }
     }
 

--- a/App/MainWindow.xaml.h
+++ b/App/MainWindow.xaml.h
@@ -142,6 +142,9 @@ namespace winrt::GhosttyWin32::implementation
                                       ghostty_action_secure_input_e mode) override;
         void SetPwdForSurface(ghostty_surface_t surface,
                               std::wstring pwd) override;
+        void NotifyCommandFinishedForSurface(ghostty_surface_t surface,
+                                             int exitCode,
+                                             uint64_t durationNs) override;
         void AppendKeySequenceForSurface(ghostty_surface_t surface,
                                          std::wstring triggerLabel) override;
         void ClearKeySequenceForSurface(ghostty_surface_t surface) override;

--- a/Core/Ghostty/Actions/Actions.cpp
+++ b/Core/Ghostty/Actions/Actions.cpp
@@ -386,6 +386,17 @@ bool Actions::OnPwd(ghostty_surface_t surface, const char* utf8Pwd) {
     return true;
 }
 
+bool Actions::OnCommandFinished(ghostty_surface_t surface,
+                                ghostty_action_command_finished_s cf) {
+    if (!surface) return true;
+    const int exitCode = cf.exit_code;   // -1 = not reported
+    const uint64_t durationNs = cf.duration;
+    DispatchToView([this, surface, exitCode, durationNs]() {
+        m_view.NotifyCommandFinishedForSurface(surface, exitCode, durationNs);
+    });
+    return true;
+}
+
 bool Actions::OnKeySequence(ghostty_surface_t surface,
                             ghostty_action_key_sequence_s seq) {
     if (!surface) return true;

--- a/Core/Ghostty/Actions/Actions.h
+++ b/Core/Ghostty/Actions/Actions.h
@@ -138,6 +138,9 @@ public:
                        ghostty_action_secure_input_e mode);
     // PWD: shell-reported working directory (OSC 7).
     bool OnPwd(ghostty_surface_t surface, const char* utf8Pwd);
+    // COMMAND_FINISHED: policy (config + focus) lives in the view.
+    bool OnCommandFinished(ghostty_surface_t surface,
+                           ghostty_action_command_finished_s cf);
     // KEY_SEQUENCE: pending-chord progress. Formats the trigger via
     // TriggerLabel on the renderer thread so the view only sees text.
     bool OnKeySequence(ghostty_surface_t surface,

--- a/Core/Ghostty/CallbackDispatcher.cpp
+++ b/Core/Ghostty/CallbackDispatcher.cpp
@@ -100,6 +100,13 @@ bool CallbackDispatcher::DispatchAction(ghostty_target_s target, ghostty_action_
                 return m_actions.OnMouseVisibility(target.target.surface,
                                                    action.action.mouse_visibility);
             return false;
+        // COMMAND_FINISHED: shell-integration command tracking. The
+        // app-targeted variant is a no-op upstream — ack.
+        case GHOSTTY_ACTION_COMMAND_FINISHED:
+            if (target.tag == GHOSTTY_TARGET_SURFACE)
+                return m_actions.OnCommandFinished(target.target.surface,
+                                                   action.action.command_finished);
+            return true;
         // PWD: shell-reported working directory. Upstream treats the
         // app-targeted variant as a no-op (logged warning) — ack.
         case GHOSTTY_ACTION_PWD:
@@ -186,10 +193,9 @@ bool CallbackDispatcher::DispatchAction(ghostty_target_s target, ghostty_action_
         //
         // Informational actions whose UI surfaces this port
         // doesn't have yet (read-only banner, shell-supplied title
-        // source flag, post-command summary):
+        // source flag):
         case GHOSTTY_ACTION_READONLY:
         case GHOSTTY_ACTION_PROMPT_TITLE:
-        case GHOSTTY_ACTION_COMMAND_FINISHED:
         // Feature surfaces intentionally not on this port's plate
         // (search bar, ImGui inspector, tab overview, quick
         // terminal, command palette, terminal-level undo/redo):

--- a/Core/Ghostty/Config.h
+++ b/Core/Ghostty/Config.h
@@ -64,6 +64,52 @@ public:
     // own default of `.auto`. Used by the TOGGLE_WINDOW_DECORATIONS
     // tag (#68) to know what "the config default" means before
     // applying per-window overrides.
+    // ----- notify-on-command-finish (v1.3.0+, default: never) -----
+    // The whole feature is opt-in; every getter falls back to the
+    // documented default when the key is unreadable.
+
+    enum class NotifyOnCommandFinish { Never, Unfocused, Always };
+    NotifyOnCommandFinish CommandFinishNotify() const noexcept {
+        // Enum values arrive as their @tagName string — see the
+        // pointer-width warning on WindowDecoratedByConfig below.
+        const char* tag = nullptr;
+        if (!GetRaw("notify-on-command-finish", &tag) || !tag) {
+            return NotifyOnCommandFinish::Never;
+        }
+        if (std::strcmp(tag, "unfocused") == 0) return NotifyOnCommandFinish::Unfocused;
+        if (std::strcmp(tag, "always") == 0) return NotifyOnCommandFinish::Always;
+        return NotifyOnCommandFinish::Never;
+    }
+
+    // Minimum run time before a finished command qualifies.
+    // ghostty's Duration crosses the C API via cval() as
+    // MILLISECONDS (a usize) — NOT the nanoseconds the
+    // COMMAND_FINISHED action payload uses. Convert here so
+    // callers compare ns against ns; comparing the raw value made
+    // a 1s threshold behave as 1µs (caught during #148 testing).
+    uint64_t CommandFinishNotifyAfterNs() const noexcept {
+        size_t ms = 0;
+        if (!GetRaw("notify-on-command-finish-after", &ms)) {
+            return 5'000'000'000ull;  // documented default: 5s
+        }
+        return static_cast<uint64_t>(ms) * 1'000'000ull;
+    }
+
+    // How to notify. The packed struct crosses the C API as its bit
+    // representation in a c_uint: bit 0 = bell (field order in
+    // ghostty's NotifyOnCommandFinishAction), bit 1 = notify.
+    struct CommandFinishActions {
+        bool bell;
+        bool notify;
+    };
+    CommandFinishActions CommandFinishNotifyActions() const noexcept {
+        unsigned bits = 0;
+        if (!GetRaw("notify-on-command-finish-action", &bits)) {
+            return { true, false };  // documented default: bell only
+        }
+        return { (bits & 1u) != 0, (bits & 2u) != 0 };
+    }
+
     bool WindowDecoratedByConfig() const noexcept {
         // ghostty exposes enum config values as their @tagName — a
         // pointer to a null-terminated string — NOT as the

--- a/Core/Host/IWindow.h
+++ b/Core/Host/IWindow.h
@@ -197,6 +197,16 @@ struct IWindow {
     virtual void SetSecureInputForSurface(ghostty_surface_t surface,
                                           ghostty_action_secure_input_e mode) = 0;
 
+    // COMMAND_FINISHED: a shell-integration-tracked command ended.
+    // The view owns the whole policy: it reads the notify-on-
+    // command-finish config trio (mode / threshold / actions),
+    // knows whether the surface is focused and the window is
+    // foreground, and fires bell / toast accordingly. exitCode is
+    // -1 when the shell didn't report one.
+    virtual void NotifyCommandFinishedForSurface(ghostty_surface_t surface,
+                                                 int exitCode,
+                                                 uint64_t durationNs) = 0;
+
     // PWD: the shell reported its working directory (OSC 7). Shown
     // as the tooltip of the tab containing `surface` — with splits,
     // the last pane to report wins, which matches "the directory

--- a/Tests/MockMainWindowView.h
+++ b/Tests/MockMainWindowView.h
@@ -183,6 +183,18 @@ struct MockMainWindowView : core::host::IWindow {
         lastSecureInputMode = mode;
     }
 
+    int notifyCommandFinishedCalls = 0;
+    ghostty_surface_t lastCommandFinishedSurface = nullptr;
+    int lastCommandExitCode = 0;
+    uint64_t lastCommandDurationNs = 0;
+    void NotifyCommandFinishedForSurface(ghostty_surface_t s, int exitCode,
+                                         uint64_t durationNs) override {
+        ++notifyCommandFinishedCalls;
+        lastCommandFinishedSurface = s;
+        lastCommandExitCode = exitCode;
+        lastCommandDurationNs = durationNs;
+    }
+
     int setPwdCalls = 0;
     ghostty_surface_t lastPwdSurface = nullptr;
     std::wstring lastPwd;

--- a/Tests/test_ghostty_actions.cpp
+++ b/Tests/test_ghostty_actions.cpp
@@ -358,6 +358,28 @@ TEST(GhosttyActionsTest, OnSecureInputIgnoresNullSurface) {
     EXPECT_EQ(view.setSecureInputCalls, 0);
 }
 
+TEST(GhosttyActionsTest, OnCommandFinishedForwardsExitCodeAndDuration) {
+    MockMainWindowView view;
+    Actions actions(view);
+    auto surface = FakeSurface(0xCF);
+    ghostty_action_command_finished_s cf{};
+    cf.exit_code = 2;
+    cf.duration = 7'000'000'000ull;
+    EXPECT_TRUE(actions.OnCommandFinished(surface, cf));
+    EXPECT_EQ(view.notifyCommandFinishedCalls, 1);
+    EXPECT_EQ(view.lastCommandFinishedSurface, surface);
+    EXPECT_EQ(view.lastCommandExitCode, 2);
+    EXPECT_EQ(view.lastCommandDurationNs, 7'000'000'000ull);
+}
+
+TEST(GhosttyActionsTest, OnCommandFinishedIgnoresNullSurface) {
+    MockMainWindowView view;
+    Actions actions(view);
+    ghostty_action_command_finished_s cf{};
+    EXPECT_TRUE(actions.OnCommandFinished(nullptr, cf));
+    EXPECT_EQ(view.notifyCommandFinishedCalls, 0);
+}
+
 TEST(GhosttyActionsTest, OnPwdForwardsUtf16Path) {
     MockMainWindowView view;
     Actions actions(view);

--- a/Tests/test_ghostty_callback_dispatcher.cpp
+++ b/Tests/test_ghostty_callback_dispatcher.cpp
@@ -132,6 +132,27 @@ TEST(GhosttyCallbackDispatcherTest, MouseVisibilityRoutesToTheOwningSurface) {
     EXPECT_FALSE(DispatchTag(*d, GHOSTTY_ACTION_MOUSE_VISIBILITY));
 }
 
+TEST(GhosttyCallbackDispatcherTest, CommandFinishedRoutesToTheOwningSurface) {
+    MockMainWindowView view;
+    auto d = CallbackDispatcher::Create(view);
+
+    ghostty_target_s target{};
+    target.tag = GHOSTTY_TARGET_SURFACE;
+    target.target.surface = reinterpret_cast<ghostty_surface_t>(0xBEEF);
+    ghostty_action_s action{};
+    action.tag = GHOSTTY_ACTION_COMMAND_FINISHED;
+    action.action.command_finished = { /*exit_code=*/1,
+                                       /*duration=*/6'000'000'000ull };
+
+    EXPECT_TRUE(d->DispatchAction(target, action));
+    EXPECT_EQ(view.notifyCommandFinishedCalls, 1);
+    EXPECT_EQ(view.lastCommandExitCode, 1);
+
+    // App-targeted: upstream logs and ignores — acked.
+    EXPECT_TRUE(DispatchTag(*d, GHOSTTY_ACTION_COMMAND_FINISHED));
+    EXPECT_EQ(view.notifyCommandFinishedCalls, 1);
+}
+
 TEST(GhosttyCallbackDispatcherTest, PwdRoutesToTheOwningSurface) {
     MockMainWindowView view;
     auto d = CallbackDispatcher::Create(view);


### PR DESCRIPTION
## Summary

Fourth of the "informational" coverage batch (#57): `COMMAND_FINISHED` now honors the `notify-on-command-finish` config trio. A long command finishing in a background tab rings the bell and/or raises a toast; clicking the toast refocuses the pane it came from (existing desktop-notification path).

<details>
<summary>日本語</summary>

#57 の「informational」カバレッジ埋めの第 4 弾。`COMMAND_FINISHED` が `notify-on-command-finish` config 3 点セットを尊重するようになる。バックグラウンドのタブで長いコマンドが終わると bell と/または toast が出て、toast クリックで発生元 pane にフォーカスが戻る (既存の desktop-notification 経路)。

</details>

## Design

Policy mirrors macOS `commandFinished`, and all of it lives in the view (the view owns config access and focus knowledge):

1. **Mode gate** — `notify-on-command-finish`: `never` (default — the whole feature is opt-in) / `unfocused` / `always`. "Focused" is defined as: the surface is this window's active surface **and** the window is foreground (`GetForegroundWindow`).
2. **Duration threshold** — `notify-on-command-finish-after` (default 5s). ghostty's `Duration` crosses the C API via `cval()` as a `usize` of **milliseconds** — while the action payload's duration is nanoseconds. The Config getter converts to ns so callers compare like units; the raw-value comparison made a 1s threshold behave as 1µs and was caught during this PR's verification (sub-threshold commands notified).
3. **Actions** — `notify-on-command-finish-action` (default `bell`): bell = `MessageBeep`, notify = toast with upstream's title wording (Succeeded / Failed / Finished by exit code) and a "Finished in 12s (exit 0)" body.

Config is read fresh per event, so a config reload takes effect immediately. The packed action flags cross the C API as their bit representation (`bit0 = bell, bit1 = notify`) — documented at the reader. App-targeted delivery acks (upstream logs and ignores).

<details>
<summary>日本語</summary>

ポリシーは macOS の `commandFinished` を踏襲し、すべて view 側に置いた (config アクセスと focus の知識は view が持っている):

1. **mode ゲート** — `notify-on-command-finish`: `never` (既定 — 機能自体が opt-in) / `unfocused` / `always`。「focused」の定義は「surface がこのウインドウの active surface **かつ** ウインドウが前面 (`GetForegroundWindow`)」
2. **実行時間しきい値** — `notify-on-command-finish-after` (既定 5s)。ghostty の `Duration` は `cval()` 経由で **ミリ秒**の `usize` として C API を渡ってくる (action payload の duration は ns)。Config getter が ns に変換して単位を揃える — 生値のまま比較すると 1s のしきい値が 1µs として振る舞う。この PR の検証中に発見して修正した (しきい値未満でも通知が出ていた)
3. **actions** — `notify-on-command-finish-action` (既定 `bell`): bell = `MessageBeep`、notify = toast (タイトルは本家と同じ Succeeded / Failed / Finished の exit code 出し分け、本文は "Finished in 12s (exit 0)" 形式)

config はイベントごとに読み直すので reload が即反映される。packed な action flags は bit 表現 (`bit0 = bell, bit1 = notify`) で C API を渡る — 読み手側に明記。app 宛は ack (本家も warning ログを出して無視)。

</details>

## Changes

- `Core/Ghostty/Config.h` — three new getters: `CommandFinishNotify()` (enum tag string), `CommandFinishNotifyAfterNs()`, `CommandFinishNotifyActions()` (packed bits), each with the documented default as fallback.
- `Core/Ghostty/CallbackDispatcher.cpp` — `COMMAND_FINISHED` leaves the informational ack list; surface routes, app acks.
- `Core/Ghostty/Actions/Actions.{h,cpp}` — `OnCommandFinished` forwards exit code (-1 = unreported) and duration.
- `Core/Host/IWindow.h` — new `NotifyCommandFinishedForSurface(surface, exitCode, durationNs)`.
- `App/MainWindow.xaml.cpp` — the policy above + `FormatDurationNs` ("2m 5s").
- Tests — dispatcher (surface routes, app-target acks); Actions (forward, null-surface guard).

<details>
<summary>日本語</summary>

- `Core/Ghostty/Config.h` — getter 3 つを追加: `CommandFinishNotify()` (enum は tag 文字列)、`CommandFinishNotifyAfterNs()`、`CommandFinishNotifyActions()` (packed bits)。いずれも文書化された既定値にフォールバック
- `Core/Ghostty/CallbackDispatcher.cpp` — `COMMAND_FINISHED` を informational ack リストから外し、surface 宛は routing、app 宛は ack
- `Core/Ghostty/Actions/Actions.{h,cpp}` — `OnCommandFinished` は exit code (-1 = 未報告) と duration を転送
- `Core/Host/IWindow.h` — `NotifyCommandFinishedForSurface(surface, exitCode, durationNs)` を追加
- `App/MainWindow.xaml.cpp` — 上記ポリシー + `FormatDurationNs` ("2m 5s" 形式)
- テスト — dispatcher (surface 宛 routing、app 宛 ack)、Actions (転送、null surface ガード)

</details>

## Verification

Config (already added to the local config — `always` is noisy, drop to `unfocused` or delete after verifying):

```
notify-on-command-finish = always
notify-on-command-finish-action = bell,notify
notify-on-command-finish-after = 1s
```

Command tracking needs OSC 133 marks; without shell integration, emit them by hand — start a "command", wait past the threshold, end it with exit code 2:

```powershell
Write-Host -NoNewline ([char]27 + ']133;C' + [char]27 + '\'); Start-Sleep 2; Write-Host -NoNewline ([char]27 + ']133;D;2' + [char]27 + '\')
```

- [x] Tests.exe green (new dispatcher/Actions tests included)
- [x] Run the command above — bell rings and a toast appears: "Command Failed / Finished in 2s (exit 2)"
- [x] Same with `;D;0` — title reads "Command Succeeded", body "(exit 0)"
- [x] With `Start-Sleep` removed (sub-threshold) — nothing fires
- [x] Set `notify-on-command-finish = unfocused`, reload config (`Ctrl+Shift+,`): running it while the window is focused fires nothing; run it with `Start-Sleep 6` and Alt-Tab away before it ends — bell + toast fire
- [x] Clicking the toast focuses the originating pane
- [x] Set `notify-on-command-finish = never` (or delete the lines), reload — nothing fires

<details>
<summary>日本語</summary>

config (ローカル config に追加済み — `always` はうるさいので検証後は `unfocused` に落とすか削除):

コマンド追跡には OSC 133 マークが必要。shell integration なしでも手で撃てる — 「コマンド開始」→ しきい値超えまで待つ → exit code 2 で終了 (上の PowerShell)。

- Tests.exe が green (新規 dispatcher / Actions テスト含む)
- 上のコマンド実行 — bell が鳴って toast が出る: "Command Failed / Finished in 2s (exit 2)"
- `;D;0` に変えると — タイトル "Command Succeeded"、本文 "(exit 0)"
- `Start-Sleep` を抜く (しきい値未満) — 何も起きない
- `notify-on-command-finish = unfocused` にして reload (`Ctrl+Shift+,`): ウインドウにフォーカスがある状態では発火しない。`Start-Sleep 6` にして実行し、終わる前に Alt+Tab で離れる — bell + toast が出る
- toast クリックで発生元 pane にフォーカスが戻る
- `never` にする (か行を消す) → reload — 何も起きない

</details>
