### PR TITLE
Enumerate release-note PRs from first-parent history

### DIFF
--- a/.github/workflows/open-release-pr.yml
+++ b/.github/workflows/open-release-pr.yml
@@ -88,8 +88,33 @@ jobs:
           prev_tag=$(gh release list --json tagName,isPrerelease \
             --jq '[.[] | select(.isPrerelease == false) | .tagName] | first // ""')
 
+          # Enumerate the PRs ourselves instead of calling the
+          # generate-notes API anchored at $prev_tag: that tag points
+          # at a squash commit on main which cannot reach dev's
+          # per-PR merge commits, so the API lists every PR since
+          # squash releases began (issue #139's PR-body sibling; the
+          # v0.6.0 release PR opened with 70 entries back to #41).
+          # The correct baseline is the previous release PR's
+          # dev-side head — walk first-parent from there to HEAD and
+          # collect the squash subjects' (#N) suffixes.
+          prev_head=""
           if [[ -n "$prev_tag" ]]; then
-            echo "Generating notes vs previous tag: $prev_tag"
+            prev_head=$(gh pr list --state closed \
+              --search "head:release/${prev_tag} base:main" \
+              --json headRefOid --jq '.[0].headRefOid // empty')
+          fi
+
+          if [[ -n "$prev_head" ]]; then
+            echo "Enumerating PRs in $prev_head..HEAD (since $prev_tag)"
+            notes="## What's Changed"
+            for n in $(git log --first-parent --format='%s' "$prev_head..HEAD" \
+                | grep -oE '\(#[0-9]+\)$' | tr -d '(#)' | sort -n || true); do
+              notes+=$'\n'"$(gh pr view "$n" --json number,title,author --jq \
+                '"* \(.title) by @\(.author.login) in https://github.com/'"${GITHUB_REPOSITORY}"'/pull/\(.number)"')"
+            done
+            notes+=$'\n\n'"**Full Changelog**: https://github.com/${GITHUB_REPOSITORY}/compare/${prev_tag}...v${VERSION}"
+          elif [[ -n "$prev_tag" ]]; then
+            echo "No release PR found for $prev_tag — falling back to generate-notes."
             notes=$(gh api "repos/${GITHUB_REPOSITORY}/releases/generate-notes" \
               --method POST \
               -f tag_name="v$VERSION" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -171,21 +171,22 @@ jobs:
           echo "head_sha=$head_sha" >> "$GITHUB_OUTPUT"
           echo "Release-PR head SHA: ${head_sha:-<none>}"
 
-      # Generate the changelog body manually so we can pass
-      # previous_tag_name explicitly. softprops/action-gh-release's
-      # generate_release_notes: true would call the same API but with
-      # GitHub's default baseline.
+      # Generate the changelog body. Two regimes:
       #
-      # Production tags need a workaround: the tag already exists by the
-      # time this workflow runs (we're triggered by its push), so the
-      # generate-notes API resolves tag_name → the squashed commit main
-      # actually holds and ignores target_commitish. That loses every
-      # dev-side PR that landed as an intermediate merge (the release/
-      # branch's history) because those commits aren't reachable from
-      # main's history. Pass a UNIQUE probe tag_name that doesn't exist,
-      # which forces the API to honour target_commitish=<release-PR head>,
-      # then rewrite the probe name in the returned body so the
-      # "Full Changelog" URL uses the real tag.
+      # Production tags: enumerate the PRs ourselves. generate-notes
+      # anchored at the previous production tag is structurally wrong
+      # under squash releases — that tag points at a squash commit on
+      # main which cannot reach dev's per-PR merge commits, so the API
+      # lists every PR since squash releases began (issue #139; the
+      # #140 ancestor rule fixed only the RC chain, whose anchor tags
+      # live on dev). The correct baseline is the PREVIOUS release
+      # PR's dev-side head: walk first-parent between the two release
+      # snapshots and collect the squash subjects' (#N) suffixes.
+      #
+      # RC tags: generate-notes with previous_tag_name from the
+      # ancestor rule above — anchor and target share the dev lineage,
+      # so the API range is right. Also the fallback for a production
+      # bootstrap without a previous release PR.
       - name: Generate release notes body
         id: notes
         shell: bash
@@ -196,23 +197,32 @@ jobs:
           RELPR_HEAD_SHA: ${{ steps.relpr.outputs.head_sha }}
         run: |
           set -euo pipefail
-          args=(--method POST)
-          if [[ -n "$RELPR_HEAD_SHA" ]]; then
-            probe_tag="${REF_NAME}-notes-probe"
-            args+=(-f "tag_name=$probe_tag" -f "target_commitish=$RELPR_HEAD_SHA")
-          else
-            probe_tag=""
-            args+=(-f "tag_name=$REF_NAME")
+          body=""
+          if [[ -n "$RELPR_HEAD_SHA" && -n "$PREV_TAG" ]]; then
+            prev_head=$(gh pr list --state closed \
+              --search "head:release/${PREV_TAG} base:main" \
+              --json headRefOid --jq '.[0].headRefOid // empty')
+            if [[ -n "$prev_head" ]]; then
+              # Release branches persist after merge; fetching them
+              # brings the dev-lineage commits that the tag checkout
+              # of main doesn't have.
+              git fetch --quiet origin 'refs/heads/release/*:refs/remotes/origin/release/*'
+              body="## What's Changed"
+              for n in $(git log --first-parent --format='%s' "$prev_head..$RELPR_HEAD_SHA" \
+                  | grep -oE '\(#[0-9]+\)$' | tr -d '(#)' | sort -n || true); do
+                body+=$'\n'"$(gh pr view "$n" --json number,title,author --jq \
+                  '"* \(.title) by @\(.author.login) in https://github.com/'"${GITHUB_REPOSITORY}"'/pull/\(.number)"')"
+              done
+              body+=$'\n\n'"**Full Changelog**: https://github.com/${GITHUB_REPOSITORY}/compare/${PREV_TAG}...${REF_NAME}"
+            fi
           fi
-          if [[ -n "$PREV_TAG" ]]; then
-            args+=(-f "previous_tag_name=$PREV_TAG")
-          fi
-          body=$(gh api "repos/${GITHUB_REPOSITORY}/releases/generate-notes" \
-            "${args[@]}" --jq '.body')
-          # Undo the probe substitution so the Full Changelog URL points
-          # at the real tag.
-          if [[ -n "$probe_tag" ]]; then
-            body="${body//$probe_tag/$REF_NAME}"
+          if [[ -z "$body" ]]; then
+            args=(--method POST -f "tag_name=$REF_NAME")
+            if [[ -n "$PREV_TAG" ]]; then
+              args+=(-f "previous_tag_name=$PREV_TAG")
+            fi
+            body=$(gh api "repos/${GITHUB_REPOSITORY}/releases/generate-notes" \
+              "${args[@]}" --jq '.body')
           fi
           {
             echo "body<<RELEASE_NOTES_EOF"


### PR DESCRIPTION
## Why

The v0.6.0 release PR (#159) opened with a **70-entry What's Changed going back to #41**. Same structural disease as #139: the generator anchors at the previous production tag (`v0.5.0`), which points at a squash commit on `main`. Under squash releases, main's history can never reach dev's per-PR merge commits — so "commits since the anchor" degenerates to *every dev PR since squash releases began*. The #140 ancestor rule fixed only the RC chain, because RC anchor tags live on dev; both the release-PR body (`open-release-pr.yml`) and the **production** notes path (`release.yml`) were still broken. The v0.6.0 production notes would have exploded the same way at tag time.

## What

For the production paths, stop asking generate-notes and build the list ourselves:

1. Baseline = the previous release PR's **dev-side head** (`gh pr list --search "head:release/<prev> base:main"`), the commit that actually shares a lineage with the release snapshot
2. `git log --first-parent <prev-head>..<release-head>`, collect the squash subjects' trailing `(#N)`
3. Emit GitHub-style `* Title by @author in <url>` lines + a Full Changelog compare link

RC tags keep the #140 generate-notes path (anchor and target both on dev — verified correct on v0.6.0-rc2). Production bootstrap without a previous release PR falls back to generate-notes too.

## Verification

- The exact first-parent pipeline run against `release/v0.5.0-head..release/v0.6.0` yields precisely #140–#150 + #158 (12 PRs) — the list now hand-placed on #159
- jq/quoting of the line builder exercised locally, output byte-identical to generate-notes' line format
- YAML validated with js-yaml

## Notes

- Ships with v0.7.0 — the **v0.6.0 production notes will still be generated by the old code** at tag time and will need the same manual replacement as #159's body
- `open-release-pr.yml` is dispatched from the default branch, so until this reaches `main` (v0.7.0), open the v0.7.0 release PR with `gh workflow run open-release-pr.yml --ref dev -f version=0.7.0` to pick up the fixed script

<details><summary>日本語</summary>

#159 の body が #41 まで 70 件並んだ。原因は #139 と同じ構造で、anchor の `v0.5.0` タグが main 側の squash コミットを指しているため、dev の個別 PR マージ履歴に到達できず「squash 運用開始以降の全 PR」に爆発する。#140 の ancestor ルールで直ったのは rc チェーンだけ (rc タグは dev 側にあるから)。本番ノートと release PR body は generate-notes をやめて、前リリース PR の dev 側 head を基準に first-parent を歩いて `(#N)` を自前で列挙する方式に変えた。v0.6.0 の本番ノートは旧コードで生成されるので、#159 と同じ手動差し替えが 1 回だけ必要。

</details>