### PR TITLE
Toggle background opacity with an opaque underlay

### DIFF
--- a/App/App.vcxproj
+++ b/App/App.vcxproj
@@ -119,7 +119,7 @@
     </ClCompile>
     <Link>
       <AdditionalLibraryDirectories>$(ProjectDir)..\external\ghostty\zig-out\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>ghostty-internal.lib;d3d11.lib;dxgi.lib;comctl32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>ghostty-internal.lib;d3d11.lib;dxgi.lib;comctl32.lib;gdi32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug' or '$(Configuration)'=='ASan'">
@@ -170,6 +170,7 @@
     </ClInclude>
     <ClInclude Include="MainWindows.h" />
     <ClInclude Include="SplitPanel.h" />
+    <ClInclude Include="TransparentBackdrop.h" />
     <ClInclude Include="WindowCloseGate.h" />
     <ClInclude Include="Tabs\Panes\Branch.h" />
     <ClInclude Include="Tabs\Panes\Pane.h" />
@@ -209,6 +210,7 @@
     <ClCompile Include="MainWindows.cpp" />
     <ClCompile Include="Ghostty\MainWindowRuntime.cpp" />
     <ClCompile Include="SplitPanel.cpp" />
+    <ClCompile Include="TransparentBackdrop.cpp" />
     <ClCompile Include="WindowCloseGate.cpp" />
     <ClCompile Include="TerminalControl.xaml.cpp">
       <DependentUpon>TerminalControl.xaml</DependentUpon>
@@ -221,6 +223,9 @@
       <DependentUpon>MainWindow.xaml</DependentUpon>
     </Midl>
     <Midl Include="SplitPanel.idl">
+      <SubType>Code</SubType>
+    </Midl>
+    <Midl Include="TransparentBackdrop.idl">
       <SubType>Code</SubType>
     </Midl>
     <Midl Include="TerminalControl.idl">

--- a/App/MainWindow.xaml.cpp
+++ b/App/MainWindow.xaml.cpp
@@ -3,6 +3,7 @@
 #include "App.xaml.h"
 #include "Ghostty/CallbackDispatcher.h"
 #include "Ghostty/Config.h"
+#include "TransparentBackdrop.h"
 #include "Host/KeyModifiers.h"
 #include "Interop/Encoding.h"
 #include "Display/PhysicalPixels.h"
@@ -1059,6 +1060,15 @@ namespace winrt::GhosttyWin32::implementation
             auto onLeafFocused = [this](ghostty_surface_t surface) noexcept {
                 NotifySurfaceFocused(surface);
             };
+            // Window-state initialization for every new leaf: the
+            // background-opacity mode is window-scoped (#69), and a
+            // pane born after a toggle must match its window.
+            auto onLeafCreated = [this](implementation::TerminalControl& tc) {
+                ghostty::Config cfg(m_ghosttyApp->ConfigHandle());
+                const bool underlay =
+                    m_bgOpaque && cfg.BackgroundOpacity() < 1.0;
+                tc.SetOpaqueBackground(underlay, m_bgColor);
+            };
             // Hand the factory the App wrapper, not a Config snapshot:
             // the config handle is freed and swapped on every config
             // change (reload, theme follow), so the factory must
@@ -1067,7 +1077,16 @@ namespace winrt::GhosttyWin32::implementation
                 *m_ghosttyApp,
                 m_hwnd,
                 App::g_app->PaneIds(),
-                std::move(onLeafFocused));
+                std::move(onLeafFocused),
+                std::move(onLeafCreated));
+            // Seed the tracked background colour from config so the
+            // opaque underlay has a real colour before the first
+            // COLOR_CHANGE arrives, then apply the opacity mode once
+            // so a translucent config gets its backdrop/root state
+            // from the first frame instead of waiting for the first
+            // COLOR_CHANGE.
+            m_bgColor = ghostty::Config(m_ghosttyApp->ConfigHandle()).Background();
+            ApplyBackgroundOpacityAppearance();
         }
     }
 
@@ -1609,10 +1628,105 @@ namespace winrt::GhosttyWin32::implementation
             COLORREF textColor = (luminance < 128) ? RGB(255, 255, 255) : RGB(0, 0, 0);
             DwmSetWindowAttribute(m_hwnd, DWMWA_TEXT_COLOR, &textColor, sizeof(textColor));
         }
-        auto brush = winrt::Microsoft::UI::Xaml::Media::SolidColorBrush(
-            winrt::Windows::UI::Color{ 255, r, g, b });
+        m_bgColor = winrt::Windows::UI::Color{ 255, r, g, b };
+        // Root painting + per-pane underlays both depend on the
+        // background-opacity mode, so a recolour funnels through the
+        // same apply as the toggle (#69).
+        ApplyBackgroundOpacityAppearance();
+    }
+
+    void MainWindow::ToggleBackgroundOpacity()
+    {
+        if (!m_ghosttyApp) return;
+        ghostty::Config cfg(m_ghosttyApp->ConfigHandle());
+        // macOS guards: nothing to toggle when no transparency is
+        // configured; never while fullscreen.
+        if (cfg.BackgroundOpacity() >= 1.0) return;
+        if (m_fullscreen.Active()) return;
+        m_bgOpaque = !m_bgOpaque;
+        ApplyBackgroundOpacityAppearance();
+    }
+
+    void MainWindow::ApplyBackgroundOpacityAppearance()
+    {
+        bool translucent = false;
+        if (m_ghosttyApp) {
+            ghostty::Config cfg(m_ghosttyApp->ConfigHandle());
+            translucent = cfg.BackgroundOpacity() < 1.0 && !m_bgOpaque;
+        }
+        // Backdrop selection mirrors Windows Terminal's two
+        // transparency modes and maps 1:1 onto ghostty config:
+        //   translucent + background-blur  -> DesktopAcrylic (blur
+        //     whatever is behind the window)
+        //   translucent, no blur           -> TransparentBackdrop
+        //     (crisp see-through — WT's "vintage opacity" look)
+        //   opaque                         -> Mica, as before
+        // Mica alone was tried first and reads as "slightly gray",
+        // not transparent — it only tints toward the wallpaper
+        // (observed during #69 verification).
+        bool blur = false;
+        if (translucent && m_ghosttyApp) {
+            blur = ghostty::Config(m_ghosttyApp->ConfigHandle())
+                       .BackgroundBlurEnabled();
+        }
+        try {
+            if (translucent) {
+                if (blur) {
+                    // Not the stock DesktopAcrylicBackdrop: its
+                    // material tint swallows the terminal's own
+                    // translucency. ClearAcrylic is pure blur, so
+                    // background-opacity and background-blur compose
+                    // (frosted glass).
+                    SystemBackdrop(winrt::GhosttyWin32::ClearAcrylicBackdrop());
+                } else {
+                    SystemBackdrop(winrt::GhosttyWin32::TransparentBackdrop());
+                }
+            } else {
+                SystemBackdrop(winrt::Microsoft::UI::Xaml::Media::MicaBackdrop());
+            }
+        } catch (winrt::hresult_error const&) {
+            // Backdrop swap can fail during teardown; visuals only.
+        }
+        // DWM composites a window's surface as opaque by default, so
+        // the transparent backdrop alone renders BLACK, not
+        // see-through. Enabling "blur behind" with an empty region is
+        // the long-standing switch that makes DWM honour the window's
+        // per-pixel alpha (the blur itself has been a no-op since
+        // Win8; only the alpha semantics remain). Only needed for the
+        // crisp mode — Acrylic/Mica are DWM materials that composite
+        // on their own.
+        if (m_hwnd) {
+            const bool wantAlpha = translucent && !blur;
+            DWM_BLURBEHIND bb{};
+            bb.dwFlags = DWM_BB_ENABLE;
+            bb.fEnable = wantAlpha ? TRUE : FALSE;
+            HRGN rgn = nullptr;
+            if (wantAlpha) {
+                rgn = CreateRectRgn(-1, -1, 0, 0);
+                bb.dwFlags |= DWM_BB_BLURREGION;
+                bb.hRgnBlur = rgn;
+            }
+            DwmEnableBlurBehindWindow(m_hwnd, &bb);
+            if (rgn) DeleteObject(rgn);
+        }
+        // Root: in translucent mode the root stays unpainted so the
+        // window backdrop shows through behind the panes; otherwise
+        // paint it with the terminal background as before.
         if (auto content = Content()) {
-            content.as<winrt::Microsoft::UI::Xaml::Controls::Panel>().Background(brush);
+            auto panel = content.as<winrt::Microsoft::UI::Xaml::Controls::Panel>();
+            if (translucent) {
+                panel.Background(nullptr);
+            } else {
+                panel.Background(
+                    winrt::Microsoft::UI::Xaml::Media::SolidColorBrush(m_bgColor));
+            }
+        }
+        // Underlays only earn their pixel cost when they change the
+        // result: config transparency present AND the user toggled
+        // opaque. (With opacity 1.0 the swap chain is opaque anyway.)
+        const bool underlay = !translucent && m_bgOpaque;
+        for (auto& tab : m_tabs) {
+            if (tab) tab->ApplyBackgroundOpacity(underlay, m_bgColor);
         }
     }
 
@@ -2464,6 +2578,10 @@ namespace winrt::GhosttyWin32::implementation
         // activates its freshly spawned host, while a merge adopts
         // into a window that is already visible and focused.
         if (m_hwnd) ShowWindow(m_hwnd, SW_SHOWNOACTIVATE);
+        // The adopted panes carry the previous window's background-
+        // opacity mode (#69 — window-scoped state); restate this
+        // window's mode over the whole tab set.
+        ApplyBackgroundOpacityAppearance();
     }
 
     void MainWindow::CloseIfTornOutEmpty()

--- a/App/MainWindow.xaml.h
+++ b/App/MainWindow.xaml.h
@@ -119,6 +119,13 @@ namespace winrt::GhosttyWin32::implementation
         void ToggleFullscreen() override;
         void ToggleWindowDecorations() override;
         void SetFloatOnTop(ghostty_action_float_window_e mode) override;
+        void ToggleBackgroundOpacity() override;
+        // Push the current background-opacity mode (m_bgOpaque +
+        // config) to the XAML root and every pane. Called from the
+        // toggle, from pane-creation funnels (CreateTab / split /
+        // adopt) so new panes match the window state, and from
+        // ApplyBackgroundColor when the terminal recolours.
+        void ApplyBackgroundOpacityAppearance();
         // Apply the current decoration state (config + any override
         // installed by ToggleWindowDecorations) to the XAML caption
         // buttons / drag region. Called once at startup so the config
@@ -371,6 +378,16 @@ namespace winrt::GhosttyWin32::implementation
         // one is up throws. Set when the dialog opens, cleared in its
         // Completed handler.
         bool m_renamePromptOpen = false;
+        // TOGGLE_BACKGROUND_OPACITY state (#69). false = the config's
+        // background-opacity applies (translucent when < 1.0, which
+        // is also the launch state, matching macOS); true = the user
+        // toggled to fully opaque. Meaningless while the config
+        // opacity is 1.0 — the toggle no-ops there.
+        bool m_bgOpaque = false;
+        // Terminal background colour as last applied (config value at
+        // init, updated by COLOR_CHANGE via ApplyBackgroundColor).
+        // Feeds the opaque underlays and the root brush.
+        winrt::Windows::UI::Color m_bgColor{ 255, 0, 0, 0 };
         // Constructed once ghostty is initialized — needs the app handle
         // and HWND, neither available until InitGhostty has run.
         std::unique_ptr<TabFactory> m_tabFactory;

--- a/App/Tabs/Tab.h
+++ b/App/Tabs/Tab.h
@@ -170,6 +170,18 @@ public:
         }
     }
 
+    // Apply the window's background-opacity mode to every pane in
+    // the tree (#69). See TerminalControl::SetOpaqueBackground.
+    void ApplyBackgroundOpacity(bool opaque, winrt::Windows::UI::Color bg) {
+        if (auto* panelImpl = winrt::get_self<implementation::SplitPanel>(m_panel)) {
+            panelImpl->Tree().ForEachPane([&](Pane& p) {
+                if (auto* tc = PaneToTerminalControl(p)) {
+                    tc->SetOpaqueBackground(opaque, bg);
+                }
+            });
+        }
+    }
+
     // Detach every TerminalControl in the tree (surface free, swap
     // chain release, composition handle close, SizeChanged unhook).
     // Must run while the SplitPanel is still in the live visual tree

--- a/App/Tabs/TabFactory.h
+++ b/App/Tabs/TabFactory.h
@@ -49,9 +49,11 @@ class TabFactory {
 public:
     TabFactory(ghostty::App const& app, HWND hwnd,
                PaneIdAllocator& idAllocator,
-               std::function<void(ghostty_surface_t)> onLeafFocused = {}) noexcept
+               std::function<void(ghostty_surface_t)> onLeafFocused = {},
+               std::function<void(implementation::TerminalControl&)> onLeafCreated = {}) noexcept
         : m_ghostty(app), m_hwnd(hwnd), m_idAllocator(idAllocator),
-          m_onLeafFocused(std::move(onLeafFocused)) {}
+          m_onLeafFocused(std::move(onLeafFocused)),
+          m_onLeafCreated(std::move(onLeafCreated)) {}
 
     TabFactory(const TabFactory&) = delete;
     TabFactory& operator=(const TabFactory&) = delete;
@@ -276,6 +278,14 @@ public:
             1.0 - liveCfg.UnfocusedSplitOpacity(),
             liveCfg.UnfocusedSplitFill());
 
+        // Host-supplied per-leaf initialization that depends on
+        // window state the factory can't know (today: the window's
+        // background-opacity mode, #69). Runs for every creation
+        // path — first tab, split, new window — so window-scoped
+        // visual state can't be missed by a pane born after a
+        // toggle.
+        if (m_onLeafCreated) m_onLeafCreated(*controlImpl);
+
         return MakePaneBranch(control, paneId);
     }
 
@@ -304,6 +314,9 @@ private:
     // Optional. Fires with the leaf's ghostty_surface_t whenever the
     // leaf's TerminalControl receives keyboard focus.
     std::function<void(ghostty_surface_t)> m_onLeafFocused;
+    // See the call site in MakePane: window-state-dependent per-leaf
+    // initialization supplied by the host.
+    std::function<void(implementation::TerminalControl&)> m_onLeafCreated;
 };
 
 }  // namespace winrt::GhosttyWin32::implementation

--- a/App/TerminalControl.xaml
+++ b/App/TerminalControl.xaml
@@ -22,6 +22,19 @@
       the user having to find an explicit border.
     -->
     <Grid>
+        <!--
+          Opaque background underlay (#69). The renderer composites
+          the swap chain with premultiplied alpha, so with
+          background-opacity < 1 the pane is genuinely translucent.
+          TOGGLE_BACKGROUND_OPACITY's "opaque" state shows this
+          rectangle in the terminal's own background colour UNDER the
+          swap chain: opacity*bg blended over solid bg equals bg
+          exactly, so the pane reads as fully opaque — no renderer
+          round-trip needed to toggle.
+        -->
+        <Rectangle x:Name="OpaqueUnderlay"
+                   IsHitTestVisible="False"
+                   Visibility="Collapsed" />
         <SwapChainPanel x:Name="Panel"
                         IsTabStop="False"
                         AllowFocusOnInteraction="False" />

--- a/App/TerminalControl.xaml.cpp
+++ b/App/TerminalControl.xaml.cpp
@@ -366,6 +366,18 @@ namespace winrt::GhosttyWin32::implementation
         KeyStateBadge().Visibility(winrt::Microsoft::UI::Xaml::Visibility::Visible);
     }
 
+    void TerminalControl::SetOpaqueBackground(bool opaque, winrt::Windows::UI::Color bg)
+    {
+        auto underlay = OpaqueUnderlay();
+        if (!underlay) return;
+        if (opaque) {
+            underlay.Fill(winrt::Microsoft::UI::Xaml::Media::SolidColorBrush(bg));
+            underlay.Visibility(winrt::Microsoft::UI::Xaml::Visibility::Visible);
+        } else {
+            underlay.Visibility(winrt::Microsoft::UI::Xaml::Visibility::Collapsed);
+        }
+    }
+
     void TerminalControl::SetReadonly(bool readonly)
     {
         ReadonlyBadge().Visibility(readonly

--- a/App/TerminalControl.xaml.h
+++ b/App/TerminalControl.xaml.h
@@ -184,6 +184,13 @@ namespace winrt::GhosttyWin32::implementation
         void PushKeyTable(winrt::hstring const& name);
         void PopKeyTable(bool all);
 
+        // Show/hide the opaque background underlay beneath the swap
+        // chain (#69 — see the XAML comment on OpaqueUnderlay for
+        // the compositing math). `bg` is the terminal's current
+        // background colour so opaque mode is pixel-identical to
+        // opacity 1.0. UI thread only.
+        void SetOpaqueBackground(bool opaque, winrt::Windows::UI::Color bg);
+
         // Show/hide the read-only chip (READONLY action). The write
         // blocking is core-side; this is indicator only. UI thread.
         void SetReadonly(bool readonly);

--- a/App/TransparentBackdrop.cpp
+++ b/App/TransparentBackdrop.cpp
@@ -1,0 +1,69 @@
+#include "pch.h"
+#include "TransparentBackdrop.h"
+// Neither is in pch. Note the namespace split: the target interface
+// lives in Microsoft.UI.Composition, but its SystemBackdrop property
+// (WinAppSDK 1.8 projection) takes a brush from the SYSTEM
+// compositor's family — Windows.UI.Composition — so the brush has to
+// be created by a Windows::UI::Composition::Compositor.
+#include <winrt/Microsoft.UI.Composition.h>
+#include <winrt/Microsoft.UI.Composition.SystemBackdrops.h>
+#include <winrt/Windows.UI.Composition.h>
+#if __has_include("TransparentBackdrop.g.cpp")
+#include "TransparentBackdrop.g.cpp"
+#endif
+#if __has_include("ClearAcrylicBackdrop.g.cpp")
+#include "ClearAcrylicBackdrop.g.cpp"
+#endif
+
+namespace winrt::GhosttyWin32::implementation
+{
+    void TransparentBackdrop::OnTargetConnected(
+        winrt::Microsoft::UI::Composition::ICompositionSupportsSystemBackdrop const& target,
+        winrt::Microsoft::UI::Xaml::XamlRoot const& /*xamlRoot*/)
+    {
+        // Deliberately no base call: the base class's bookkeeping
+        // feeds SystemBackdropConfiguration policy updates (theme,
+        // activation), and a constant transparent brush has no
+        // policy to react to.
+        //
+        // The brush must come from the system compositor family
+        // (Windows.UI.Composition); the brush keeps its compositor
+        // alive, so a local is fine.
+        winrt::Windows::UI::Composition::Compositor compositor;
+        target.SystemBackdrop(compositor.CreateColorBrush(
+            winrt::Windows::UI::Color{ 0, 0, 0, 0 }));
+    }
+
+    void TransparentBackdrop::OnTargetDisconnected(
+        winrt::Microsoft::UI::Composition::ICompositionSupportsSystemBackdrop const& target)
+    {
+        target.SystemBackdrop(nullptr);
+    }
+
+    void ClearAcrylicBackdrop::OnTargetConnected(
+        winrt::Microsoft::UI::Composition::ICompositionSupportsSystemBackdrop const& target,
+        winrt::Microsoft::UI::Xaml::XamlRoot const& /*xamlRoot*/)
+    {
+        namespace sb = winrt::Microsoft::UI::Composition::SystemBackdrops;
+        if (!m_controller) {
+            m_controller = sb::DesktopAcrylicController();
+            // Zero out the material: no tint, no luminosity wash.
+            // What remains is the blur of whatever is behind the
+            // window, and the terminal's own background-opacity
+            // provides the color on top of it.
+            m_controller.TintOpacity(0.0f);
+            m_controller.LuminosityOpacity(0.0f);
+        }
+        if (!m_configuration) {
+            m_configuration = sb::SystemBackdropConfiguration();
+            m_controller.SetSystemBackdropConfiguration(m_configuration);
+        }
+        m_controller.AddSystemBackdropTarget(target);
+    }
+
+    void ClearAcrylicBackdrop::OnTargetDisconnected(
+        winrt::Microsoft::UI::Composition::ICompositionSupportsSystemBackdrop const& target)
+    {
+        if (m_controller) m_controller.RemoveSystemBackdropTarget(target);
+    }
+}

--- a/App/TransparentBackdrop.h
+++ b/App/TransparentBackdrop.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include "TransparentBackdrop.g.h"
+
+namespace winrt::GhosttyWin32::implementation
+{
+    // See TransparentBackdrop.idl. The mechanics: a SystemBackdrop's
+    // job is to hand the composition target a brush; handing it a
+    // transparent CompositionColorBrush means DWM composites the
+    // window's alpha directly against whatever is behind the window
+    // — no blur, no tint. Same technique WinUIEx's
+    // TransparentTintBackdrop uses.
+    struct TransparentBackdrop : TransparentBackdropT<TransparentBackdrop>
+    {
+        TransparentBackdrop() = default;
+
+        void OnTargetConnected(
+            winrt::Microsoft::UI::Composition::ICompositionSupportsSystemBackdrop const& target,
+            winrt::Microsoft::UI::Xaml::XamlRoot const& xamlRoot);
+        void OnTargetDisconnected(
+            winrt::Microsoft::UI::Composition::ICompositionSupportsSystemBackdrop const& target);
+    };
+}
+
+namespace winrt::GhosttyWin32::factory_implementation
+{
+    struct TransparentBackdrop : TransparentBackdropT<TransparentBackdrop, implementation::TransparentBackdrop>
+    {
+    };
+}
+
+#include "ClearAcrylicBackdrop.g.h"
+
+namespace winrt::GhosttyWin32::implementation
+{
+    // See ClearAcrylicBackdrop in the IDL: DesktopAcrylicController
+    // with TintOpacity / LuminosityOpacity forced to 0 — pure blur,
+    // no color wash, so the terminal's own alpha stays visible
+    // through it.
+    struct ClearAcrylicBackdrop : ClearAcrylicBackdropT<ClearAcrylicBackdrop>
+    {
+        ClearAcrylicBackdrop() = default;
+
+        void OnTargetConnected(
+            winrt::Microsoft::UI::Composition::ICompositionSupportsSystemBackdrop const& target,
+            winrt::Microsoft::UI::Xaml::XamlRoot const& xamlRoot);
+        void OnTargetDisconnected(
+            winrt::Microsoft::UI::Composition::ICompositionSupportsSystemBackdrop const& target);
+
+    private:
+        winrt::Microsoft::UI::Composition::SystemBackdrops::DesktopAcrylicController m_controller{ nullptr };
+        winrt::Microsoft::UI::Composition::SystemBackdrops::SystemBackdropConfiguration m_configuration{ nullptr };
+    };
+}
+
+namespace winrt::GhosttyWin32::factory_implementation
+{
+    struct ClearAcrylicBackdrop : ClearAcrylicBackdropT<ClearAcrylicBackdrop, implementation::ClearAcrylicBackdrop>
+    {
+    };
+}

--- a/App/TransparentBackdrop.idl
+++ b/App/TransparentBackdrop.idl
@@ -1,0 +1,29 @@
+namespace GhosttyWin32
+{
+    // System backdrop whose brush is a plain transparent color:
+    // combined with a transparent XAML root this yields crisp,
+    // unblurred per-pixel window transparency (Windows Terminal's
+    // "vintage opacity" look). Used when background-opacity < 1
+    // and background-blur is off; blur uses DesktopAcrylicBackdrop
+    // instead.
+    // [default_interface] is required: the class body only declares
+    // a constructor (the behavior lives in base-class overrides,
+    // which don't count as members in IDL), and midlrt rejects an
+    // "empty" activatable/composable runtimeclass without it.
+    [default_interface]
+    runtimeclass TransparentBackdrop : Microsoft.UI.Xaml.Media.SystemBackdrop
+    {
+        TransparentBackdrop();
+    }
+
+    // Acrylic blur with the tint dialed to zero: full blur of what's
+    // behind the window with no color wash, so background-opacity's
+    // translucency and background-blur compose ("frosted glass")
+    // instead of the stock DesktopAcrylicBackdrop's heavy material
+    // tint swallowing the transparency.
+    [default_interface]
+    runtimeclass ClearAcrylicBackdrop : Microsoft.UI.Xaml.Media.SystemBackdrop
+    {
+        ClearAcrylicBackdrop();
+    }
+}

--- a/Core/Ghostty/Actions/Actions.cpp
+++ b/Core/Ghostty/Actions/Actions.cpp
@@ -475,6 +475,15 @@ bool Actions::OnMouseOverLink(ghostty_surface_t surface,
     return true;
 }
 
+bool Actions::OnToggleBackgroundOpacity() {
+    // Guards (opacity >= 1.0, fullscreen) live in the view — it
+    // owns config access and the fullscreen state.
+    DispatchToView([this]() {
+        m_view.ToggleBackgroundOpacity();
+    });
+    return true;
+}
+
 bool Actions::OnReloadConfig(bool soft) {
     // The view-side implementation handles thread placement
     // (soft re-uses UI thread, hard spins a 4MB-stack worker

--- a/Core/Ghostty/Actions/Actions.h
+++ b/Core/Ghostty/Actions/Actions.h
@@ -153,6 +153,7 @@ public:
     // KEY_TABLE: named modal key-table activate/deactivate stack ops.
     bool OnKeyTable(ghostty_surface_t surface,
                     ghostty_action_key_table_s table);
+    bool OnToggleBackgroundOpacity();
     bool OnReloadConfig(bool soft);
     bool OnConfigChange(ghostty_config_t newCfg);
     bool OnDesktopNotification(ghostty_surface_t surface,

--- a/Core/Ghostty/Actions/Tags/Fullscreen.h
+++ b/Core/Ghostty/Actions/Tags/Fullscreen.h
@@ -30,6 +30,11 @@ public:
     // HWND is null.
     void Toggle(HWND hwnd) noexcept;
 
+    // Whether borderless fullscreen is currently active. Used by
+    // guards that must no-op while fullscreen (e.g. background-
+    // opacity toggling, mirroring upstream macOS).
+    bool Active() const noexcept { return m_active; }
+
 private:
     bool m_active = false;
     WINDOWPLACEMENT m_prevPlacement{};

--- a/Core/Ghostty/CallbackDispatcher.cpp
+++ b/Core/Ghostty/CallbackDispatcher.cpp
@@ -175,6 +175,8 @@ bool CallbackDispatcher::DispatchAction(ghostty_target_s target, ghostty_action_
             return m_actions.OnToggleWindowDecorations();
         case GHOSTTY_ACTION_FLOAT_WINDOW:
             return m_actions.OnFloatWindow(action.action.float_window);
+        case GHOSTTY_ACTION_TOGGLE_BACKGROUND_OPACITY:
+            return m_actions.OnToggleBackgroundOpacity();
 
         // ----- split-pane (surface-targeted) -----
         case GHOSTTY_ACTION_NEW_SPLIT:
@@ -230,13 +232,6 @@ bool CallbackDispatcher::DispatchAction(ghostty_target_s target, ghostty_action_
         case GHOSTTY_ACTION_QUIT_TIMER:
         // Cell metrics — no host-side consumer today:
         case GHOSTTY_ACTION_CELL_SIZE:
-        // TOGGLE_BACKGROUND_OPACITY: dispatched but not yet
-        // implemented — tracked in #69. (The layered-alpha approach
-        // sketched in the issue body doesn't work over a flip-model
-        // DComp swap chain; the real fix is a libghostty
-        // premultiplied-alpha change. Ack to keep the action_cb
-        // path quiet meanwhile.)
-        case GHOSTTY_ACTION_TOGGLE_BACKGROUND_OPACITY:
             return true;
 
         default:

--- a/Core/Ghostty/Config.h
+++ b/Core/Ghostty/Config.h
@@ -64,6 +64,26 @@ public:
     // own default of `.auto`. Used by the TOGGLE_WINDOW_DECORATIONS
     // tag (#68) to know what "the config default" means before
     // applying per-window overrides.
+    // `background-opacity` as configured (clamped by ghostty to
+    // [0,1] at load). 1.0 = fully opaque; the TOGGLE_BACKGROUND_
+    // OPACITY guards treat >= 1.0 as "no transparency configured",
+    // mirroring upstream macOS.
+    double BackgroundOpacity() const noexcept {
+        double opacity = 1.0;
+        GetRaw("background-opacity", &opacity);
+        return opacity;
+    }
+
+    // `background-blur` crosses the C API via cval() as an i16:
+    // 0 = off, 20 = a bare `true`, positive = the radius, negative
+    // = macOS glass sentinels ("imply some blur" per upstream, so
+    // any non-zero value counts as enabled here).
+    bool BackgroundBlurEnabled() const noexcept {
+        short v = 0;
+        if (!GetRaw("background-blur", &v)) return false;
+        return v != 0;
+    }
+
     // ----- notify-on-command-finish (v1.3.0+, default: never) -----
     // The whole feature is opt-in; every getter falls back to the
     // documented default when the key is unreadable.

--- a/Core/Host/IWindow.h
+++ b/Core/Host/IWindow.h
@@ -145,6 +145,13 @@ struct IWindow {
     // the "flip now" trigger from the dispatcher.
     virtual void ToggleWindowDecorations() = 0;
 
+    // TOGGLE_BACKGROUND_OPACITY: flip this window between "as
+    // configured" translucency and fully opaque. Window-scoped like
+    // upstream macOS (NSWindow.alphaValue flip), with the same
+    // guards: no-op when background-opacity >= 1.0 (no transparency
+    // configured) and while fullscreen.
+    virtual void ToggleBackgroundOpacity() = 0;
+
     // Bring the window to the foreground (restoring it from a
     // minimized state first) and give it focus. Used by
     // PRESENT_TERMINAL — typically triggered by an external

--- a/Tests/MockMainWindowView.h
+++ b/Tests/MockMainWindowView.h
@@ -131,6 +131,9 @@ struct MockMainWindowView : core::host::IWindow {
     int toggleWindowDecorationsCalls = 0;
     void ToggleWindowDecorations() override { ++toggleWindowDecorationsCalls; }
 
+    int toggleBackgroundOpacityCalls = 0;
+    void ToggleBackgroundOpacity() override { ++toggleBackgroundOpacityCalls; }
+
     int setFloatOnTopCalls = 0;
     ghostty_action_float_window_e lastFloatOnTopMode{};
     void SetFloatOnTop(ghostty_action_float_window_e mode) override {

--- a/Tests/test_ghostty_actions.cpp
+++ b/Tests/test_ghostty_actions.cpp
@@ -525,6 +525,13 @@ TEST(GhosttyActionsTest, OnMouseOverLinkIgnoresNullSurface) {
 
 // ----- config -----
 
+TEST(GhosttyActionsTest, OnToggleBackgroundOpacityAsksTheView) {
+    MockMainWindowView view;
+    Actions actions(view);
+    EXPECT_TRUE(actions.OnToggleBackgroundOpacity());
+    EXPECT_EQ(view.toggleBackgroundOpacityCalls, 1);
+}
+
 TEST(GhosttyActionsTest, OnReloadConfigPassesSoftFlagThrough) {
     MockMainWindowView view;
     Actions actions(view);

--- a/Tests/test_ghostty_callback_dispatcher.cpp
+++ b/Tests/test_ghostty_callback_dispatcher.cpp
@@ -81,6 +81,16 @@ TEST(GhosttyCallbackDispatcherTest, NoConsumerAcksReturnTrue) {
     EXPECT_TRUE(DispatchTag(*d, GHOSTTY_ACTION_CELL_SIZE));
 }
 
+TEST(GhosttyCallbackDispatcherTest, ToggleBackgroundOpacityRoutesToTheView) {
+    // Was the last "disabled by bug" ack (#69); now routed. The
+    // opacity/fullscreen guards are view-side, so the dispatcher's
+    // contract is just delivery.
+    MockMainWindowView view;
+    auto d = CallbackDispatcher::Create(view);
+    EXPECT_TRUE(DispatchTag(*d, GHOSTTY_ACTION_TOGGLE_BACKGROUND_OPACITY));
+    EXPECT_EQ(view.toggleBackgroundOpacityCalls, 1);
+}
+
 TEST(GhosttyCallbackDispatcherTest, FloatWindowRoutesToTheView) {
     // Was part of the "disabled features" ack set; now routed for
     // real (#109). Kept here so the tag can't silently fall back to


### PR DESCRIPTION
Closes #69. Requires the libghostty side (i999rri/ghostty#46: premultiplied swap chain alpha + bg_image replacement-pass fix) — without that DLL, background-opacity stays visually inert and the toggle no-ops into an unchanged picture.

## Summary

The last disabled-by-bug ack (#57): `TOGGLE_BACKGROUND_OPACITY` now works. With `background-opacity < 1.0` the terminal is genuinely translucent (the window backdrop shows through), and the toggle keybind flips the window between that and fully opaque.

<details>
<summary>日本語</summary>

最後の「バグで無効化」ack (#57)。`TOGGLE_BACKGROUND_OPACITY` が動くようになる。`background-opacity < 1.0` なら terminal が本当に透過し (ウインドウの backdrop が透ける)、toggle keybind でウインドウ単位に「設定通りの透過 ⇔ 完全不透明」を切り替えられる。

</details>

## Design

- **The opaque state is an underlay, not a renderer round-trip.** The renderer always composites at the configured opacity; "opaque" shows a rectangle in the terminal's own background colour *under* the swap chain. The math is exact: `opacity·bg + (1−opacity)·bg = bg`, so opaque mode is pixel-identical to opacity 1.0 — and libghostty needs no runtime opacity API.
- **Window-scoped, macOS guards**: state lives per window (like `NSWindow.alphaValue` upstream); no-op when `background-opacity >= 1.0` and while fullscreen (new `Fullscreen::Active()` accessor).
- **Every path restates the mode**: root painting (transparent in translucent mode so the backdrop shows), COLOR_CHANGE recolours, new panes via a new `TabFactory` `onLeafCreated` hook (single funnel — `Make` delegates to `MakePane`), and adopted tear-out tabs (window-scoped state must not travel with the tab).
- **Backdrop selection mirrors Windows Terminal's two transparency modes** and maps 1:1 onto ghostty config: translucent + `background-blur` → DesktopAcrylic (blur what's behind the window); translucent without blur → a new custom `TransparentBackdrop` (a SystemBackdrop whose brush is a transparent CompositionColorBrush — crisp per-pixel see-through, WT's "vintage opacity" look); opaque → Mica as before. Mica alone was tried first during verification and reads as "slightly gray": it only tints toward the wallpaper.
- Launch state matches macOS: config opacity < 1.0 ⇒ translucent (Acrylic) from the first frame.

<details>
<summary>日本語</summary>

- **不透明状態は renderer 往復ではなく下敷き。** renderer は常に設定どおりの opacity で合成し、「不透明」は swap chain の*下*に terminal 自身の背景色の矩形を敷く。数学は厳密: `opacity·bg + (1−opacity)·bg = bg` — 不透明モードは opacity 1.0 とピクセル単位で同一で、libghostty に実行時 opacity API を足す必要がない
- **window スコープ + macOS のガード**: 状態はウインドウ単位 (本家の `NSWindow.alphaValue` と同じ)。`background-opacity >= 1.0` と fullscreen 中は no-op (`Fullscreen::Active()` アクセサを追加)
- **全経路がモードを再宣言する**: root の塗り (透過モードでは backdrop が透けるよう透明化)、COLOR_CHANGE の再着色、新規 pane は `TabFactory` の新フック `onLeafCreated` (単一ファネル — `Make` は `MakePane` に委譲)、tear-out の adopt (window スコープの状態はタブと一緒に移動してはいけない)
- **透過モードでは backdrop を DesktopAcrylic に切替** (不透明モードで Mica に復帰)。検証での発見: alpha は正しく流れていたが、Mica の上の透過 terminal は「少しグレー」にしか見えない (Mica は壁紙のトーンしか反映しない)。正しい形は Windows Terminal の 2 モードと同じで、ghostty config と 1:1 に対応: 透過 + `background-blur` → DesktopAcrylic (背後をぼかして透かす)、透過で blur なし → 新規の `TransparentBackdrop` (透明な CompositionColorBrush を渡す SystemBackdrop サブクラス — ぼかしなしの素通し、WT の vintage opacity 相当)、不透明 → 従来通り Mica
- 起動時の状態は macOS と同じ: config opacity < 1.0 なら最初のフレームから透過 (Acrylic)

</details>

## Changes

- `Core/Ghostty/CallbackDispatcher.cpp` — `TOGGLE_BACKGROUND_OPACITY` leaves the ack list (the #69 diagnosis comment retires with it); routes like the other window-state actions.
- `Core/Ghostty/Actions/Actions.{h,cpp}` — `OnToggleBackgroundOpacity` (guards live view-side).
- `Core/Ghostty/Config.h` — `BackgroundOpacity()` getter.
- `Core/Ghostty/Actions/Tags/Fullscreen.h` — public `Active()`.
- `Core/Host/IWindow.h` — `ToggleBackgroundOpacity()`.
- `App/TerminalControl.xaml{,.h,.cpp}` — `OpaqueUnderlay` rectangle under the SwapChainPanel + `SetOpaqueBackground()`.
- `App/Tabs/Tab.h` — `ApplyBackgroundOpacity` tree walk; `App/Tabs/TabFactory.h` — `onLeafCreated` hook.
- `App/MainWindow.xaml.{h,cpp}` — `m_bgOpaque` / `m_bgColor` state, `ToggleBackgroundOpacity`, `ApplyBackgroundOpacityAppearance`, `ApplyBackgroundColor` funnels through it, adopt restates.
- Tests — dispatcher route + Actions forward.

<details>
<summary>日本語</summary>

- `Core/Ghostty/CallbackDispatcher.cpp` — `TOGGLE_BACKGROUND_OPACITY` を ack リストから外す (#69 の診断コメントも役目を終えて退役)。他の window-state action と同様に routing
- `Core/Ghostty/Actions/Actions.{h,cpp}` — `OnToggleBackgroundOpacity` (ガードは view 側)
- `Core/Ghostty/Config.h` — `BackgroundOpacity()` getter
- `Core/Ghostty/Actions/Tags/Fullscreen.h` — public な `Active()`
- `Core/Host/IWindow.h` — `ToggleBackgroundOpacity()`
- `App/TerminalControl.xaml{,.h,.cpp}` — SwapChainPanel の下の `OpaqueUnderlay` 矩形と `SetOpaqueBackground()`
- `App/Tabs/Tab.h` — `ApplyBackgroundOpacity` のツリー走査。`App/Tabs/TabFactory.h` — `onLeafCreated` フック
- `App/MainWindow.xaml.{h,cpp}` — `m_bgOpaque` / `m_bgColor` 状態、`ToggleBackgroundOpacity`、`ApplyBackgroundOpacityAppearance`、`ApplyBackgroundColor` の合流、adopt での再宣言
- テスト — dispatcher routing と Actions 転送

</details>

## Verification

Config already has `background-opacity = 0.75` and `keybind = ctrl+shift+b=toggle_background_opacity`. Build against the premultiplied-alpha DLL (currently in `zig-out` from the fork branch).

- [x] Tests.exe green
- [x] Launch (no `background-blur` in config): crisp see-through — windows behind ghostty are visible un-blurred through the background; text stays fully legible
- [x] Add `background-blur = true`, restart: the see-through becomes blurred (Acrylic)
- [x] `Ctrl+Shift+B` — fully opaque, pixel-look of opacity 1.0
- [x] `Ctrl+Shift+B` again — translucent again
- [x] While toggled opaque: open a new tab and a split — new panes are opaque too (factory hook)
- [x] Tear a tab out into a window whose mode differs — the adopted tab takes the adopting window's mode
- [x] `F11` (fullscreen), then `Ctrl+Shift+B` — no-op while fullscreen
- [x] Remove `background-opacity` (or set 1.0), reload — visuals identical to before this PR, and the toggle no-ops
- [x] Background image (`background-image` is configured) still renders correctly in both modes. Found and fixed during verification: the bg_image pipeline blended over the bg_color pass even though its shader already composites the background into its own output — the double-composite re-opacified the pane whenever an image was set (and had been double-counting the background color all along, masked while alpha was discarded). Fixed submodule-side in i999rri/ghostty#46 (`blending_enabled = false`)

<details>
<summary>日本語</summary>

config には `background-opacity = 0.75` と `keybind = ctrl+shift+b=toggle_background_opacity` が設定済み。premultiplied-alpha 版 DLL (fork ブランチの `zig-out` に生成済み) と一緒にビルドすること。

- Tests.exe が green
- 起動時 (`background-blur` なし): 素通しで透ける — ghostty の背後のウインドウがぼやけずに見える。文字は完全に読める
- `background-blur = true` を足して再起動: 透け方がぼかし (Acrylic) に変わる
- `Ctrl+Shift+B` — 完全不透明 (opacity 1.0 と同じ見た目)
- もう一度 `Ctrl+Shift+B` — 透過に戻る
- 不透明にトグルした状態で新規タブと split — 新しい pane も不透明 (factory フック)
- モードの違うウインドウへタブを tear-out/merge — 移った先のウインドウのモードに従う
- `F11` (fullscreen) 中に `Ctrl+Shift+B` — no-op
- `background-opacity` を消す (か 1.0) + reload — この PR 以前と見た目が同一で、toggle は no-op
- 背景画像 (`background-image` 設定済み) が両モードで正しく描画される。検証中に発見・修正: bg_image パイプラインが、shader 自身が背景を合成済みの出力を返すのに bg_color パスの上にさらにブレンドしていた — 二重合成で画像設定時に pane が不透明化していた (背景色の二重計上は以前からあったが alpha 破棄で隠れていた)。i999rri/ghostty#46 側で修正 (`blending_enabled = false`)

</details>
