### PR TITLE
Pin CI ghostty.dll builds to the baseline x86-64 CPU

### DIFF
--- a/.github/actions/build-signed-msix/action.yml
+++ b/.github/actions/build-signed-msix/action.yml
@@ -71,7 +71,14 @@ runs:
         $ErrorActionPreference = 'Stop'
         $PSNativeCommandUseErrorActionPreference = $true
         cd external/ghostty
-        zig build -Doptimize=ReleaseSafe -Drenderer=directx
+        # -Dcpu=baseline: Zig's standardTargetOptions defaults to the
+        # BUILD machine's native CPU. GitHub's windows runners are a
+        # mixed fleet (some with AVX-512, some without), so an
+        # unpinned build ships whatever ISA extensions the runner
+        # happened to have — a DLL built on an AVX-512 runner dies
+        # with STATUS_ILLEGAL_INSTRUCTION at ghostty_init on any CPU
+        # without it. Baseline x86-64 runs everywhere.
+        zig build -Doptimize=ReleaseSafe -Drenderer=directx -Dcpu=baseline
         # The DLL lands in zig-out/lib/ghostty-internal.dll already;
         # ghostty.h is read directly from external/ghostty/include/
         # via the vcxprojs' AdditionalIncludeDirectories. The one


### PR DESCRIPTION
## Why

The v0.6.0-rc1 MSIX crashed at launch on an Intel i9-10850K with `STATUS_ILLEGAL_INSTRUCTION` (0xc000001d) inside `ghostty.dll`. The crash dump shows the faulting instruction is `vmovups zmmword ptr [...], zmm0` — AVX-512 — executed during `ghostty_init`'s global initialization. The i9-10850K (Comet Lake) has no AVX-512.

The CI build step runs `zig build` with no CPU pin, and Zig's `standardTargetOptions` defaults to the **build machine's native CPU**. GitHub's `windows-latest` fleet mixes Intel Xeon (AVX-512) and AMD EPYC (no AVX-512) machines, so whether a release DLL is installable on a given user CPU depends on which runner picked up the job. Past releases that worked were luck, not correctness.

## What

Pass `-Dcpu=baseline` in the `build-signed-msix` composite action's `zig build` line. All three consumers (`ci.yml`, `dev-build.yml`, `release.yml`) go through this action, so one edit covers every produced MSIX.

Baseline x86-64 runs on every 64-bit CPU. The DirectX renderer keeps the hot path on the GPU, so the CPU-side ISA floor is not a meaningful perf tradeoff for a distributable artifact.

## Verification

- Crash dump analysis (cdb): fault at `ghostty!DllMainCRTStartup` global init, `zmm0` store, exception 0xc000001d
- `IsProcessorFeaturePresent(PF_AVX512F)` = false on the target machine, AVX2 = true
- Installed rc1 DLL hash ≠ locally built DLL hash (locally built native DLL runs fine — local native CPU has no AVX-512 to leak into the binary)

v0.6.0-rc1 needs to be rebuilt as rc2 after this lands — the published rc1 asset is broken on any CPU without AVX-512.