### PR TITLE
Honor the background-blur radius with a Gaussian backdrop

### DIFF
--- a/App/App.vcxproj
+++ b/App/App.vcxproj
@@ -170,6 +170,7 @@
     </ClInclude>
     <ClInclude Include="MainWindows.h" />
     <ClInclude Include="SplitPanel.h" />
+    <ClInclude Include="GaussianBlurEffect.h" />
     <ClInclude Include="TransparentBackdrop.h" />
     <ClInclude Include="WindowCloseGate.h" />
     <ClInclude Include="Tabs\Panes\Branch.h" />

--- a/App/GaussianBlurEffect.h
+++ b/App/GaussianBlurEffect.h
@@ -1,0 +1,121 @@
+#pragma once
+
+// Hand-written IGraphicsEffect description of the D2D1 Gaussian
+// blur, so GaussianBlurBackdrop can build a variable-radius blur
+// without pulling in the Win2D NuGet — Win2D's only role in the
+// usual recipe is authoring exactly this description object.
+//
+// The composition engine consumes the description through the
+// classic-COM IGraphicsEffectD2D1Interop interface: it asks for the
+// D2D effect CLSID, its property values (boxed as IPropertyValue),
+// and the source chain. CompositionEffectFactory validates all of
+// it at creation time, so a mistake here fails fast with an hresult
+// rather than rendering garbage.
+
+#include <winrt/Windows.Foundation.h>
+#include <winrt/Windows.Graphics.Effects.h>
+#include <windows.foundation.h>
+#include <windows.graphics.effects.interop.h>
+#include <d2d1effects.h>
+
+namespace winrt::GhosttyWin32::implementation
+{
+    struct GaussianBlurEffect : winrt::implements<GaussianBlurEffect,
+        winrt::Windows::Graphics::Effects::IGraphicsEffect,
+        winrt::Windows::Graphics::Effects::IGraphicsEffectSource,
+        ABI::Windows::Graphics::Effects::IGraphicsEffectD2D1Interop>
+    {
+        // D2D takes a standard deviation; callers set this directly
+        // (the radius-to-sigma conversion lives at the call site,
+        // next to the config semantics it belongs to).
+        float StandardDeviation = 3.0f;
+        winrt::Windows::Graphics::Effects::IGraphicsEffectSource Source{ nullptr };
+
+        // ----- IGraphicsEffect -----
+        winrt::hstring Name() const { return m_name; }
+        void Name(winrt::hstring const& name) { m_name = name; }
+
+        // ----- IGraphicsEffectD2D1Interop -----
+        HRESULT STDMETHODCALLTYPE GetEffectId(GUID* id) noexcept final
+        {
+            if (!id) return E_POINTER;
+            *id = CLSID_D2D1GaussianBlur;
+            return S_OK;
+        }
+
+        HRESULT STDMETHODCALLTYPE GetNamedPropertyMapping(
+            LPCWSTR name, UINT* index,
+            ABI::Windows::Graphics::Effects::GRAPHICS_EFFECT_PROPERTY_MAPPING* mapping) noexcept final
+        {
+            if (!name || !index || !mapping) return E_POINTER;
+            if (_wcsicmp(name, L"BlurAmount") == 0) {
+                *index = D2D1_GAUSSIANBLUR_PROP_STANDARD_DEVIATION;
+                *mapping = ABI::Windows::Graphics::Effects::GRAPHICS_EFFECT_PROPERTY_MAPPING_DIRECT;
+                return S_OK;
+            }
+            return E_INVALIDARG;
+        }
+
+        HRESULT STDMETHODCALLTYPE GetPropertyCount(UINT* count) noexcept final
+        {
+            if (!count) return E_POINTER;
+            // The full D2D1 Gaussian property set, in enum order:
+            // standard deviation, optimization, border mode.
+            *count = 3;
+            return S_OK;
+        }
+
+        HRESULT STDMETHODCALLTYPE GetProperty(
+            UINT index, ABI::Windows::Foundation::IPropertyValue** value) noexcept final
+        {
+            if (!value) return E_POINTER;
+            try {
+                winrt::Windows::Foundation::IInspectable boxed{ nullptr };
+                namespace wf = winrt::Windows::Foundation;
+                switch (index) {
+                case D2D1_GAUSSIANBLUR_PROP_STANDARD_DEVIATION:
+                    boxed = wf::PropertyValue::CreateSingle(StandardDeviation);
+                    break;
+                case D2D1_GAUSSIANBLUR_PROP_OPTIMIZATION:
+                    boxed = wf::PropertyValue::CreateUInt32(D2D1_GAUSSIANBLUR_OPTIMIZATION_BALANCED);
+                    break;
+                case D2D1_GAUSSIANBLUR_PROP_BORDER_MODE:
+                    // HARD keeps the blur from sampling transparent
+                    // black outside the window bounds, which would
+                    // darken the edges.
+                    boxed = wf::PropertyValue::CreateUInt32(D2D1_BORDER_MODE_HARD);
+                    break;
+                default:
+                    return E_BOUNDS;
+                }
+                *value = boxed.as<ABI::Windows::Foundation::IPropertyValue>().detach();
+                return S_OK;
+            } catch (...) {
+                return winrt::to_hresult();
+            }
+        }
+
+        HRESULT STDMETHODCALLTYPE GetSource(
+            UINT index, ABI::Windows::Graphics::Effects::IGraphicsEffectSource** source) noexcept final
+        {
+            if (!source) return E_POINTER;
+            if (index != 0 || !Source) return E_BOUNDS;
+            try {
+                *source = Source.as<ABI::Windows::Graphics::Effects::IGraphicsEffectSource>().detach();
+                return S_OK;
+            } catch (...) {
+                return winrt::to_hresult();
+            }
+        }
+
+        HRESULT STDMETHODCALLTYPE GetSourceCount(UINT* count) noexcept final
+        {
+            if (!count) return E_POINTER;
+            *count = 1;
+            return S_OK;
+        }
+
+    private:
+        winrt::hstring m_name{ L"GaussianBlur" };
+    };
+}

--- a/App/MainWindow.xaml.cpp
+++ b/App/MainWindow.xaml.cpp
@@ -1654,24 +1654,31 @@ namespace winrt::GhosttyWin32::implementation
             ghostty::Config cfg(m_ghosttyApp->ConfigHandle());
             translucent = cfg.BackgroundOpacity() < 1.0 && !m_bgOpaque;
         }
-        // Backdrop selection mirrors Windows Terminal's two
-        // transparency modes and maps 1:1 onto ghostty config:
-        //   translucent + background-blur  -> DesktopAcrylic (blur
-        //     whatever is behind the window)
+        // Backdrop selection maps 1:1 onto ghostty config:
+        //   translucent + blur radius > 0  -> GaussianBlurBackdrop
+        //     (host backdrop through a D2D Gaussian at the radius
+        //     the user wrote in `background-blur = <radius>`)
+        //   translucent + blur radius < 0  -> ClearAcrylic (macOS
+        //     glass sentinels don't name a radius, so use the
+        //     system material's fixed blur)
         //   translucent, no blur           -> TransparentBackdrop
         //     (crisp see-through — WT's "vintage opacity" look)
         //   opaque                         -> Mica, as before
         // Mica alone was tried first and reads as "slightly gray",
         // not transparent — it only tints toward the wallpaper
         // (observed during #69 verification).
-        bool blur = false;
+        short blurRadius = 0;
         if (translucent && m_ghosttyApp) {
-            blur = ghostty::Config(m_ghosttyApp->ConfigHandle())
-                       .BackgroundBlurEnabled();
+            blurRadius = ghostty::Config(m_ghosttyApp->ConfigHandle())
+                             .BackgroundBlurRadius();
         }
+        const bool blur = blurRadius != 0;
         try {
             if (translucent) {
-                if (blur) {
+                if (blurRadius > 0) {
+                    SystemBackdrop(winrt::GhosttyWin32::GaussianBlurBackdrop(
+                        static_cast<float>(blurRadius)));
+                } else if (blurRadius < 0) {
                     // Not the stock DesktopAcrylicBackdrop: its
                     // material tint swallows the terminal's own
                     // translucency. ClearAcrylic is pure blur, so
@@ -1696,6 +1703,14 @@ namespace winrt::GhosttyWin32::implementation
         // crisp mode — Acrylic/Mica are DWM materials that composite
         // on their own.
         if (m_hwnd) {
+            // A raw CreateHostBackdropBrush() renders empty unless
+            // the window opts in to host-backdrop sampling. The
+            // Acrylic/Mica controllers flip this internally; the
+            // hand-built Gaussian backdrop has to do it itself.
+            const BOOL useHostBackdrop =
+                (translucent && blurRadius > 0) ? TRUE : FALSE;
+            DwmSetWindowAttribute(m_hwnd, DWMWA_USE_HOSTBACKDROPBRUSH,
+                                  &useHostBackdrop, sizeof(useHostBackdrop));
             const bool wantAlpha = translucent && !blur;
             DWM_BLURBEHIND bb{};
             bb.dwFlags = DWM_BB_ENABLE;

--- a/App/TransparentBackdrop.cpp
+++ b/App/TransparentBackdrop.cpp
@@ -1,5 +1,11 @@
 #include "pch.h"
+// initguid.h makes the DEFINE_GUID in d2d1effects.h (reached via
+// GaussianBlurEffect.h) emit the actual CLSID_D2D1GaussianBlur
+// definition in this TU, so no extra GUID lib needs linking. It has
+// to come before the include chain that pulls in d2d1effects.h.
+#include <initguid.h>
 #include "TransparentBackdrop.h"
+#include "GaussianBlurEffect.h"
 // Neither is in pch. Note the namespace split: the target interface
 // lives in Microsoft.UI.Composition, but its SystemBackdrop property
 // (WinAppSDK 1.8 projection) takes a brush from the SYSTEM
@@ -13,6 +19,9 @@
 #endif
 #if __has_include("ClearAcrylicBackdrop.g.cpp")
 #include "ClearAcrylicBackdrop.g.cpp"
+#endif
+#if __has_include("GaussianBlurBackdrop.g.cpp")
+#include "GaussianBlurBackdrop.g.cpp"
 #endif
 
 namespace winrt::GhosttyWin32::implementation
@@ -65,5 +74,37 @@ namespace winrt::GhosttyWin32::implementation
         winrt::Microsoft::UI::Composition::ICompositionSupportsSystemBackdrop const& target)
     {
         if (m_controller) m_controller.RemoveSystemBackdropTarget(target);
+    }
+
+    void GaussianBlurBackdrop::OnTargetConnected(
+        winrt::Microsoft::UI::Composition::ICompositionSupportsSystemBackdrop const& target,
+        winrt::Microsoft::UI::Xaml::XamlRoot const& /*xamlRoot*/)
+    {
+        // No base call, same reasoning as TransparentBackdrop: a
+        // constant blur has no theme/activation policy to react to.
+        namespace wuc = winrt::Windows::UI::Composition;
+        wuc::Compositor compositor;
+
+        auto effect = winrt::make_self<GaussianBlurEffect>();
+        // ghostty's radius follows the macOS CGS blur-radius
+        // convention (pixels); D2D takes a standard deviation with
+        // the documented relation radius = 3 * sigma.
+        effect->StandardDeviation = m_radius / 3.0f;
+        effect->Source = wuc::CompositionEffectSourceParameter{ L"backdrop" };
+
+        auto factory = compositor.CreateEffectFactory(
+            effect.as<winrt::Windows::Graphics::Effects::IGraphicsEffect>());
+        auto brush = factory.CreateBrush();
+        // Host backdrop = what is behind the WINDOW (desktop,
+        // other apps), as opposed to CreateBackdropBrush's
+        // behind-the-visual-within-this-window.
+        brush.SetSourceParameter(L"backdrop", compositor.CreateHostBackdropBrush());
+        target.SystemBackdrop(brush);
+    }
+
+    void GaussianBlurBackdrop::OnTargetDisconnected(
+        winrt::Microsoft::UI::Composition::ICompositionSupportsSystemBackdrop const& target)
+    {
+        target.SystemBackdrop(nullptr);
     }
 }

--- a/App/TransparentBackdrop.cpp
+++ b/App/TransparentBackdrop.cpp
@@ -101,16 +101,62 @@ namespace winrt::GhosttyWin32::implementation
             // behind-the-visual-within-this-window.
             brush.SetSourceParameter(L"backdrop", compositor.CreateHostBackdropBrush());
 #if 1
-            // DIAGNOSTIC step 2 (pre-merge): the effect brush connects
-            // but the picture doesn't change with sigma. Substitute an
-            // unconditional red brush: red on screen = the SystemBackdrop
-            // brush is what's visible (effect binding is the bug); the
-            // same fixed blur = DWM's host-backdrop layer is what's
-            // visible and our brush contributes nothing (wiring is the
-            // bug).
-            target.SystemBackdrop(compositor.CreateColorBrush(
-                winrt::Windows::UI::Color{ 128, 255, 0, 0 }));
-            OutputDebugStringW(L"GaussianBlurBackdrop: DIAGNOSTIC red brush connected\n");
+            // DIAGNOSTIC step 3 (pre-merge): red proved the
+            // SystemBackdrop brush is the visible layer. Now swap the
+            // Gaussian for a saturation-0 (grayscale) effect over the
+            // same host backdrop source. Grayscale on screen = the
+            // effect pipeline (including property delivery) works, so
+            // the sigma invisibility is the pre-blurred/downscaled
+            // host backdrop source saturating perceptually. Colors
+            // unchanged = property/effect application is broken.
+            struct DiagnosticSaturationEffect : winrt::implements<DiagnosticSaturationEffect,
+                winrt::Windows::Graphics::Effects::IGraphicsEffect,
+                winrt::Windows::Graphics::Effects::IGraphicsEffectSource,
+                ABI::Windows::Graphics::Effects::IGraphicsEffectD2D1Interop>
+            {
+                winrt::Windows::Graphics::Effects::IGraphicsEffectSource Source{ nullptr };
+                winrt::hstring m_name{ L"Saturation" };
+                winrt::hstring Name() const { return m_name; }
+                void Name(winrt::hstring const& name) { m_name = name; }
+                HRESULT STDMETHODCALLTYPE GetEffectId(GUID* id) noexcept final
+                { if (!id) return E_POINTER; *id = CLSID_D2D1Saturation; return S_OK; }
+                HRESULT STDMETHODCALLTYPE GetNamedPropertyMapping(LPCWSTR, UINT*,
+                    ABI::Windows::Graphics::Effects::GRAPHICS_EFFECT_PROPERTY_MAPPING*) noexcept final
+                { return E_INVALIDARG; }
+                HRESULT STDMETHODCALLTYPE GetPropertyCount(UINT* count) noexcept final
+                { if (!count) return E_POINTER; *count = 1; return S_OK; }
+                HRESULT STDMETHODCALLTYPE GetProperty(UINT index,
+                    ABI::Windows::Foundation::IPropertyValue** value) noexcept final
+                {
+                    if (!value) return E_POINTER;
+                    if (index != 0) return E_BOUNDS;
+                    try {
+                        *value = winrt::Windows::Foundation::PropertyValue::CreateSingle(0.0f)
+                            .as<ABI::Windows::Foundation::IPropertyValue>().detach();
+                        return S_OK;
+                    } catch (...) { return winrt::to_hresult(); }
+                }
+                HRESULT STDMETHODCALLTYPE GetSource(UINT index,
+                    ABI::Windows::Graphics::Effects::IGraphicsEffectSource** source) noexcept final
+                {
+                    if (!source) return E_POINTER;
+                    if (index != 0 || !Source) return E_BOUNDS;
+                    try {
+                        *source = Source.as<ABI::Windows::Graphics::Effects::IGraphicsEffectSource>().detach();
+                        return S_OK;
+                    } catch (...) { return winrt::to_hresult(); }
+                }
+                HRESULT STDMETHODCALLTYPE GetSourceCount(UINT* count) noexcept final
+                { if (!count) return E_POINTER; *count = 1; return S_OK; }
+            };
+            auto sat = winrt::make_self<DiagnosticSaturationEffect>();
+            sat->Source = wuc::CompositionEffectSourceParameter{ L"backdrop" };
+            auto satFactory = compositor.CreateEffectFactory(
+                sat.as<winrt::Windows::Graphics::Effects::IGraphicsEffect>());
+            auto satBrush = satFactory.CreateBrush();
+            satBrush.SetSourceParameter(L"backdrop", compositor.CreateHostBackdropBrush());
+            target.SystemBackdrop(satBrush);
+            OutputDebugStringW(L"GaussianBlurBackdrop: DIAGNOSTIC saturation brush connected\n");
 #else
             target.SystemBackdrop(brush);
             OutputDebugStringW(L"GaussianBlurBackdrop: effect brush connected\n");

--- a/App/TransparentBackdrop.cpp
+++ b/App/TransparentBackdrop.cpp
@@ -149,14 +149,11 @@ namespace winrt::GhosttyWin32::implementation
                 HRESULT STDMETHODCALLTYPE GetSourceCount(UINT* count) noexcept final
                 { if (!count) return E_POINTER; *count = 1; return S_OK; }
             };
-            auto sat = winrt::make_self<DiagnosticSaturationEffect>();
-            sat->Source = wuc::CompositionEffectSourceParameter{ L"backdrop" };
-            auto satFactory = compositor.CreateEffectFactory(
-                sat.as<winrt::Windows::Graphics::Effects::IGraphicsEffect>());
-            auto satBrush = satFactory.CreateBrush();
-            satBrush.SetSourceParameter(L"backdrop", compositor.CreateHostBackdropBrush());
-            target.SystemBackdrop(satBrush);
-            OutputDebugStringW(L"GaussianBlurBackdrop: DIAGNOSTIC saturation brush connected\n");
+            // DIAGNOSTIC step 4: the raw host backdrop with NO effect
+            // in the chain at all. Frosted glass here = the blur is
+            // baked into the material DWM hands us, closing the case.
+            target.SystemBackdrop(compositor.CreateHostBackdropBrush());
+            OutputDebugStringW(L"GaussianBlurBackdrop: DIAGNOSTIC raw host backdrop connected\n");
 #else
             target.SystemBackdrop(brush);
             OutputDebugStringW(L"GaussianBlurBackdrop: effect brush connected\n");

--- a/App/TransparentBackdrop.cpp
+++ b/App/TransparentBackdrop.cpp
@@ -100,8 +100,21 @@ namespace winrt::GhosttyWin32::implementation
             // other apps), as opposed to CreateBackdropBrush's
             // behind-the-visual-within-this-window.
             brush.SetSourceParameter(L"backdrop", compositor.CreateHostBackdropBrush());
+#if 1
+            // DIAGNOSTIC step 2 (pre-merge): the effect brush connects
+            // but the picture doesn't change with sigma. Substitute an
+            // unconditional red brush: red on screen = the SystemBackdrop
+            // brush is what's visible (effect binding is the bug); the
+            // same fixed blur = DWM's host-backdrop layer is what's
+            // visible and our brush contributes nothing (wiring is the
+            // bug).
+            target.SystemBackdrop(compositor.CreateColorBrush(
+                winrt::Windows::UI::Color{ 128, 255, 0, 0 }));
+            OutputDebugStringW(L"GaussianBlurBackdrop: DIAGNOSTIC red brush connected\n");
+#else
             target.SystemBackdrop(brush);
             OutputDebugStringW(L"GaussianBlurBackdrop: effect brush connected\n");
+#endif
         } catch (winrt::hresult_error const& e) {
             // DIAGNOSTIC (pre-merge): an unmissable red backdrop +
             // debug output instead of a silent fallback, so a failed

--- a/App/TransparentBackdrop.cpp
+++ b/App/TransparentBackdrop.cpp
@@ -83,23 +83,35 @@ namespace winrt::GhosttyWin32::implementation
         // No base call, same reasoning as TransparentBackdrop: a
         // constant blur has no theme/activation policy to react to.
         namespace wuc = winrt::Windows::UI::Composition;
-        wuc::Compositor compositor;
+        try {
+            wuc::Compositor compositor;
 
-        auto effect = winrt::make_self<GaussianBlurEffect>();
-        // ghostty's radius follows the macOS CGS blur-radius
-        // convention (pixels); D2D takes a standard deviation with
-        // the documented relation radius = 3 * sigma.
-        effect->StandardDeviation = m_radius / 3.0f;
-        effect->Source = wuc::CompositionEffectSourceParameter{ L"backdrop" };
+            auto effect = winrt::make_self<GaussianBlurEffect>();
+            // ghostty's radius follows the macOS CGS blur-radius
+            // convention (pixels); D2D takes a standard deviation with
+            // the documented relation radius = 3 * sigma.
+            effect->StandardDeviation = m_radius / 3.0f;
+            effect->Source = wuc::CompositionEffectSourceParameter{ L"backdrop" };
 
-        auto factory = compositor.CreateEffectFactory(
-            effect.as<winrt::Windows::Graphics::Effects::IGraphicsEffect>());
-        auto brush = factory.CreateBrush();
-        // Host backdrop = what is behind the WINDOW (desktop,
-        // other apps), as opposed to CreateBackdropBrush's
-        // behind-the-visual-within-this-window.
-        brush.SetSourceParameter(L"backdrop", compositor.CreateHostBackdropBrush());
-        target.SystemBackdrop(brush);
+            auto factory = compositor.CreateEffectFactory(
+                effect.as<winrt::Windows::Graphics::Effects::IGraphicsEffect>());
+            auto brush = factory.CreateBrush();
+            // Host backdrop = what is behind the WINDOW (desktop,
+            // other apps), as opposed to CreateBackdropBrush's
+            // behind-the-visual-within-this-window.
+            brush.SetSourceParameter(L"backdrop", compositor.CreateHostBackdropBrush());
+            target.SystemBackdrop(brush);
+            OutputDebugStringW(L"GaussianBlurBackdrop: effect brush connected\n");
+        } catch (winrt::hresult_error const& e) {
+            // DIAGNOSTIC (pre-merge): an unmissable red backdrop +
+            // debug output instead of a silent fallback, so a failed
+            // effect chain can't masquerade as "blur looks the same".
+            OutputDebugStringW(
+                (L"GaussianBlurBackdrop FAILED: " + e.message() + L"\n").c_str());
+            wuc::Compositor fallback;
+            target.SystemBackdrop(fallback.CreateColorBrush(
+                winrt::Windows::UI::Color{ 128, 255, 0, 0 }));
+        }
     }
 
     void GaussianBlurBackdrop::OnTargetDisconnected(

--- a/App/TransparentBackdrop.h
+++ b/App/TransparentBackdrop.h
@@ -59,3 +59,33 @@ namespace winrt::GhosttyWin32::factory_implementation
     {
     };
 }
+
+#include "GaussianBlurBackdrop.g.h"
+
+namespace winrt::GhosttyWin32::implementation
+{
+    // See GaussianBlurBackdrop in the IDL. Same system-compositor
+    // technique as TransparentBackdrop, but the brush handed to the
+    // target is CreateHostBackdropBrush() run through a D2D Gaussian
+    // blur (GaussianBlurEffect.h) with the configured radius.
+    struct GaussianBlurBackdrop : GaussianBlurBackdropT<GaussianBlurBackdrop>
+    {
+        explicit GaussianBlurBackdrop(float radius) : m_radius(radius) {}
+
+        void OnTargetConnected(
+            winrt::Microsoft::UI::Composition::ICompositionSupportsSystemBackdrop const& target,
+            winrt::Microsoft::UI::Xaml::XamlRoot const& xamlRoot);
+        void OnTargetDisconnected(
+            winrt::Microsoft::UI::Composition::ICompositionSupportsSystemBackdrop const& target);
+
+    private:
+        float m_radius = 0.0f;
+    };
+}
+
+namespace winrt::GhosttyWin32::factory_implementation
+{
+    struct GaussianBlurBackdrop : GaussianBlurBackdropT<GaussianBlurBackdrop, implementation::GaussianBlurBackdrop>
+    {
+    };
+}

--- a/App/TransparentBackdrop.idl
+++ b/App/TransparentBackdrop.idl
@@ -26,4 +26,15 @@ namespace GhosttyWin32
     {
         ClearAcrylicBackdrop();
     }
+
+    // Variable-radius Gaussian blur of whatever is behind the
+    // window: a host backdrop brush run through a D2D Gaussian blur
+    // effect. Unlike ClearAcrylicBackdrop (the system material's
+    // fixed blur), this honours the radius the user wrote in
+    // `background-blur = <radius>`.
+    [default_interface]
+    runtimeclass GaussianBlurBackdrop : Microsoft.UI.Xaml.Media.SystemBackdrop
+    {
+        GaussianBlurBackdrop(Single radius);
+    }
 }

--- a/Core/Ghostty/Config.h
+++ b/Core/Ghostty/Config.h
@@ -76,12 +76,14 @@ public:
 
     // `background-blur` crosses the C API via cval() as an i16:
     // 0 = off, 20 = a bare `true`, positive = the radius, negative
-    // = macOS glass sentinels ("imply some blur" per upstream, so
-    // any non-zero value counts as enabled here).
-    bool BackgroundBlurEnabled() const noexcept {
+    // = macOS glass sentinels ("imply some blur" per upstream). The
+    // raw value is exposed so the host can honour the radius
+    // (Gaussian backdrop) and route the sentinel forms to a system
+    // material instead.
+    short BackgroundBlurRadius() const noexcept {
         short v = 0;
-        if (!GetRaw("background-blur", &v)) return false;
-        return v != 0;
+        GetRaw("background-blur", &v);
+        return v;
     }
 
     // ----- notify-on-command-finish (v1.3.0+, default: never) -----


### PR DESCRIPTION
## Why

`background-blur = <radius>` accepts a radius, but the blur path handed every value to `ClearAcrylicBackdrop`, whose blur strength is fixed by the system material — `background-blur = 5` and `= 60` looked identical.

## What

- **`GaussianBlurBackdrop(radius)`** (TransparentBackdrop family): system compositor → `CreateHostBackdropBrush()` → D2D Gaussian blur at the configured radius → `SystemBackdrop`
- **`GaussianBlurEffect.h`**: hand-written `IGraphicsEffect` / `IGraphicsEffectD2D1Interop` description of `CLSID_D2D1GaussianBlur` — **no Win2D NuGet**; Win2D's only role in the usual recipe is authoring exactly this object, and it's ~100 lines against SDK headers. `initguid.h` in the one consuming TU emits the CLSID, so no GUID lib either
- **`DWMWA_USE_HOSTBACKDROPBRUSH`**: a raw host backdrop brush renders empty unless the window opts in to host-backdrop sampling (the Acrylic/Mica controllers flip this internally); set alongside the existing DWM blur-behind handling
- **`Config::BackgroundBlurRadius()`** exposes the raw i16 cval (0 = off, 20 = bare `true`, positive = radius, negative = macOS glass sentinels); `BackgroundBlurEnabled()` had no remaining consumers and is removed
- Selection in `ApplyBackgroundOpacityAppearance`: radius > 0 → Gaussian, radius < 0 → ClearAcrylic (sentinels name no radius, keep the system material), 0 → crisp TransparentBackdrop, opaque → Mica
- Radius→sigma: D2D takes a standard deviation, documented relation radius = 3σ, so `StandardDeviation = radius / 3`

## Verification (config: `background-opacity = 0.9` + `background-blur = <N>`)

- [ ] `background-blur = 40`: frosted glass, noticeably stronger than the old acrylic look
- [ ] `background-blur = 5`: weak blur — **visibly different from 40** (the point of the feature)
- [ ] `background-blur = true` (= 20): moderate blur
- [ ] `Ctrl+Shift+B`: opaque (Mica) ⇔ blur restores correctly both ways
- [ ] `background-blur` commented out: crisp transparency unchanged (regression)
- [ ] `background-opacity = 1.0`: Mica as before (regression)
- [ ] Tear-out window shows the same backdrop; F11 fullscreen guard unaffected
- [ ] Tests.exe green

<details><summary>日本語</summary>

`background-blur` は半径を受け取れるのに、blur 経路は値を捨てて固定強度の acrylic に流していた (5 でも 60 でも同じ見た目)。半径が正なら host backdrop brush を D2D Gaussian に通す `GaussianBlurBackdrop` を使うようにした。effect の記述オブジェクトは SDK ヘッダだけで手書きして Win2D 依存を回避。生の host backdrop brush は `DWMWA_USE_HOSTBACKDROPBRUSH` で opt-in しないと空になるので DWM 処理に追加。負の値 (macOS glass sentinel、半径を持たない) は従来どおり ClearAcrylic に落とす。

</details>