### PR TITLE
Encode the release channel in the MSIX Revision part

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,19 +39,36 @@ jobs:
         run: |
           $ErrorActionPreference = 'Stop'
           $PSNativeCommandUseErrorActionPreference = $true
-          # Tag "vX.Y.Z" -> manifest Version "X.Y.Z.0". Strip any -rcN / -beta
-          # suffix because appxmanifest only accepts a four-part numeric.
+          # The appxmanifest Version is a fixed 4-part numeric
+          # (Major.Minor.Build.Revision, each 0-65535), so the -rcN
+          # suffix can't ride along as text. Encode the channel in
+          # Revision instead, keeping upgrade order rc1 < rc2 < ... <
+          # production within one X.Y.Z:
+          #
+          #   v0.7.0-rc1 -> 0.7.0.1
+          #   v0.7.0-rc2 -> 0.7.0.2
+          #   v0.7.0     -> 0.7.0.65535   (max Revision = "final")
+          #
+          # This lets an rc install upgrade in place to the next rc
+          # and to production, instead of colliding on an identical
+          # version number. Sideload-only: the Store would require
+          # Revision 0, which we don't target.
           $tag = "${{ github.ref_name }}"
-          $version = ($tag.TrimStart('v') -split '-')[0]
-          # Fail-fast on malformed tags. The MSIX manifest only accepts a
-          # 4-part numeric Version, so anything that doesn't reduce to
-          # exactly 3 numeric segments here would fail later in obscure
-          # ways. Reject up front with a clear message instead.
-          if ($version -notmatch '^\d+\.\d+\.\d+$') {
-            Write-Error "Tag '$tag' produced version '$version', which is not 3 numeric parts. Expected v<major>.<minor>.<patch> (optional -rcN / -beta suffix)."
+          if ($tag -match '^v(\d+\.\d+\.\d+)$') {
+            $version = $Matches[1]
+            $revision = 65535
+          } elseif ($tag -match '^v(\d+\.\d+\.\d+)-rc(\d+)$') {
+            $version = $Matches[1]
+            $revision = [int]$Matches[2]
+            if ($revision -lt 1 -or $revision -ge 65535) {
+              Write-Error "Tag '$tag' has rc number $revision, outside the encodable range 1-65534."
+              exit 1
+            }
+          } else {
+            Write-Error "Tag '$tag' is not v<major>.<minor>.<patch> or v<major>.<minor>.<patch>-rc<N>."
             exit 1
           }
-          $fullVersion = "$version.0"
+          $fullVersion = "$version.$revision"
           "msix_version=$fullVersion" >> $env:GITHUB_OUTPUT
           "release_version=$version" >> $env:GITHUB_OUTPUT
           Write-Host "Tag $tag -> MSIX version $fullVersion (release version $version)"


### PR DESCRIPTION
## Why

The appxmanifest Version is a fixed 4-part numeric (`Major.Minor.Build.Revision`, each 0–65535), so the `-rcN` suffix was stripped and rc + production shared the same MSIX version (e.g. both `0.7.0.0`). MSIX only upgrades to a numerically higher version, so installing production over an rc fails as "already installed" and needs a manual uninstall in between.

## What

Encode the channel in Revision, preserving upgrade order within one X.Y.Z:

| tag | MSIX version |
|---|---|
| `v0.7.0-rc1` | `0.7.0.1` |
| `v0.7.0-rc2` | `0.7.0.2` |
| `v0.7.0` | `0.7.0.65535` |

rc → next rc → production all upgrade in place. Sideload-only concern: the Store requires Revision 0, which this repo doesn't target.

Tags that are neither `vX.Y.Z` nor `vX.Y.Z-rcN` are now rejected up front — `-beta` was never used, and silently stripping it would collide with rc numbering.

Mapping logic exercised locally: `v0.7.0 → 0.7.0.65535`, `v0.7.0-rc1 → 0.7.0.1`, `v0.7.0-rc12 → 0.7.0.12`, `v0.7.0-beta1 / v0.7 / vfoo → reject`.

Note: v0.7.0-rc1 (already tagged) was built by the old code as `0.7.0.0` — the first tag to use this scheme will be the next one, and `0.7.0.0 < 0.7.0.N` means even that transition upgrades cleanly.

<details><summary>日本語</summary>

MSIX の Version は 4 部数値固定で -rcN を載せられず、rc と本番が同じ版数になっていた (本番を rc の上に入れると「インストール済み」で弾かれる)。Revision に channel をエンコードし、rcN → N、本番 → 65535 で同一 X.Y.Z 内の序列を rc1 < rc2 < 本番にした。これで rc → 本番が in-place アップグレードになる。仕様外のタグ (-beta 等) は fail-fast で拒否。打ち済みの v0.7.0-rc1 は旧コードの 0.7.0.0 だが、0.7.0.0 < 0.7.0.N なので次のタグから綺麗に移行できる。

</details>