### PR TITLE
Show a rename-tab prompt for PROMPT_TITLE

### DIFF
--- a/App/MainWindow.xaml.cpp
+++ b/App/MainWindow.xaml.cpp
@@ -261,6 +261,22 @@ namespace winrt::GhosttyWin32::implementation
                                 if (!self->IsForeground()) {
                                     return;
                                 }
+                                // A modal ContentDialog (rename
+                                // prompt, close confirm) owns focus
+                                // while it's up; restoring the
+                                // terminal here would steal it and
+                                // let keystrokes leak into the shell
+                                // behind the dialog. Any open popup
+                                // on this XamlRoot means skip — the
+                                // dialog puts focus back on its own
+                                // when it closes.
+                                if (auto content = self->Content()) {
+                                    if (auto root = content.XamlRoot()) {
+                                        auto popups = winrt::Microsoft::UI::Xaml::Media::
+                                            VisualTreeHelper::GetOpenPopupsForXamlRoot(root);
+                                        if (popups && popups.Size() > 0) return;
+                                    }
+                                }
                                 if (auto* tab = self->ActiveTab()) {
                                     tab->Focus();
                                 }
@@ -1360,6 +1376,12 @@ namespace winrt::GhosttyWin32::implementation
     void MainWindow::SetTabTitleForSurface(ghostty_surface_t surface, std::wstring title)
     {
         if (auto* t = m_tabs.FindBySurface(surface)) {
+            // A user-chosen name (rename prompt) outranks the shell:
+            // upstream documents the prompt title as overriding any
+            // terminal-set title, and shells re-assert their OSC
+            // title on every prompt — honouring it here would undo
+            // the rename within seconds.
+            if (t->HasUserTitle()) return;
             t->Item().Header(box_value(winrt::hstring(title)));
             // Once the shell has spoken, the foreground-pid poll
             // stops overwriting the header for this tab.
@@ -1683,6 +1705,65 @@ namespace winrt::GhosttyWin32::implementation
             }
             ShowDesktopNotification(surface, std::move(title), std::move(body));
         }
+    }
+
+    void MainWindow::PromptTitleForSurface(ghostty_surface_t surface)
+    {
+        // One ContentDialog per XamlRoot is a WinUI rule; a second
+        // ShowAsync throws. If a rename prompt (or the close-confirm
+        // dialog) is already up, dropping the request matches how
+        // repeated keypresses should feel anyway.
+        if (m_renamePromptOpen) return;
+        auto* t = m_tabs.FindBySurface(surface);
+        if (!t) return;
+        auto content = Content();
+        auto xamlRoot = content ? content.XamlRoot() : nullptr;
+        if (!xamlRoot) return;
+
+        muxc::TextBox input;
+        input.Text(unbox_value_or<winrt::hstring>(t->Item().Header(), L""));
+        // Pre-select so typing replaces the old title outright —
+        // the common case is a full rename, not an edit.
+        input.SelectAll();
+
+        muxc::ContentDialog dlg;
+        dlg.XamlRoot(xamlRoot);
+        dlg.Title(box_value(L"Rename tab"));
+        dlg.Content(input);
+        dlg.PrimaryButtonText(L"Rename");
+        dlg.CloseButtonText(L"Cancel");
+        dlg.DefaultButton(muxc::ContentDialogButton::Primary);
+
+        m_renamePromptOpen = true;
+        auto op = dlg.ShowAsync();
+        // Weak ref: the dialog can outlive this window if teardown
+        // starts while it's up (same rationale as WindowCloseGate).
+        // The TabViewItem is captured by value — WinRT projections
+        // are refcounted handles, so applying the rename to a tab
+        // that got torn out or closed mid-prompt is a safe no-op on
+        // a still-alive object rather than a dangling pointer.
+        auto weak = get_weak();
+        auto item = t->Item();
+        op.Completed([weak, item, input](auto const& sender, auto const&) {
+            auto self = weak.get();
+            if (self) self->m_renamePromptOpen = false;
+            if (sender.GetResults() != muxc::ContentDialogResult::Primary) return;
+            auto text = input.Text();
+            // Empty input is treated as cancel: this port has no
+            // inverse of MarkExplicitTitle yet, so "reset to the
+            // automatic title" can't be honoured truthfully.
+            if (text.empty()) return;
+            item.Header(box_value(text));
+            if (self) {
+                if (auto* tab = self->m_tabs.FindByItem(item)) {
+                    // User latch: outranks both the foreground-pid
+                    // poll AND shell SET_TITLE (see HasUserTitle) —
+                    // shells re-assert their OSC title constantly,
+                    // so anything weaker gets undone in seconds.
+                    tab->MarkUserTitle();
+                }
+            }
+        });
     }
 
     void MainWindow::SetReadonlyForSurface(ghostty_surface_t surface, bool readonly)

--- a/App/MainWindow.xaml.h
+++ b/App/MainWindow.xaml.h
@@ -147,6 +147,7 @@ namespace winrt::GhosttyWin32::implementation
                                              uint64_t durationNs) override;
         void SetReadonlyForSurface(ghostty_surface_t surface,
                                    bool readonly) override;
+        void PromptTitleForSurface(ghostty_surface_t surface) override;
         void AppendKeySequenceForSurface(ghostty_surface_t surface,
                                          std::wstring triggerLabel) override;
         void ClearKeySequenceForSurface(ghostty_surface_t surface) override;
@@ -365,6 +366,11 @@ namespace winrt::GhosttyWin32::implementation
         // when a TerminalControl gains focus, cleared when the
         // matching surface is torn down through CloseSurfaceByPaneId.
         ghostty_surface_t m_activeSurface = nullptr;
+        // Re-entrancy guard for the rename-title prompt: WinUI allows
+        // one ContentDialog per XamlRoot, and a second ShowAsync while
+        // one is up throws. Set when the dialog opens, cleared in its
+        // Completed handler.
+        bool m_renamePromptOpen = false;
         // Constructed once ghostty is initialized — needs the app handle
         // and HWND, neither available until InitGhostty has run.
         std::unique_ptr<TabFactory> m_tabFactory;

--- a/App/Tabs/Tab.h
+++ b/App/Tabs/Tab.h
@@ -98,6 +98,20 @@ public:
     bool HasExplicitTitle() const noexcept { return m_hasExplicitTitle; }
     void MarkExplicitTitle() noexcept { m_hasExplicitTitle = true; }
 
+    // True once the USER named this tab via the rename prompt
+    // (PROMPT_TITLE). One level stronger than the shell latch above:
+    // upstream documents that a prompt-set title "overrides any
+    // title set by the terminal", so SET_TITLE / SET_TAB_TITLE must
+    // skip a user-titled tab (the shell keeps re-asserting its OSC
+    // title on every prompt, which would instantly undo the rename).
+    // Marking a user title implies the explicit latch too, so the
+    // pid poll stays out without callers having to set both.
+    bool HasUserTitle() const noexcept { return m_hasUserTitle; }
+    void MarkUserTitle() noexcept {
+        m_hasUserTitle = true;
+        m_hasExplicitTitle = true;
+    }
+
     // Last PID resolved for this tab's active pane's foreground
     // process, and the basename cached from it. The poll updates both
     // when the PID changes so QueryFullProcessImageNameW only runs on
@@ -211,6 +225,10 @@ private:
     // pane is destroyed.
     Pane* m_activePane{ nullptr };
 
+    // See HasUserTitle. Sticky for the tab's lifetime — there is no
+    // inverse yet (the rename prompt treats empty input as cancel
+    // for exactly this reason).
+    bool m_hasUserTitle{ false };
     // See HasExplicitTitle. Sticky: once the shell sets a title the
     // poll leaves it alone for the rest of the tab's life.
     bool m_hasExplicitTitle{ false };

--- a/Core/Ghostty/Actions/Actions.cpp
+++ b/Core/Ghostty/Actions/Actions.cpp
@@ -386,6 +386,14 @@ bool Actions::OnPwd(ghostty_surface_t surface, const char* utf8Pwd) {
     return true;
 }
 
+bool Actions::OnPromptTitle(ghostty_surface_t surface) {
+    if (!surface) return true;
+    DispatchToView([this, surface]() {
+        m_view.PromptTitleForSurface(surface);
+    });
+    return true;
+}
+
 bool Actions::OnReadonly(ghostty_surface_t surface,
                          ghostty_action_readonly_e readonly) {
     if (!surface) return true;

--- a/Core/Ghostty/Actions/Actions.h
+++ b/Core/Ghostty/Actions/Actions.h
@@ -138,6 +138,8 @@ public:
                        ghostty_action_secure_input_e mode);
     // PWD: shell-reported working directory (OSC 7).
     bool OnPwd(ghostty_surface_t surface, const char* utf8Pwd);
+    // PROMPT_TITLE: SURFACE/TAB variants collapse (one title per tab).
+    bool OnPromptTitle(ghostty_surface_t surface);
     // READONLY: indicator only — the write blocking is in core.
     bool OnReadonly(ghostty_surface_t surface,
                     ghostty_action_readonly_e readonly);

--- a/Core/Ghostty/CallbackDispatcher.cpp
+++ b/Core/Ghostty/CallbackDispatcher.cpp
@@ -100,6 +100,14 @@ bool CallbackDispatcher::DispatchAction(ghostty_target_s target, ghostty_action_
                 return m_actions.OnMouseVisibility(target.target.surface,
                                                    action.action.mouse_visibility);
             return false;
+        // PROMPT_TITLE: rename-title prompt. The SURFACE/TAB payload
+        // variants collapse in the handler (one title per tab, same
+        // as SET_TITLE/SET_TAB_TITLE). App-targeted is a no-op
+        // upstream — ack.
+        case GHOSTTY_ACTION_PROMPT_TITLE:
+            if (target.tag == GHOSTTY_TARGET_SURFACE)
+                return m_actions.OnPromptTitle(target.target.surface);
+            return true;
         // READONLY: toggle_readonly indicator (the blocking itself
         // is core-side). App-targeted is a no-op upstream — ack.
         case GHOSTTY_ACTION_READONLY:
@@ -198,10 +206,6 @@ bool CallbackDispatcher::DispatchAction(ghostty_target_s target, ghostty_action_
         // here keeps libghostty's future "unhandled action" audit
         // quiet without inventing empty GhosttyActions methods.
         //
-        // PROMPT_TITLE: "show a rename-title prompt" keybind action.
-        // Pending its own PR (ContentDialog + TextBox); acked until
-        // then so the keybind doesn't read as unhandled.
-        case GHOSTTY_ACTION_PROMPT_TITLE:
         // Feature surfaces intentionally not on this port's plate
         // (search bar, ImGui inspector, tab overview, quick
         // terminal, command palette, terminal-level undo/redo):

--- a/Core/Host/IWindow.h
+++ b/Core/Host/IWindow.h
@@ -197,6 +197,14 @@ struct IWindow {
     virtual void SetSecureInputForSurface(ghostty_surface_t surface,
                                           ghostty_action_secure_input_e mode) = 0;
 
+    // PROMPT_TITLE: the prompt_surface_title / prompt_tab_title
+    // keybind asked for a rename-title prompt. Both variants
+    // collapse to renaming the tab — this port has one title
+    // surface per tab, the same collapse SET_TITLE/SET_TAB_TITLE
+    // already use. UI thread hop happens in the handler; the view
+    // shows a ContentDialog and applies the result itself.
+    virtual void PromptTitleForSurface(ghostty_surface_t surface) = 0;
+
     // READONLY: the toggle_readonly keybind flipped the surface's
     // read-only state. The functional half (pty writes blocked)
     // lives in libghostty and already works — this is purely the

--- a/Tests/MockMainWindowView.h
+++ b/Tests/MockMainWindowView.h
@@ -183,6 +183,13 @@ struct MockMainWindowView : core::host::IWindow {
         lastSecureInputMode = mode;
     }
 
+    int promptTitleCalls = 0;
+    ghostty_surface_t lastPromptTitleSurface = nullptr;
+    void PromptTitleForSurface(ghostty_surface_t s) override {
+        ++promptTitleCalls;
+        lastPromptTitleSurface = s;
+    }
+
     int setReadonlyCalls = 0;
     ghostty_surface_t lastReadonlySurface = nullptr;
     bool lastReadonly = false;

--- a/Tests/test_ghostty_actions.cpp
+++ b/Tests/test_ghostty_actions.cpp
@@ -358,6 +358,22 @@ TEST(GhosttyActionsTest, OnSecureInputIgnoresNullSurface) {
     EXPECT_EQ(view.setSecureInputCalls, 0);
 }
 
+TEST(GhosttyActionsTest, OnPromptTitleForwardsSurface) {
+    MockMainWindowView view;
+    Actions actions(view);
+    auto surface = FakeSurface(0x71);
+    EXPECT_TRUE(actions.OnPromptTitle(surface));
+    EXPECT_EQ(view.promptTitleCalls, 1);
+    EXPECT_EQ(view.lastPromptTitleSurface, surface);
+}
+
+TEST(GhosttyActionsTest, OnPromptTitleIgnoresNullSurface) {
+    MockMainWindowView view;
+    Actions actions(view);
+    EXPECT_TRUE(actions.OnPromptTitle(nullptr));
+    EXPECT_EQ(view.promptTitleCalls, 0);
+}
+
 TEST(GhosttyActionsTest, OnReadonlyMapsEnumToBool) {
     MockMainWindowView view;
     Actions actions(view);

--- a/Tests/test_ghostty_callback_dispatcher.cpp
+++ b/Tests/test_ghostty_callback_dispatcher.cpp
@@ -135,6 +135,30 @@ TEST(GhosttyCallbackDispatcherTest, MouseVisibilityRoutesToTheOwningSurface) {
     EXPECT_FALSE(DispatchTag(*d, GHOSTTY_ACTION_MOUSE_VISIBILITY));
 }
 
+TEST(GhosttyCallbackDispatcherTest, PromptTitleRoutesToTheOwningSurface) {
+    MockMainWindowView view;
+    auto d = CallbackDispatcher::Create(view);
+
+    ghostty_target_s target{};
+    target.tag = GHOSTTY_TARGET_SURFACE;
+    target.target.surface = reinterpret_cast<ghostty_surface_t>(0xBEEF);
+    ghostty_action_s action{};
+    action.tag = GHOSTTY_ACTION_PROMPT_TITLE;
+
+    // Both payload variants land on the same handler — one title
+    // surface per tab (same collapse as SET_TITLE/SET_TAB_TITLE).
+    action.action.prompt_title = GHOSTTY_PROMPT_TITLE_SURFACE;
+    EXPECT_TRUE(d->DispatchAction(target, action));
+    action.action.prompt_title = GHOSTTY_PROMPT_TITLE_TAB;
+    EXPECT_TRUE(d->DispatchAction(target, action));
+    EXPECT_EQ(view.promptTitleCalls, 2);
+    EXPECT_EQ(view.lastPromptTitleSurface, target.target.surface);
+
+    // App-targeted: upstream logs and ignores — acked.
+    EXPECT_TRUE(DispatchTag(*d, GHOSTTY_ACTION_PROMPT_TITLE));
+    EXPECT_EQ(view.promptTitleCalls, 2);
+}
+
 TEST(GhosttyCallbackDispatcherTest, ReadonlyRoutesToTheOwningSurface) {
     MockMainWindowView view;
     auto d = CallbackDispatcher::Create(view);


### PR DESCRIPTION
Stacked on #149 (`feature/readonly-indicator`); retarget to `dev` after it merges instead of recreating.

## Summary

Last of the misfiled "informational" actions (#57): `PROMPT_TITLE` is the `prompt_surface_title` / `prompt_tab_title` keybind asking for a rename prompt. It now opens a "Rename tab" dialog — the first way to name a tab by hand in this port.

<details>
<summary>日本語</summary>

誤分類されていた「informational」の最後の 1 つ (#57)。`PROMPT_TITLE` は `prompt_surface_title` / `prompt_tab_title` keybind の「リネームプロンプトを出せ」という指示で、これを「Rename tab」ダイアログとして実装する — この port で初めて、タブに手動で名前を付けられるようになる。

</details>

## Design

- **ContentDialog + pre-selected TextBox** (typing replaces the old title outright — the common case is a full rename).
- **Title priority becomes a 3-level hierarchy: user > shell > automatic.** The existing shell latch (`MarkExplicitTitle`) only kept the pid poll out — shells re-assert their OSC title on every prompt, which undid a rename within seconds (caught during verification: launching a program overwrote the name, exiting reverted it). Renaming now sets a stronger `MarkUserTitle` latch, and `SET_TITLE`/`SET_TAB_TITLE` skip a user-titled tab — matching upstream's documented "overrides any title set by the terminal".
- **SURFACE/TAB variants collapse** to the tab rename — one title surface per tab, the same collapse `SET_TITLE`/`SET_TAB_TITLE` already use.
- **Empty input = cancel.** Upstream treats an empty title as "reset to automatic", but this port has no inverse of `MarkExplicitTitle` yet, so that reset can't be honoured truthfully — treating it as cancel is the honest v1. Noted in code.
- **Re-entrancy guard**: WinUI allows one ContentDialog per XamlRoot; repeat keypresses while the prompt is up are dropped.
- **Window-reactivation focus guard**: MainWindow's Activated restore used to call `tab->Focus()` unconditionally, so alt-tabbing away and back while the dialog was up stole focus from it and let keystrokes leak into the shell (caught during verification). The restore now skips when `GetOpenPopupsForXamlRoot` reports any open popup — covering this dialog, the close-confirm dialog, and anything future.
- Lifetime: the Completed handler holds a weak window ref (dialog can outlive teardown, same rationale as WindowCloseGate) and the TabViewItem by value — renaming a tab that was closed or torn out mid-prompt is a safe no-op on a refcounted handle, not a dangling pointer.

<details>
<summary>日本語</summary>

- **ContentDialog + 全選択済み TextBox** (打ち始めた瞬間に旧タイトルが置き換わる — 全リネームが一番の使われ方だから)
- **タイトル優先順位を 3 段階に: user > shell > 自動。** 既存の shell ラッチ (`MarkExplicitTitle`) は pid ポーリングしか止めておらず、shell はプロンプトのたびに OSC タイトルを再アサートするのでリネームが数秒で戻ってしまう (検証で発見: プログラム起動で上書き、exit で元のディレクトリ名に復帰)。リネームはより強い `MarkUserTitle` ラッチを掛け、`SET_TITLE`/`SET_TAB_TITLE` は user タイトル付きタブをスキップする — 本家 docs の「terminal が設定したタイトルより優先」と一致
- **SURFACE/TAB variant はタブリネームに集約** — タブごとにタイトルは 1 つで、`SET_TITLE`/`SET_TAB_TITLE` が既にやっている集約と同じ
- **空入力はキャンセル扱い。** 本家は空タイトルを「自動タイトルに戻す」として扱うが、この port には `MarkExplicitTitle` の逆操作がまだ無く、そのリセットを正直に実現できない — キャンセル扱いが誠実な v1。コードにも明記
- **再入ガード**: WinUI は XamlRoot につき ContentDialog 1 枚まで。プロンプト表示中の連打は捨てる
- **ウインドウ再 activate 時のフォーカスガード**: MainWindow の Activated 復帰処理が `tab->Focus()` を無条件に呼んでいたため、ダイアログ表示中に alt-tab で離れて戻るとフォーカスが奪われ、shell にキー入力が漏れていた (検証で発見)。復帰処理は `GetOpenPopupsForXamlRoot` が open popup を報告したらスキップする — このダイアログ、close 確認ダイアログ、将来のダイアログすべてをカバー
- lifetime: Completed ハンドラは window を weak 参照で持ち (ダイアログは teardown を生き延び得る — WindowCloseGate と同じ理由)、TabViewItem は値キャプチャ — プロンプト中に閉じられた/tear-out されたタブへの適用は、dangling ではなく refcounted handle 上の安全な no-op になる

</details>

## Changes

- `Core/Ghostty/CallbackDispatcher.cpp` — `PROMPT_TITLE` leaves the ack list; surface routes, app acks (upstream logs and ignores).
- `Core/Ghostty/Actions/Actions.{h,cpp}` — `OnPromptTitle`.
- `Core/Host/IWindow.h` — new `PromptTitleForSurface(surface)`.
- `App/MainWindow.xaml.{h,cpp}` — the dialog + `m_renamePromptOpen` guard.
- Tests — dispatcher (both payload variants route, app-target acks); Actions (forward, null-surface guard).

<details>
<summary>日本語</summary>

- `Core/Ghostty/CallbackDispatcher.cpp` — `PROMPT_TITLE` を ack リストから外し、surface 宛は routing、app 宛は ack (本家も warning ログで無視)
- `Core/Ghostty/Actions/Actions.{h,cpp}` — `OnPromptTitle`
- `Core/Host/IWindow.h` — `PromptTitleForSurface(surface)` を追加
- `App/MainWindow.xaml.{h,cpp}` — ダイアログ本体と `m_renamePromptOpen` ガード
- テスト — dispatcher (payload 2 variant とも routing、app 宛は ack)、Actions (転送、null surface ガード)

</details>

## Verification

Config (already added to the local config):

```
keybind = alt+shift+t=prompt_tab_title
keybind = alt+shift+u=prompt_surface_title
```

- [x] Tests.exe green (new dispatcher/Actions tests included)
- [x] `Alt+Shift+T` — "Rename tab" dialog opens with the current title pre-selected
- [x] Type a name, Rename (or Enter — Primary is the default button) — the tab header changes and stays (the process-name poll no longer overwrites it)
- [x] Cancel (or Esc) — title unchanged
- [x] Empty the TextBox and Rename — title unchanged (empty = cancel by design)
- [x] `Alt+Shift+U` (surface variant) — same dialog, same behavior
- [x] Press the keybind twice quickly — only one dialog appears
- [x] Light/dark theme: dialog follows the theme
- [x] Focus guard: with the dialog open, alt-tab away and back — focus stays on the dialog (typing goes to the TextBox, not the shell)

<details>
<summary>日本語</summary>

config (ローカル config に追加済み):

- Tests.exe が green (新規 dispatcher / Actions テスト含む)
- `Alt+Shift+T` — 「Rename tab」ダイアログが開き、現タイトルが全選択済み
- 名前を入れて Rename (Enter でも可 — Primary が既定ボタン) — タブの header が変わり、以後プロセス名ポーリングに上書きされない
- Cancel (か Esc) — タイトル変化なし
- TextBox を空にして Rename — タイトル変化なし (空 = 仕様上キャンセル)
- `Alt+Shift+U` (surface variant) — 同じダイアログ・同じ挙動
- keybind を素早く 2 連打 — ダイアログは 1 枚だけ
- ライト / ダークテーマ: ダイアログがテーマに追従
- フォーカスガード: ダイアログを開いたまま alt-tab で離れて戻る — フォーカスはダイアログに残る (入力は TextBox に入り、shell に漏れない)

</details>
