### PR TITLE
Show a read-only chip on the owning pane

### DIFF
--- a/App/MainWindow.xaml.cpp
+++ b/App/MainWindow.xaml.cpp
@@ -1685,6 +1685,17 @@ namespace winrt::GhosttyWin32::implementation
         }
     }
 
+    void MainWindow::SetReadonlyForSurface(ghostty_surface_t surface, bool readonly)
+    {
+        // Owning-leaf routing: the read-only state belongs to the
+        // pane whose pty stopped accepting writes.
+        auto lookup = m_tabs.FindPaneBySurface(surface);
+        if (!lookup.pane) return;
+        if (auto* tc = Tab::PaneToTerminalControl(*lookup.pane)) {
+            tc->SetReadonly(readonly);
+        }
+    }
+
     void MainWindow::SetPwdForSurface(ghostty_surface_t surface, std::wstring pwd)
     {
         // Tab-level, not pane-level: the tooltip hangs off the

--- a/App/MainWindow.xaml.h
+++ b/App/MainWindow.xaml.h
@@ -145,6 +145,8 @@ namespace winrt::GhosttyWin32::implementation
         void NotifyCommandFinishedForSurface(ghostty_surface_t surface,
                                              int exitCode,
                                              uint64_t durationNs) override;
+        void SetReadonlyForSurface(ghostty_surface_t surface,
+                                   bool readonly) override;
         void AppendKeySequenceForSurface(ghostty_surface_t surface,
                                          std::wstring triggerLabel) override;
         void ClearKeySequenceForSurface(ghostty_surface_t surface) override;

--- a/App/TerminalControl.xaml
+++ b/App/TerminalControl.xaml
@@ -44,18 +44,37 @@
           collides with the LinkBanner in the bottom-left; same
           in-tree hit-test-transparent overlay pattern.
         -->
-        <Border x:Name="SecureInputBadge"
-                IsHitTestVisible="False"
-                Visibility="Collapsed"
-                HorizontalAlignment="Right"
-                VerticalAlignment="Top"
-                CornerRadius="0,0,0,6"
-                Padding="8,4,8,4"
-                Background="{ThemeResource SolidBackgroundFillColorSecondaryBrush}">
-            <TextBlock FontSize="12"
-                       Text="&#x1F512;"
-                       Foreground="{ThemeResource TextFillColorPrimaryBrush}" />
-        </Border>
+        <StackPanel Orientation="Horizontal"
+                    Spacing="4"
+                    IsHitTestVisible="False"
+                    HorizontalAlignment="Right"
+                    VerticalAlignment="Top">
+            <!--
+              read-only chip (READONLY, from the toggle_readonly
+              keybind). The write blocking itself happens inside
+              libghostty; without the chip the keyboard just "goes
+              silent" with no explanation — same problem class the
+              key-state badge solves.
+            -->
+            <Border x:Name="ReadonlyBadge"
+                    Visibility="Collapsed"
+                    CornerRadius="0,0,6,6"
+                    Padding="8,4,8,4"
+                    Background="{ThemeResource SolidBackgroundFillColorSecondaryBrush}">
+                <TextBlock FontSize="12"
+                           Text="read-only"
+                           Foreground="{ThemeResource TextFillColorPrimaryBrush}" />
+            </Border>
+            <Border x:Name="SecureInputBadge"
+                    Visibility="Collapsed"
+                    CornerRadius="0,0,0,6"
+                    Padding="8,4,8,4"
+                    Background="{ThemeResource SolidBackgroundFillColorSecondaryBrush}">
+                <TextBlock FontSize="12"
+                           Text="&#x1F512;"
+                           Foreground="{ThemeResource TextFillColorPrimaryBrush}" />
+            </Border>
+        </StackPanel>
         <!--
           Key-state badge (KEY_SEQUENCE / KEY_TABLE). Shows the
           active key-table stack and/or the pending multi-chord

--- a/App/TerminalControl.xaml.cpp
+++ b/App/TerminalControl.xaml.cpp
@@ -366,6 +366,13 @@ namespace winrt::GhosttyWin32::implementation
         KeyStateBadge().Visibility(winrt::Microsoft::UI::Xaml::Visibility::Visible);
     }
 
+    void TerminalControl::SetReadonly(bool readonly)
+    {
+        ReadonlyBadge().Visibility(readonly
+            ? winrt::Microsoft::UI::Xaml::Visibility::Visible
+            : winrt::Microsoft::UI::Xaml::Visibility::Collapsed);
+    }
+
     void TerminalControl::SetSecureInput(ghostty_action_secure_input_e mode)
     {
         const bool on = mode == GHOSTTY_SECURE_INPUT_ON    ? true

--- a/App/TerminalControl.xaml.h
+++ b/App/TerminalControl.xaml.h
@@ -184,6 +184,10 @@ namespace winrt::GhosttyWin32::implementation
         void PushKeyTable(winrt::hstring const& name);
         void PopKeyTable(bool all);
 
+        // Show/hide the read-only chip (READONLY action). The write
+        // blocking is core-side; this is indicator only. UI thread.
+        void SetReadonly(bool readonly);
+
         // Reflect SECURE_INPUT on this pane's badge. ON/OFF set the
         // state directly; TOGGLE flips it here because the pane owns
         // the indicator state (ghostty's toggle keybind carries no

--- a/Core/Ghostty/Actions/Actions.cpp
+++ b/Core/Ghostty/Actions/Actions.cpp
@@ -386,6 +386,16 @@ bool Actions::OnPwd(ghostty_surface_t surface, const char* utf8Pwd) {
     return true;
 }
 
+bool Actions::OnReadonly(ghostty_surface_t surface,
+                         ghostty_action_readonly_e readonly) {
+    if (!surface) return true;
+    const bool on = readonly == GHOSTTY_READONLY_ON;
+    DispatchToView([this, surface, on]() {
+        m_view.SetReadonlyForSurface(surface, on);
+    });
+    return true;
+}
+
 bool Actions::OnCommandFinished(ghostty_surface_t surface,
                                 ghostty_action_command_finished_s cf) {
     if (!surface) return true;

--- a/Core/Ghostty/Actions/Actions.h
+++ b/Core/Ghostty/Actions/Actions.h
@@ -138,6 +138,9 @@ public:
                        ghostty_action_secure_input_e mode);
     // PWD: shell-reported working directory (OSC 7).
     bool OnPwd(ghostty_surface_t surface, const char* utf8Pwd);
+    // READONLY: indicator only — the write blocking is in core.
+    bool OnReadonly(ghostty_surface_t surface,
+                    ghostty_action_readonly_e readonly);
     // COMMAND_FINISHED: policy (config + focus) lives in the view.
     bool OnCommandFinished(ghostty_surface_t surface,
                            ghostty_action_command_finished_s cf);

--- a/Core/Ghostty/CallbackDispatcher.cpp
+++ b/Core/Ghostty/CallbackDispatcher.cpp
@@ -100,6 +100,13 @@ bool CallbackDispatcher::DispatchAction(ghostty_target_s target, ghostty_action_
                 return m_actions.OnMouseVisibility(target.target.surface,
                                                    action.action.mouse_visibility);
             return false;
+        // READONLY: toggle_readonly indicator (the blocking itself
+        // is core-side). App-targeted is a no-op upstream — ack.
+        case GHOSTTY_ACTION_READONLY:
+            if (target.tag == GHOSTTY_TARGET_SURFACE)
+                return m_actions.OnReadonly(target.target.surface,
+                                            action.action.readonly);
+            return true;
         // COMMAND_FINISHED: shell-integration command tracking. The
         // app-targeted variant is a no-op upstream — ack.
         case GHOSTTY_ACTION_COMMAND_FINISHED:
@@ -191,10 +198,9 @@ bool CallbackDispatcher::DispatchAction(ghostty_target_s target, ghostty_action_
         // here keeps libghostty's future "unhandled action" audit
         // quiet without inventing empty GhosttyActions methods.
         //
-        // Informational actions whose UI surfaces this port
-        // doesn't have yet (read-only banner, shell-supplied title
-        // source flag):
-        case GHOSTTY_ACTION_READONLY:
+        // PROMPT_TITLE: "show a rename-title prompt" keybind action.
+        // Pending its own PR (ContentDialog + TextBox); acked until
+        // then so the keybind doesn't read as unhandled.
         case GHOSTTY_ACTION_PROMPT_TITLE:
         // Feature surfaces intentionally not on this port's plate
         // (search bar, ImGui inspector, tab overview, quick

--- a/Core/Host/IWindow.h
+++ b/Core/Host/IWindow.h
@@ -197,6 +197,14 @@ struct IWindow {
     virtual void SetSecureInputForSurface(ghostty_surface_t surface,
                                           ghostty_action_secure_input_e mode) = 0;
 
+    // READONLY: the toggle_readonly keybind flipped the surface's
+    // read-only state. The functional half (pty writes blocked)
+    // lives in libghostty and already works — this is purely the
+    // indicator, so the user can tell why their keystrokes stopped
+    // reaching the shell.
+    virtual void SetReadonlyForSurface(ghostty_surface_t surface,
+                                       bool readonly) = 0;
+
     // COMMAND_FINISHED: a shell-integration-tracked command ended.
     // The view owns the whole policy: it reads the notify-on-
     // command-finish config trio (mode / threshold / actions),

--- a/Tests/MockMainWindowView.h
+++ b/Tests/MockMainWindowView.h
@@ -183,6 +183,15 @@ struct MockMainWindowView : core::host::IWindow {
         lastSecureInputMode = mode;
     }
 
+    int setReadonlyCalls = 0;
+    ghostty_surface_t lastReadonlySurface = nullptr;
+    bool lastReadonly = false;
+    void SetReadonlyForSurface(ghostty_surface_t s, bool readonly) override {
+        ++setReadonlyCalls;
+        lastReadonlySurface = s;
+        lastReadonly = readonly;
+    }
+
     int notifyCommandFinishedCalls = 0;
     ghostty_surface_t lastCommandFinishedSurface = nullptr;
     int lastCommandExitCode = 0;

--- a/Tests/test_ghostty_actions.cpp
+++ b/Tests/test_ghostty_actions.cpp
@@ -358,6 +358,26 @@ TEST(GhosttyActionsTest, OnSecureInputIgnoresNullSurface) {
     EXPECT_EQ(view.setSecureInputCalls, 0);
 }
 
+TEST(GhosttyActionsTest, OnReadonlyMapsEnumToBool) {
+    MockMainWindowView view;
+    Actions actions(view);
+    auto surface = FakeSurface(0x20);
+    EXPECT_TRUE(actions.OnReadonly(surface, GHOSTTY_READONLY_ON));
+    EXPECT_EQ(view.setReadonlyCalls, 1);
+    EXPECT_EQ(view.lastReadonlySurface, surface);
+    EXPECT_TRUE(view.lastReadonly);
+    EXPECT_TRUE(actions.OnReadonly(surface, GHOSTTY_READONLY_OFF));
+    EXPECT_EQ(view.setReadonlyCalls, 2);
+    EXPECT_FALSE(view.lastReadonly);
+}
+
+TEST(GhosttyActionsTest, OnReadonlyIgnoresNullSurface) {
+    MockMainWindowView view;
+    Actions actions(view);
+    EXPECT_TRUE(actions.OnReadonly(nullptr, GHOSTTY_READONLY_ON));
+    EXPECT_EQ(view.setReadonlyCalls, 0);
+}
+
 TEST(GhosttyActionsTest, OnCommandFinishedForwardsExitCodeAndDuration) {
     MockMainWindowView view;
     Actions actions(view);

--- a/Tests/test_ghostty_callback_dispatcher.cpp
+++ b/Tests/test_ghostty_callback_dispatcher.cpp
@@ -31,7 +31,10 @@ TEST(GhosttyCallbackDispatcherTest, InformationalAcksReturnTrue) {
     MockMainWindowView view;
     auto d = CallbackDispatcher::Create(view);
 
+    // READONLY with an app target: upstream logs and ignores —
+    // acked. Surface-targeted delivery routes (routing tests below).
     EXPECT_TRUE(DispatchTag(*d, GHOSTTY_ACTION_READONLY));
+    EXPECT_EQ(view.setReadonlyCalls, 0);
     // SECURE_INPUT with an app target: macOS's EnableSecureEventInput
     // concept, no Windows counterpart — deliberately acked. The
     // surface-targeted variant routes (see the routing tests below).
@@ -130,6 +133,23 @@ TEST(GhosttyCallbackDispatcherTest, MouseVisibilityRoutesToTheOwningSurface) {
 
     // App-targeted delivery has no owning pane — refuse.
     EXPECT_FALSE(DispatchTag(*d, GHOSTTY_ACTION_MOUSE_VISIBILITY));
+}
+
+TEST(GhosttyCallbackDispatcherTest, ReadonlyRoutesToTheOwningSurface) {
+    MockMainWindowView view;
+    auto d = CallbackDispatcher::Create(view);
+
+    ghostty_target_s target{};
+    target.tag = GHOSTTY_TARGET_SURFACE;
+    target.target.surface = reinterpret_cast<ghostty_surface_t>(0xBEEF);
+    ghostty_action_s action{};
+    action.tag = GHOSTTY_ACTION_READONLY;
+    action.action.readonly = GHOSTTY_READONLY_ON;
+
+    EXPECT_TRUE(d->DispatchAction(target, action));
+    EXPECT_EQ(view.setReadonlyCalls, 1);
+    EXPECT_EQ(view.lastReadonlySurface, target.target.surface);
+    EXPECT_TRUE(view.lastReadonly);
 }
 
 TEST(GhosttyCallbackDispatcherTest, CommandFinishedRoutesToTheOwningSurface) {


### PR DESCRIPTION
Was stacked on #148; rebased onto `dev` after its merge (base retargeted, not recreated).

## Summary

`READONLY` was misfiled as "informational with no UI": it is the indicator half of the `toggle_readonly` keybind, whose functional half — libghostty blocking pty writes — **already works on Windows**. Toggling it today makes the keyboard go silent with no explanation. This PR adds a "read-only" chip next to the secure-input badge.

<details>
<summary>日本語</summary>

`READONLY` は「UI のない informational」に誤分類されていた。実際は `toggle_readonly` keybind の表示側で、機能側 (libghostty が pty への書き込みをブロック) は **Windows でも既に動いている**。今トグルすると「キーボードが黙る」だけで画面に説明が出ない。本 PR で secure-input バッジの隣に「read-only」チップを追加する。

</details>

## Design

- Top-right corner becomes a small horizontal stack: the read-only chip and the 🔒 secure-input badge — both are input-state indicators, so they share the corner. Hit-test transparent as ever.
- Indicator only, no state to keep: the action carries the absolute ON/OFF (unlike SECURE_INPUT's TOGGLE), so `SetReadonly(bool)` is a one-liner.
- App-targeted delivery acks (upstream logs and ignores).
- Side change: `PROMPT_TITLE`'s ack comment now records what the action actually is — a "show a rename-title prompt" keybind action pending its own PR — replacing the stale "informational" grouping it shared with READONLY.

<details>
<summary>日本語</summary>

- pane 右上を小さな横並びスタックに: read-only チップと 🔒 secure-input バッジ — どちらも入力状態のインジケータなので同じコーナーを共有する。従来通り hit-test 透過
- インジケータのみで保持する状態なし: この action は絶対値の ON/OFF を運ぶ (SECURE_INPUT の TOGGLE と違って) ので、`SetReadonly(bool)` は 1 行で済む
- app 宛は ack (本家も warning ログを出して無視)
- 付随変更: `PROMPT_TITLE` の ack コメントを実態 (「タイトル変更プロンプトを出せ」という keybind action、単独 PR 待ち) に書き換え — READONLY と一緒くたにされていた古い「informational」分類を置き換える

</details>

## Changes

- `Core/Ghostty/CallbackDispatcher.cpp` — `READONLY` routes surface-targeted, acks app-targeted; `PROMPT_TITLE` ack comment corrected.
- `Core/Ghostty/Actions/Actions.{h,cpp}` — `OnReadonly` maps the enum to a bool at the boundary.
- `Core/Host/IWindow.h` — new `SetReadonlyForSurface(surface, readonly)`.
- `App/TerminalControl.xaml{,.h,.cpp}` — `ReadonlyBadge` + `SetReadonly()`; top-right overlay restructured into a StackPanel.
- `App/MainWindow.xaml.cpp` — owning-leaf routing.
- Tests — dispatcher (surface routes, app acks without touching the view); Actions (enum→bool, null-surface guard).

<details>
<summary>日本語</summary>

- `Core/Ghostty/CallbackDispatcher.cpp` — `READONLY` は surface 宛 routing / app 宛 ack。`PROMPT_TITLE` の ack コメントを訂正
- `Core/Ghostty/Actions/Actions.{h,cpp}` — `OnReadonly` は境界で enum を bool に写像
- `Core/Host/IWindow.h` — `SetReadonlyForSurface(surface, readonly)` を追加
- `App/TerminalControl.xaml{,.h,.cpp}` — `ReadonlyBadge` と `SetReadonly()`。右上オーバーレイを StackPanel に再構成
- `App/MainWindow.xaml.cpp` — 所有 leaf routing
- テスト — dispatcher (surface 宛 routing、app 宛は view 不干渉の ack)、Actions (enum→bool、null surface ガード)

</details>

## Verification

Config: `keybind = alt+shift+r=toggle_readonly` is already added to the local config.

- [x] Tests.exe green (new dispatcher/Actions tests included)
- [x] `Alt+Shift+R` — "read-only" chip appears top-right AND typing stops reaching the shell (the blocking is core-side and predates this PR)
- [x] `Alt+Shift+R` again — chip disappears, typing works again
- [x] Both badges together: `Alt+Shift+I` while read-only — 🔒 and "read-only" sit side by side without overlap
- [x] Splits: toggling in one pane shows the chip only on that pane
- [x] Light/dark theme: chip colors follow the theme

<details>
<summary>日本語</summary>

config: `keybind = alt+shift+r=toggle_readonly` はローカル config に追加済み。

- Tests.exe が green (新規 dispatcher / Actions テスト含む)
- `Alt+Shift+R` — 右上に「read-only」チップが出て、**かつ**タイプが shell に届かなくなる (ブロック自体は core 側で本 PR 以前から動作)
- もう一度 `Alt+Shift+R` — チップが消えてタイプが戻る
- バッジ共存: read-only 中に `Alt+Shift+I` — 🔒 と「read-only」が重ならず横に並ぶ
- split: 片方の pane でトグルしたとき、チップが出るのはその pane だけ
- ライト / ダークテーマ: チップの色がテーマに追従する

</details>
