### PR TITLE
Use the raw host backdrop for background-blur frost

### DIFF
--- a/App/MainWindow.xaml.cpp
+++ b/App/MainWindow.xaml.cpp
@@ -1656,8 +1656,9 @@ namespace winrt::GhosttyWin32::implementation
         }
         // Backdrop selection mirrors Windows Terminal's two
         // transparency modes and maps 1:1 onto ghostty config:
-        //   translucent + background-blur  -> DesktopAcrylic (blur
-        //     whatever is behind the window)
+        //   translucent + background-blur  -> FrostedBackdrop (the
+        //     raw host backdrop: DWM's fixed-strength blur of what
+        //     is behind the window, no acrylic material on top)
         //   translucent, no blur           -> TransparentBackdrop
         //     (crisp see-through — WT's "vintage opacity" look)
         //   opaque                         -> Mica, as before
@@ -1672,12 +1673,7 @@ namespace winrt::GhosttyWin32::implementation
         try {
             if (translucent) {
                 if (blur) {
-                    // Not the stock DesktopAcrylicBackdrop: its
-                    // material tint swallows the terminal's own
-                    // translucency. ClearAcrylic is pure blur, so
-                    // background-opacity and background-blur compose
-                    // (frosted glass).
-                    SystemBackdrop(winrt::GhosttyWin32::ClearAcrylicBackdrop());
+                    SystemBackdrop(winrt::GhosttyWin32::FrostedBackdrop());
                 } else {
                     SystemBackdrop(winrt::GhosttyWin32::TransparentBackdrop());
                 }
@@ -1696,6 +1692,14 @@ namespace winrt::GhosttyWin32::implementation
         // crisp mode — Acrylic/Mica are DWM materials that composite
         // on their own.
         if (m_hwnd) {
+            // A raw host backdrop brush renders empty unless the
+            // window opts in to host-backdrop sampling. The
+            // Acrylic/Mica controllers flip this internally; the
+            // hand-assigned FrostedBackdrop brush has to do it here,
+            // where the HWND lives.
+            const BOOL useHostBackdrop = (translucent && blur) ? TRUE : FALSE;
+            DwmSetWindowAttribute(m_hwnd, DWMWA_USE_HOSTBACKDROPBRUSH,
+                                  &useHostBackdrop, sizeof(useHostBackdrop));
             const bool wantAlpha = translucent && !blur;
             DWM_BLURBEHIND bb{};
             bb.dwFlags = DWM_BB_ENABLE;

--- a/App/TransparentBackdrop.cpp
+++ b/App/TransparentBackdrop.cpp
@@ -6,13 +6,12 @@
 // compositor's family — Windows.UI.Composition — so the brush has to
 // be created by a Windows::UI::Composition::Compositor.
 #include <winrt/Microsoft.UI.Composition.h>
-#include <winrt/Microsoft.UI.Composition.SystemBackdrops.h>
 #include <winrt/Windows.UI.Composition.h>
 #if __has_include("TransparentBackdrop.g.cpp")
 #include "TransparentBackdrop.g.cpp"
 #endif
-#if __has_include("ClearAcrylicBackdrop.g.cpp")
-#include "ClearAcrylicBackdrop.g.cpp"
+#if __has_include("FrostedBackdrop.g.cpp")
+#include "FrostedBackdrop.g.cpp"
 #endif
 
 namespace winrt::GhosttyWin32::implementation
@@ -40,30 +39,27 @@ namespace winrt::GhosttyWin32::implementation
         target.SystemBackdrop(nullptr);
     }
 
-    void ClearAcrylicBackdrop::OnTargetConnected(
+    void FrostedBackdrop::OnTargetConnected(
         winrt::Microsoft::UI::Composition::ICompositionSupportsSystemBackdrop const& target,
         winrt::Microsoft::UI::Xaml::XamlRoot const& /*xamlRoot*/)
     {
-        namespace sb = winrt::Microsoft::UI::Composition::SystemBackdrops;
-        if (!m_controller) {
-            m_controller = sb::DesktopAcrylicController();
-            // Zero out the material: no tint, no luminosity wash.
-            // What remains is the blur of whatever is behind the
-            // window, and the terminal's own background-opacity
-            // provides the color on top of it.
-            m_controller.TintOpacity(0.0f);
-            m_controller.LuminosityOpacity(0.0f);
-        }
-        if (!m_configuration) {
-            m_configuration = sb::SystemBackdropConfiguration();
-            m_controller.SetSystemBackdropConfiguration(m_configuration);
-        }
-        m_controller.AddSystemBackdropTarget(target);
+        // No base call, same reasoning as TransparentBackdrop: a
+        // constant brush has no theme/activation policy to react to.
+        //
+        // The host backdrop brush is the behind-window imagery DWM
+        // provides — pre-blurred at a fixed strength by design
+        // (apps must not be able to read other windows' pixels; see
+        // the #165 investigation). That fixed frost is exactly what
+        // background-blur wants, without the noise texture and
+        // milky wash the acrylic MATERIAL adds on top of the same
+        // source.
+        winrt::Windows::UI::Composition::Compositor compositor;
+        target.SystemBackdrop(compositor.CreateHostBackdropBrush());
     }
 
-    void ClearAcrylicBackdrop::OnTargetDisconnected(
+    void FrostedBackdrop::OnTargetDisconnected(
         winrt::Microsoft::UI::Composition::ICompositionSupportsSystemBackdrop const& target)
     {
-        if (m_controller) m_controller.RemoveSystemBackdropTarget(target);
+        target.SystemBackdrop(nullptr);
     }
 }

--- a/App/TransparentBackdrop.h
+++ b/App/TransparentBackdrop.h
@@ -29,33 +29,30 @@ namespace winrt::GhosttyWin32::factory_implementation
     };
 }
 
-#include "ClearAcrylicBackdrop.g.h"
+#include "FrostedBackdrop.g.h"
 
 namespace winrt::GhosttyWin32::implementation
 {
-    // See ClearAcrylicBackdrop in the IDL: DesktopAcrylicController
-    // with TintOpacity / LuminosityOpacity forced to 0 — pure blur,
-    // no color wash, so the terminal's own alpha stays visible
-    // through it.
-    struct ClearAcrylicBackdrop : ClearAcrylicBackdropT<ClearAcrylicBackdrop>
+    // See FrostedBackdrop in the IDL: the raw host backdrop brush,
+    // no material layered on top. Requires the window to opt in to
+    // host-backdrop sampling (DWMWA_USE_HOSTBACKDROPBRUSH — set in
+    // MainWindow::ApplyBackgroundOpacityAppearance, which owns the
+    // HWND); without it the brush renders empty.
+    struct FrostedBackdrop : FrostedBackdropT<FrostedBackdrop>
     {
-        ClearAcrylicBackdrop() = default;
+        FrostedBackdrop() = default;
 
         void OnTargetConnected(
             winrt::Microsoft::UI::Composition::ICompositionSupportsSystemBackdrop const& target,
             winrt::Microsoft::UI::Xaml::XamlRoot const& xamlRoot);
         void OnTargetDisconnected(
             winrt::Microsoft::UI::Composition::ICompositionSupportsSystemBackdrop const& target);
-
-    private:
-        winrt::Microsoft::UI::Composition::SystemBackdrops::DesktopAcrylicController m_controller{ nullptr };
-        winrt::Microsoft::UI::Composition::SystemBackdrops::SystemBackdropConfiguration m_configuration{ nullptr };
     };
 }
 
 namespace winrt::GhosttyWin32::factory_implementation
 {
-    struct ClearAcrylicBackdrop : ClearAcrylicBackdropT<ClearAcrylicBackdrop, implementation::ClearAcrylicBackdrop>
+    struct FrostedBackdrop : FrostedBackdropT<FrostedBackdrop, implementation::FrostedBackdrop>
     {
     };
 }

--- a/App/TransparentBackdrop.idl
+++ b/App/TransparentBackdrop.idl
@@ -16,14 +16,17 @@ namespace GhosttyWin32
         TransparentBackdrop();
     }
 
-    // Acrylic blur with the tint dialed to zero: full blur of what's
-    // behind the window with no color wash, so background-opacity's
-    // translucency and background-blur compose ("frosted glass")
-    // instead of the stock DesktopAcrylicBackdrop's heavy material
-    // tint swallowing the transparency.
+    // Frosted glass for background-blur: the raw host backdrop
+    // brush, i.e. the pre-blurred behind-window imagery DWM hands
+    // to apps. Preferred over DesktopAcrylicController with its
+    // tint dialed to zero because the acrylic MATERIAL still adds
+    // its noise texture and a milky gray wash even at zero
+    // opacities — the raw brush is the same blur without the
+    // material on top (side-by-side comparison during the #165
+    // blur-radius investigation).
     [default_interface]
-    runtimeclass ClearAcrylicBackdrop : Microsoft.UI.Xaml.Media.SystemBackdrop
+    runtimeclass FrostedBackdrop : Microsoft.UI.Xaml.Media.SystemBackdrop
     {
-        ClearAcrylicBackdrop();
+        FrostedBackdrop();
     }
 }


### PR DESCRIPTION
## Why

`background-blur` built its frost from `DesktopAcrylicController` with tint and luminosity zeroed — but the acrylic **material** still layers its noise texture and a milky gray wash over the blur. Side-by-side during the #165 blur-radius investigation (where a diagnostic build showed the raw host backdrop), the raw brush was the clearly better look: same blur, no gray cast.

## What

- `ClearAcrylicBackdrop` → **`FrostedBackdrop`**: hands the target `CreateHostBackdropBrush()` directly — the same DWM pre-blurred behind-window imagery the acrylic recipe samples, without the material on top. Less code: the controller + configuration plumbing collapses into one brush assignment
- `DWMWA_USE_HOSTBACKDROPBRUSH` set in `ApplyBackgroundOpacityAppearance` (where the HWND lives) when the blur mode is active — a raw host backdrop brush renders empty without this opt-in, which the material controllers used to flip internally

## Verification (config: `background-opacity = 0.9`, `background-blur = true`)

- [ ] Frost looks like the #165 diagnostic build: clean blur, no gray/milky cast, no noise grain
- [ ] `Ctrl+Shift+B`: Mica ⇔ frost round-trips
- [ ] Blur off (commented): crisp transparency unchanged
- [ ] `background-opacity = 1.0`: Mica unchanged
- [ ] **Unfocused window**: click another app and observe the frost — host backdrop content is reported to drop when the window deactivates; note what actually happens (acceptable either way, but worth knowing)
- [ ] Tear-out window gets the same frost

<details><summary>日本語</summary>

blur のすりガラスを DesktopAcrylicController (tint/luminosity 0) から生の host backdrop brush に差し替えた。acrylic はゼロ設定でもマテリアルのノイズと乳白色の被りが乗る。#165 調査の診断ビルドで生 brush の見た目を比較して、そちらが好みだったため。生 brush は `DWMWA_USE_HOSTBACKDROPBRUSH` の opt-in が無いと空描画になるので、HWND を持つ MainWindow 側で blur モード時に立てる。非アクティブ時に host backdrop の中身が消えるという報告があるので、検証項目に入れてある。

</details>