### PR TITLE
Force tag updates in the release changelog fetch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,8 +131,17 @@ jobs:
           set -euo pipefail
           # The checkout above is shallow and tagless; ancestry checks
           # need the full graph.
-          git fetch --quiet --unshallow --tags origin 2>/dev/null \
-            || git fetch --quiet --tags origin
+          #
+          # --force is load-bearing: on a tag push actions/checkout
+          # plants github.sha (the PEELED commit) at refs/tags/<tag>,
+          # while auto-tag-release-pr.yml creates ANNOTATED production
+          # tags. The mismatched local tag makes a plain --tags fetch
+          # refuse to clobber and exit 1 — and --quiet suppresses the
+          # rejection table, so the step dies with no output at all
+          # (this killed the v0.6.0 release run). RC tags are
+          # lightweight, which is why rc runs never tripped this.
+          git fetch --quiet --force --unshallow --tags origin 2>/dev/null \
+            || git fetch --quiet --force --tags origin
           prev=""
           while read -r tag; do
             if git merge-base --is-ancestor "$tag" HEAD 2>/dev/null; then


### PR DESCRIPTION
## Why

The v0.6.0 production release run died in "Determine previous tag for changelog" with exit 1 and **zero output**. Root cause chain:

1. `auto-tag-release-pr.yml` creates production tags with `git tag -a` (**annotated**)
2. On the tag push, `actions/checkout` fetches `github.sha` — the **peeled commit** — into `refs/tags/v0.6.0`, so the local tag object differs from the remote annotated tag
3. `git fetch --tags` refuses to clobber a mismatched local tag and exits 1 — and `--quiet` suppresses the per-ref rejection table, so **both** fetch attempts fail with no output and `set -e` kills the step

Reproduced locally byte-for-byte by mimicking checkout's exact fetch (`--no-tags --depth=1 +<peeled>:refs/tags/v0.6.0`): both fetch commands exit 1 printing nothing.

RC tags are created manually with plain `git tag` (lightweight), where local and remote agree — that's why v0.6.0-rc1/rc2 sailed through the same code, and why v0.5.0 (which ran the pre-#140 script with no fetch at all) never hit it. v0.6.0 was the first production tag to execute #140's fetch.

## What

Add `--force` to both fetch attempts so the local checkout-planted tag is replaced by the remote annotated one.

## Note

Like #160 this ships with v0.7.0 via the tagged commit — `release.yml` executes from the tag's tree, so the v0.6.0 tag can't benefit retroactively.

<details><summary>日本語</summary>

本番タグは annotated、checkout が置くのは peeled commit なので食い違い、`git fetch --tags` が clobber 拒否で exit 1。`--quiet` が拒否メッセージまで消すため無言死になる。rc タグは lightweight で一致するから rc だけ通っていた。両方の fetch に `--force` を追加。

</details>