### PR TITLE
Undo/redo for tab closes via timeout-parked live tabs

### DIFF
--- a/App/App.vcxproj
+++ b/App/App.vcxproj
@@ -170,6 +170,7 @@
     </ClInclude>
     <ClInclude Include="MainWindows.h" />
     <ClInclude Include="SplitPanel.h" />
+    <ClInclude Include="Tabs\ParkedTabs.h" />
     <ClInclude Include="TransparentBackdrop.h" />
     <ClInclude Include="WindowCloseGate.h" />
     <ClInclude Include="Tabs\Panes\Branch.h" />

--- a/App/MainWindow.xaml.cpp
+++ b/App/MainWindow.xaml.cpp
@@ -38,6 +38,21 @@ using namespace winrt;
 using namespace Microsoft::UI::Xaml;
 namespace muxc = Microsoft::UI::Xaml::Controls;
 
+// Undo-park lifecycle tracing (#151). Debug / ASan builds only —
+// Release compiles the calls (and the format strings) out entirely.
+// Every call site passes at least the tick argument, so the plain
+// __VA_ARGS__ form works under the conformant preprocessor too.
+#if defined(_DEBUG)
+#define UNDO_PARK_TRACE(fmt, ...)                                     \
+    do {                                                              \
+        wchar_t undoParkTraceBuf_[224];                               \
+        swprintf_s(undoParkTraceBuf_, fmt, __VA_ARGS__);              \
+        OutputDebugStringW(undoParkTraceBuf_);                        \
+    } while (0)
+#else
+#define UNDO_PARK_TRACE(fmt, ...) do { } while (0)
+#endif
+
 namespace winrt::GhosttyWin32::implementation
 {
     MainWindow::MainWindow()
@@ -1443,6 +1458,10 @@ namespace winrt::GhosttyWin32::implementation
                 parked.timer.Start();
             }
         }
+        if (!m_parkedTabs.empty()) {
+            UNDO_PARK_TRACE(L"UndoPark[%llu]: re-armed %zu parked timer(s)\n",
+                            GetTickCount64() % 100'000, m_parkedTabs.size());
+        }
 #endif
 
         ParkedTab entry;
@@ -1462,6 +1481,10 @@ namespace winrt::GhosttyWin32::implementation
         entry.timer = timer;
         m_parkedTabs.push_back(std::move(entry));
         timer.Start();
+        UNDO_PARK_TRACE(L"UndoPark[%llu]: parked tab=%p idx=%u timeout=%llums "
+                        L"(parked total: %zu)\n",
+                        GetTickCount64() % 100'000, static_cast<void*>(key),
+                        idx, timeoutMs, m_parkedTabs.size());
     }
 
     void MainWindow::ExpireParkedTab(Tab* tab)
@@ -1478,11 +1501,22 @@ namespace winrt::GhosttyWin32::implementation
         it->tab->DetachAll();
         RemoveTabPanelFromAppContent(*it->tab);
         m_parkedTabs.erase(it);
+        UNDO_PARK_TRACE(L"UndoPark[%llu]: expired tab=%p (parked left: %zu)\n",
+                        GetTickCount64() % 100'000, static_cast<void*>(tab),
+                        m_parkedTabs.size());
     }
 
     void MainWindow::Undo()
     {
-        if (m_parkedTabs.empty()) return;
+        if (m_parkedTabs.empty()) {
+            UNDO_PARK_TRACE(L"UndoPark[%llu]: undo requested, stack empty\n",
+                            GetTickCount64() % 100'000);
+            return;
+        }
+        UNDO_PARK_TRACE(L"UndoPark[%llu]: undo tab=%p (parked left: %zu)\n",
+                        GetTickCount64() % 100'000,
+                        static_cast<void*>(m_parkedTabs.back().tab.get()),
+                        m_parkedTabs.size() - 1);
         ParkedTab entry = std::move(m_parkedTabs.back());
         m_parkedTabs.pop_back();
         if (entry.timer) entry.timer.Stop();
@@ -2805,7 +2839,7 @@ namespace winrt::GhosttyWin32::implementation
         // process can't be brought back, and pane closes inside a
         // split stay immediate for stage 1 (subtree extraction is
         // its own project).
-        if (m_ghosttyApp && TabView().TabItems().Size() > 1) {
+        {
             auto* panelForPark =
                 winrt::get_self<implementation::SplitPanel>(tab->Panel());
             Branch* wrappingForPark =
@@ -2814,7 +2848,18 @@ namespace winrt::GhosttyWin32::implementation
             auto* tcForPark = Tab::PaneToTerminalControl(*pane);
             bool processAlive =
                 tcForPark && !tcForPark->Surface().ProcessExited();
-            if (onlyPane && processAlive) {
+            UNDO_PARK_TRACE(L"UndoPark[%llu]: close-eval pane=%p wrapping=%p "
+                            L"parent=%p onlyPane=%d alive=%d tabs=%u\n",
+                            GetTickCount64() % 100'000,
+                            static_cast<void*>(pane),
+                            static_cast<void*>(wrappingForPark),
+                            static_cast<void*>(
+                                wrappingForPark ? wrappingForPark->parent
+                                                : nullptr),
+                            onlyPane ? 1 : 0, processAlive ? 1 : 0,
+                            TabView().TabItems().Size());
+            if (m_ghosttyApp && TabView().TabItems().Size() > 1 &&
+                onlyPane && processAlive) {
                 uint64_t timeoutMs =
                     ghostty::Config(m_ghosttyApp->ConfigHandle()).UndoTimeoutMs();
                 if (timeoutMs > 0) {

--- a/App/MainWindow.xaml.cpp
+++ b/App/MainWindow.xaml.cpp
@@ -37,21 +37,7 @@
 using namespace winrt;
 using namespace Microsoft::UI::Xaml;
 namespace muxc = Microsoft::UI::Xaml::Controls;
-
-// Undo-park lifecycle tracing (#151). Debug / ASan builds only —
-// Release compiles the calls (and the format strings) out entirely.
-// Every call site passes at least the tick argument, so the plain
-// __VA_ARGS__ form works under the conformant preprocessor too.
-#if defined(_DEBUG)
-#define UNDO_PARK_TRACE(fmt, ...)                                     \
-    do {                                                              \
-        wchar_t undoParkTraceBuf_[224];                               \
-        swprintf_s(undoParkTraceBuf_, fmt, __VA_ARGS__);              \
-        OutputDebugStringW(undoParkTraceBuf_);                        \
-    } while (0)
-#else
-#define UNDO_PARK_TRACE(fmt, ...) do { } while (0)
-#endif
+// UNDO_PARK_TRACE comes from Tabs/ParkedTabs.h (via MainWindow.xaml.h).
 
 namespace winrt::GhosttyWin32::implementation
 {
@@ -729,14 +715,10 @@ namespace winrt::GhosttyWin32::implementation
         // ghostty_app_free's join land in the FindForSurface / Any
         // paths and must not find a half-torn-down window.
         if (App::g_app) App::g_app->Windows().Unregister(this);
-        // Parked tabs die alongside the live ones. Stop the expiry
-        // timers first so no Tick lands mid-teardown; the vector
-        // clear then runs each ~Tab (DetachAll catch-all), same as
-        // m_tabs.Clear below.
-        for (auto& parked : m_parkedTabs) {
-            if (parked.timer) parked.timer.Stop();
-        }
-        m_parkedTabs.clear();
+        // Parked tabs die alongside the live ones: Shutdown stops
+        // the expiry timers, then each ~Tab runs its DetachAll
+        // catch-all — same contract as m_tabs.Clear below.
+        m_parkedTabs.Shutdown();
         m_tabs.Clear();   // Tab destructors handle cleanup
         // ghostty::App ownership lives on App scope now (#55 prep).
         // App's destructor frees ghostty AFTER its `window` member
@@ -1436,96 +1418,35 @@ namespace winrt::GhosttyWin32::implementation
         // A fresh user-initiated close invalidates redo history
         // (standard undo semantics); a redo-initiated park is the
         // redo history being consumed, not new history.
-        if (!fromRedo) m_redoCloseItems.clear();
-
-        // Sliding window — a deliberate refinement over upstream's
-        // per-entry expiry: every new close re-arms the existing
-        // parked entries' timers, so a closing streak keeps the
-        // whole history restorable and the clock only starts once
-        // the user stops closing. Bounded in practice because each
-        // extension costs a deliberate user action; stop closing
-        // and everything expires timeout later.
-        //
-        // Set to 0 to restore upstream semantics (macOS
-        // ExpiringUndoManager: each entry expires on its own clock,
-        // counted from its own close) — upstream behavior is simply
-        // this block's absence.
-#if 1  // 1 = sliding window, 0 = upstream per-entry expiry
-        for (auto& parked : m_parkedTabs) {
-            if (parked.timer) {
-                parked.timer.Stop();
-                parked.timer.Interval(std::chrono::milliseconds{ timeoutMs });
-                parked.timer.Start();
-            }
-        }
-        if (!m_parkedTabs.empty()) {
-            UNDO_PARK_TRACE(L"UndoPark[%llu]: re-armed %zu parked timer(s)\n",
-                            GetTickCount64() % 100'000, m_parkedTabs.size());
-        }
-#endif
-
-        ParkedTab entry;
-        entry.tab = std::move(tab);
-        entry.index = idx;
-        Tab* key = entry.tab.get();
-        auto timer = DispatcherQueue().CreateTimer();
-        timer.Interval(std::chrono::milliseconds{ timeoutMs });
-        timer.IsRepeating(false);
+        if (!fromRedo) m_parkedTabs.ClearRedoCandidates();
+        // On expiry: the real teardown, with the same ordering
+        // contract as the immediate close path — DetachAll while
+        // the (collapsed) panel is still in the live visual tree,
+        // then unparent, then destroy. If the window died first,
+        // ~Tab's DetachAll catch-all still runs.
         auto weak = get_weak();
-        timer.Tick([weak, key](auto const&, auto const&) {
-            // key is only ever used as a lookup token — if Undo
-            // already reclaimed the tab, the lookup misses and this
-            // tick is a no-op.
-            if (auto self = weak.get()) self->ExpireParkedTab(key);
-        });
-        entry.timer = timer;
-        m_parkedTabs.push_back(std::move(entry));
-        timer.Start();
-        UNDO_PARK_TRACE(L"UndoPark[%llu]: parked tab=%p idx=%u timeout=%llums "
-                        L"(parked total: %zu)\n",
-                        GetTickCount64() % 100'000, static_cast<void*>(key),
-                        idx, timeoutMs, m_parkedTabs.size());
-    }
-
-    void MainWindow::ExpireParkedTab(Tab* tab)
-    {
-        auto it = std::find_if(
-            m_parkedTabs.begin(), m_parkedTabs.end(),
-            [tab](ParkedTab const& e) { return e.tab.get() == tab; });
-        if (it == m_parkedTabs.end()) return;
-        if (it->timer) it->timer.Stop();
-        // Now the real teardown, with the same ordering contract as
-        // the immediate path: DetachAll while the (collapsed) panel
-        // is still in the live visual tree, then unparent, then
-        // destroy.
-        it->tab->DetachAll();
-        RemoveTabPanelFromAppContent(*it->tab);
-        m_parkedTabs.erase(it);
-        UNDO_PARK_TRACE(L"UndoPark[%llu]: expired tab=%p (parked left: %zu)\n",
-                        GetTickCount64() % 100'000, static_cast<void*>(tab),
-                        m_parkedTabs.size());
+        m_parkedTabs.Park(
+            std::move(tab), idx, timeoutMs, DispatcherQueue(),
+            [weak](std::unique_ptr<Tab> expired) {
+                if (auto self = weak.get()) {
+                    expired->DetachAll();
+                    self->RemoveTabPanelFromAppContent(*expired);
+                }
+            });
     }
 
     void MainWindow::Undo()
     {
-        if (m_parkedTabs.empty()) {
-            UNDO_PARK_TRACE(L"UndoPark[%llu]: undo requested, stack empty\n",
-                            GetTickCount64() % 100'000);
-            return;
-        }
-        UNDO_PARK_TRACE(L"UndoPark[%llu]: undo tab=%p (parked left: %zu)\n",
-                        GetTickCount64() % 100'000,
-                        static_cast<void*>(m_parkedTabs.back().tab.get()),
-                        m_parkedTabs.size() - 1);
-        ParkedTab entry = std::move(m_parkedTabs.back());
-        m_parkedTabs.pop_back();
-        if (entry.timer) entry.timer.Stop();
+        auto restored = m_parkedTabs.PopNewest();
+        if (!restored) return;
         auto tv = TabView();
-        auto item = entry.tab->Item();
-        uint32_t idx = std::min(entry.index, tv.TabItems().Size());
-        m_tabs.Add(std::move(entry.tab));
+        auto item = restored->tab->Item();
+        // Tab-strip position at close time, clamped in case other
+        // tabs closed meanwhile.
+        uint32_t idx = std::min(restored->index, tv.TabItems().Size());
+        m_tabs.Add(std::move(restored->tab));
         tv.TabItems().InsertAt(idx, item);
-        m_redoCloseItems.push_back(winrt::make_weak(item));
+        m_parkedTabs.RememberRedoCandidate(item);
         // Selecting the restored tab drives the rest through the
         // canonical paths: SelectionChanged flips its panel back to
         // Visible (UpdateActivePanelVisibility) and refocuses.
@@ -1544,19 +1465,16 @@ namespace winrt::GhosttyWin32::implementation
                 ghostty::Config(m_ghosttyApp->ConfigHandle()).UndoTimeoutMs();
         }
         if (timeoutMs == 0) return;
-        while (!m_redoCloseItems.empty()) {
-            auto weakItem = m_redoCloseItems.back();
-            m_redoCloseItems.pop_back();
-            auto item = weakItem.get();
+        while (auto item = m_parkedTabs.PopRedoCandidate()) {
             // The tab may have been closed for real (or its window
             // died) since the undo — skip to the next candidate.
-            if (!item || !m_tabs.FindByItem(item)) continue;
+            if (!m_tabs.FindByItem(*item)) continue;
             // Last-tab guard, same as CloseTabByItem's park branch.
             if (TabView().TabItems().Size() <= 1) return;
             // No close gate here: redo re-applies a close that
             // already passed the gate once, and parking doesn't
             // kill anything the gate protects.
-            ParkTab(item, timeoutMs, /*fromRedo=*/true);
+            ParkTab(*item, timeoutMs, /*fromRedo=*/true);
             return;
         }
     }

--- a/App/MainWindow.xaml.cpp
+++ b/App/MainWindow.xaml.cpp
@@ -1423,6 +1423,28 @@ namespace winrt::GhosttyWin32::implementation
         // redo history being consumed, not new history.
         if (!fromRedo) m_redoCloseItems.clear();
 
+        // Sliding window — a deliberate refinement over upstream's
+        // per-entry expiry: every new close re-arms the existing
+        // parked entries' timers, so a closing streak keeps the
+        // whole history restorable and the clock only starts once
+        // the user stops closing. Bounded in practice because each
+        // extension costs a deliberate user action; stop closing
+        // and everything expires timeout later.
+        //
+        // Set to 0 to restore upstream semantics (macOS
+        // ExpiringUndoManager: each entry expires on its own clock,
+        // counted from its own close) — upstream behavior is simply
+        // this block's absence.
+#if 1  // 1 = sliding window, 0 = upstream per-entry expiry
+        for (auto& parked : m_parkedTabs) {
+            if (parked.timer) {
+                parked.timer.Stop();
+                parked.timer.Interval(std::chrono::milliseconds{ timeoutMs });
+                parked.timer.Start();
+            }
+        }
+#endif
+
         ParkedTab entry;
         entry.tab = std::move(tab);
         entry.index = idx;

--- a/App/MainWindow.xaml.cpp
+++ b/App/MainWindow.xaml.cpp
@@ -714,6 +714,14 @@ namespace winrt::GhosttyWin32::implementation
         // ghostty_app_free's join land in the FindForSurface / Any
         // paths and must not find a half-torn-down window.
         if (App::g_app) App::g_app->Windows().Unregister(this);
+        // Parked tabs die alongside the live ones. Stop the expiry
+        // timers first so no Tick lands mid-teardown; the vector
+        // clear then runs each ~Tab (DetachAll catch-all), same as
+        // m_tabs.Clear below.
+        for (auto& parked : m_parkedTabs) {
+            if (parked.timer) parked.timer.Stop();
+        }
+        m_parkedTabs.clear();
         m_tabs.Clear();   // Tab destructors handle cleanup
         // ghostty::App ownership lives on App scope now (#55 prep).
         // App's destructor frees ghostty AFTER its `window` member
@@ -1318,6 +1326,19 @@ namespace winrt::GhosttyWin32::implementation
     {
         auto* t = m_tabs.FindByItem(item);
         if (!t) return;
+        // Undo support (#151): instead of tearing the tab down, park
+        // it alive for undo-timeout. Only when another tab remains —
+        // closing the last tab closes the window, and window-close
+        // undo is out of scope for stage 1. undo-timeout = 0 opts
+        // out entirely and takes the immediate-teardown path below.
+        if (m_ghosttyApp && TabView().TabItems().Size() > 1) {
+            uint64_t timeoutMs =
+                ghostty::Config(m_ghosttyApp->ConfigHandle()).UndoTimeoutMs();
+            if (timeoutMs > 0) {
+                ParkTab(item, timeoutMs, /*fromRedo=*/false);
+                return;
+            }
+        }
         // A stale press record must not keep the closed item alive.
         App::g_app->PressedTab().Forget(item);
         // The focused-surface cache must not outlive the surfaces this
@@ -1360,6 +1381,127 @@ namespace winrt::GhosttyWin32::implementation
             // the panel leaks as an orphan child.
             RemoveTabPanelFromAppContent(*t);
             m_tabs.Remove(item);
+        }
+    }
+
+    void MainWindow::ParkTab(muxc::TabViewItem const& item,
+                             uint64_t timeoutMs, bool fromRedo)
+    {
+        auto* t = m_tabs.FindByItem(item);
+        if (!t) return;
+        // Same bookkeeping as the immediate-teardown path: no stale
+        // press record, and the focused-surface cache must not point
+        // at a surface that is no longer reachable via the UI.
+        App::g_app->PressedTab().Forget(item);
+        if (m_activeSurface) {
+            if (auto* panelImpl =
+                    winrt::get_self<implementation::SplitPanel>(t->Panel())) {
+                if (panelImpl->Tree().FindPaneBy([this](Pane const& p) {
+                        auto const* tc = Tab::PaneToTerminalControl(p);
+                        return tc && tc->Surface().Owns(m_activeSurface);
+                    })) {
+                    m_activeSurface = nullptr;
+                }
+            }
+        }
+        auto tv = TabView();
+        uint32_t idx = 0;
+        if (tv.TabItems().IndexOf(item, idx)) {
+            tv.TabItems().RemoveAt(idx);
+        }
+        // The panel stays parented under AppContent — no Detach, no
+        // unparent, so the swap chains and surfaces stay live and
+        // the +0x1F8 ordering contract never comes into play. It
+        // just goes Collapsed, exactly like an unselected tab; with
+        // its item gone from the strip, UpdateActivePanelVisibility
+        // will never pick it again until Undo re-lists it.
+        t->Panel().Visibility(Visibility::Collapsed);
+        auto tab = m_tabs.Extract(item);
+        if (!tab) return;
+        // A fresh user-initiated close invalidates redo history
+        // (standard undo semantics); a redo-initiated park is the
+        // redo history being consumed, not new history.
+        if (!fromRedo) m_redoCloseItems.clear();
+
+        ParkedTab entry;
+        entry.tab = std::move(tab);
+        entry.index = idx;
+        Tab* key = entry.tab.get();
+        auto timer = DispatcherQueue().CreateTimer();
+        timer.Interval(std::chrono::milliseconds{ timeoutMs });
+        timer.IsRepeating(false);
+        auto weak = get_weak();
+        timer.Tick([weak, key](auto const&, auto const&) {
+            // key is only ever used as a lookup token — if Undo
+            // already reclaimed the tab, the lookup misses and this
+            // tick is a no-op.
+            if (auto self = weak.get()) self->ExpireParkedTab(key);
+        });
+        entry.timer = timer;
+        m_parkedTabs.push_back(std::move(entry));
+        timer.Start();
+    }
+
+    void MainWindow::ExpireParkedTab(Tab* tab)
+    {
+        auto it = std::find_if(
+            m_parkedTabs.begin(), m_parkedTabs.end(),
+            [tab](ParkedTab const& e) { return e.tab.get() == tab; });
+        if (it == m_parkedTabs.end()) return;
+        if (it->timer) it->timer.Stop();
+        // Now the real teardown, with the same ordering contract as
+        // the immediate path: DetachAll while the (collapsed) panel
+        // is still in the live visual tree, then unparent, then
+        // destroy.
+        it->tab->DetachAll();
+        RemoveTabPanelFromAppContent(*it->tab);
+        m_parkedTabs.erase(it);
+    }
+
+    void MainWindow::Undo()
+    {
+        if (m_parkedTabs.empty()) return;
+        ParkedTab entry = std::move(m_parkedTabs.back());
+        m_parkedTabs.pop_back();
+        if (entry.timer) entry.timer.Stop();
+        auto tv = TabView();
+        auto item = entry.tab->Item();
+        uint32_t idx = std::min(entry.index, tv.TabItems().Size());
+        m_tabs.Add(std::move(entry.tab));
+        tv.TabItems().InsertAt(idx, item);
+        m_redoCloseItems.push_back(winrt::make_weak(item));
+        // Selecting the restored tab drives the rest through the
+        // canonical paths: SelectionChanged flips its panel back to
+        // Visible (UpdateActivePanelVisibility) and refocuses.
+        tv.SelectedIndex(static_cast<int32_t>(idx));
+        // Parked panes sat out any appearance changes (background-
+        // opacity toggle, recolour) — restate the window state over
+        // the whole tab set, same as AdoptTornOutTab does.
+        ApplyBackgroundOpacityAppearance();
+    }
+
+    void MainWindow::Redo()
+    {
+        uint64_t timeoutMs = 0;
+        if (m_ghosttyApp) {
+            timeoutMs =
+                ghostty::Config(m_ghosttyApp->ConfigHandle()).UndoTimeoutMs();
+        }
+        if (timeoutMs == 0) return;
+        while (!m_redoCloseItems.empty()) {
+            auto weakItem = m_redoCloseItems.back();
+            m_redoCloseItems.pop_back();
+            auto item = weakItem.get();
+            // The tab may have been closed for real (or its window
+            // died) since the undo — skip to the next candidate.
+            if (!item || !m_tabs.FindByItem(item)) continue;
+            // Last-tab guard, same as CloseTabByItem's park branch.
+            if (TabView().TabItems().Size() <= 1) return;
+            // No close gate here: redo re-applies a close that
+            // already passed the gate once, and parking doesn't
+            // kill anything the gate protects.
+            ParkTab(item, timeoutMs, /*fromRedo=*/true);
+            return;
         }
     }
 
@@ -2629,6 +2771,36 @@ namespace winrt::GhosttyWin32::implementation
         if (!lookup.tab || !lookup.pane) return;
         auto* tab = lookup.tab;
         auto* pane = lookup.pane;
+
+        // Undo support (#151): when this pane is the tab's only one,
+        // the close is a whole-tab close (close_surface via
+        // Ctrl+Shift+W on an unsplit tab — the most common
+        // accidental close) and can be parked exactly like
+        // CloseTabByItem's park branch. Decided BEFORE the Detach
+        // below, which frees the surface and would leave nothing to
+        // restore. Two exclusions: the shell exiting on its own also
+        // lands here (close_surface_cb after child exit) and a dead
+        // process can't be brought back, and pane closes inside a
+        // split stay immediate for stage 1 (subtree extraction is
+        // its own project).
+        if (m_ghosttyApp && TabView().TabItems().Size() > 1) {
+            auto* panelForPark =
+                winrt::get_self<implementation::SplitPanel>(tab->Panel());
+            Branch* wrappingForPark =
+                panelForPark ? BranchOfPane(panelForPark, pane) : nullptr;
+            bool onlyPane = wrappingForPark && !wrappingForPark->parent;
+            auto* tcForPark = Tab::PaneToTerminalControl(*pane);
+            bool processAlive =
+                tcForPark && !tcForPark->Surface().ProcessExited();
+            if (onlyPane && processAlive) {
+                uint64_t timeoutMs =
+                    ghostty::Config(m_ghosttyApp->ConfigHandle()).UndoTimeoutMs();
+                if (timeoutMs > 0) {
+                    ParkTab(tab->Item(), timeoutMs, /*fromRedo=*/false);
+                    return;
+                }
+            }
+        }
 
         // Detach first so the surface / DComp handle are released
         // synchronously, before the Branch holding the TerminalControl

--- a/App/MainWindow.xaml.h
+++ b/App/MainWindow.xaml.h
@@ -11,6 +11,7 @@
 #include "Interop/Encoding.h"
 #include "Win32/Clipboard.h"
 #include "Tabs/Panes/PaneId.h"
+#include "Tabs/ParkedTabs.h"
 #include "Tabs/Tab.h"
 #include "Tabs/TabFactory.h"
 #include "Tabs/Tabs.h"
@@ -367,33 +368,17 @@ namespace winrt::GhosttyWin32::implementation
         ghostty::actions::tags::Fullscreen         m_fullscreen;
         ghostty::actions::tags::WindowDecorations  m_windowDecorations;
         Tabs m_tabs;
-        // Undo support for tab closes (#151). A "closed" tab is
-        // parked here alive — surfaces, pty processes, swap chains
-        // all intact, its panel Collapsed but still parented — for
-        // `undo-timeout`, because a torn-down shell process cannot
-        // be resurrected from any snapshot. Memory stays bounded by
-        // the timeout: each entry self-destructs via its timer.
-        struct ParkedTab {
-            std::unique_ptr<Tab> tab;
-            // Tab-strip position at close time; Undo reinserts here
-            // (clamped, in case other tabs closed meanwhile).
-            uint32_t index{ 0 };
-            Microsoft::UI::Dispatching::DispatcherQueueTimer timer{ nullptr };
-        };
-        std::vector<ParkedTab> m_parkedTabs;
-        // Redo = "close that tab again": remembers the items most
-        // recently restored by Undo. Weak because the user can close
-        // the tab through any normal path meanwhile.
-        std::vector<winrt::weak_ref<Microsoft::UI::Xaml::Controls::TabViewItem>> m_redoCloseItems;
+        // Undo support for tab closes (#151): parked-tab stack,
+        // expiry timers, redo bookkeeping — see Tabs/ParkedTabs.h.
+        // This window keeps only the XAML effects (tab-strip
+        // add/remove, panel visibility, appearance restate, and the
+        // expiry teardown callback).
+        ParkedTabs m_parkedTabs;
         // Detach the item from the tab strip and move its Tab into
-        // m_parkedTabs with an expiry timer. fromRedo keeps the redo
-        // stack intact (a user-initiated close invalidates it).
+        // m_parkedTabs. fromRedo keeps the redo history intact (a
+        // user-initiated close invalidates it).
         void ParkTab(Microsoft::UI::Xaml::Controls::TabViewItem const& item,
                      uint64_t timeoutMs, bool fromRedo);
-        // Timer/teardown terminus: run the real close on a parked
-        // tab (DetachAll while the collapsed panel is still in the
-        // live tree, then unparent and destroy).
-        void ExpireParkedTab(Tab* tab);
         // Guards every close intent (window / tab / surface) so
         // needs_confirm_quit prompts land once, not one dialog per
         // path. Constructed inline so it's usable from the ctor.

--- a/App/MainWindow.xaml.h
+++ b/App/MainWindow.xaml.h
@@ -135,6 +135,13 @@ namespace winrt::GhosttyWin32::implementation
         void PresentTerminal() override;
         void ShowOnScreenKeyboard() override;
 
+        // Undo/redo of parked tab closes (#151). CloseTabByItem
+        // parks instead of destroying when undo-timeout > 0; these
+        // restore the newest parked tab / re-close the tab that was
+        // most recently restored.
+        void Undo() override;
+        void Redo() override;
+
         // Terminal-driven appearance / lifecycle overrides. Bodies
         // are in MainWindow.xaml.cpp; the logic moved verbatim
         // from the old inline action_cb chunks.
@@ -360,6 +367,33 @@ namespace winrt::GhosttyWin32::implementation
         ghostty::actions::tags::Fullscreen         m_fullscreen;
         ghostty::actions::tags::WindowDecorations  m_windowDecorations;
         Tabs m_tabs;
+        // Undo support for tab closes (#151). A "closed" tab is
+        // parked here alive — surfaces, pty processes, swap chains
+        // all intact, its panel Collapsed but still parented — for
+        // `undo-timeout`, because a torn-down shell process cannot
+        // be resurrected from any snapshot. Memory stays bounded by
+        // the timeout: each entry self-destructs via its timer.
+        struct ParkedTab {
+            std::unique_ptr<Tab> tab;
+            // Tab-strip position at close time; Undo reinserts here
+            // (clamped, in case other tabs closed meanwhile).
+            uint32_t index{ 0 };
+            Microsoft::UI::Dispatching::DispatcherQueueTimer timer{ nullptr };
+        };
+        std::vector<ParkedTab> m_parkedTabs;
+        // Redo = "close that tab again": remembers the items most
+        // recently restored by Undo. Weak because the user can close
+        // the tab through any normal path meanwhile.
+        std::vector<winrt::weak_ref<Microsoft::UI::Xaml::Controls::TabViewItem>> m_redoCloseItems;
+        // Detach the item from the tab strip and move its Tab into
+        // m_parkedTabs with an expiry timer. fromRedo keeps the redo
+        // stack intact (a user-initiated close invalidates it).
+        void ParkTab(Microsoft::UI::Xaml::Controls::TabViewItem const& item,
+                     uint64_t timeoutMs, bool fromRedo);
+        // Timer/teardown terminus: run the real close on a parked
+        // tab (DetachAll while the collapsed panel is still in the
+        // live tree, then unparent and destroy).
+        void ExpireParkedTab(Tab* tab);
         // Guards every close intent (window / tab / surface) so
         // needs_confirm_quit prompts land once, not one dialog per
         // path. Constructed inline so it's usable from the ctor.

--- a/App/Tabs/ParkedTabs.h
+++ b/App/Tabs/ParkedTabs.h
@@ -1,0 +1,207 @@
+#pragma once
+
+#include "Tabs/Tab.h"
+#include <winrt/Microsoft.UI.Dispatching.h>
+#include <winrt/Microsoft.UI.Xaml.Controls.h>
+#include <algorithm>
+#include <chrono>
+#include <functional>
+#include <memory>
+#include <optional>
+#include <vector>
+
+// Undo-park lifecycle tracing (#151). Debug / ASan builds only —
+// Release compiles the calls (and the format strings) out entirely.
+// Every call site passes at least the tick argument, so the plain
+// __VA_ARGS__ form works under the conformant preprocessor too.
+// Defined here because both this class and MainWindow's close-path
+// decision log speak the same trace vocabulary.
+#if defined(_DEBUG)
+#define UNDO_PARK_TRACE(fmt, ...)                                     \
+    do {                                                              \
+        wchar_t undoParkTraceBuf_[224];                               \
+        swprintf_s(undoParkTraceBuf_, fmt, __VA_ARGS__);              \
+        OutputDebugStringW(undoParkTraceBuf_);                        \
+    } while (0)
+#else
+#define UNDO_PARK_TRACE(fmt, ...) do { } while (0)
+#endif
+
+namespace winrt::GhosttyWin32::implementation {
+
+// Undo support for tab closes (#151): the parked-tab stack, its
+// expiry timers, and the redo bookkeeping — state and operations in
+// one place, same aggregation style as Tabs / WindowCloseGate.
+//
+// A "closed" tab is parked here alive — surfaces, pty processes,
+// swap chains all intact — because a torn-down shell process cannot
+// be resurrected from any snapshot. Memory stays bounded by the
+// timeout: each entry self-destructs via its timer, and the window
+// is SLIDING (a deliberate refinement over upstream's per-entry
+// expiry): every new park re-arms every existing timer, so a
+// closing streak stays fully restorable and the clock only counts
+// down once the user stops closing. Each extension costs a
+// deliberate close, so the parked set stays bounded in practice.
+//
+// What deliberately stays OUTSIDE: everything XAML-window-shaped.
+// The owner (MainWindow) removes/reinserts tab-strip items, hides
+// panels, restates appearance, and supplies the expiry teardown via
+// the onExpire callback — this class never touches the visual tree.
+class ParkedTabs {
+public:
+    ParkedTabs() = default;
+    ParkedTabs(const ParkedTabs&) = delete;
+    ParkedTabs& operator=(const ParkedTabs&) = delete;
+    ParkedTabs(ParkedTabs&&) = delete;
+    ParkedTabs& operator=(ParkedTabs&&) = delete;
+
+    ~ParkedTabs() { Shutdown(); }
+
+    // Take ownership of a closed-but-alive Tab for timeoutMs. When
+    // the clock runs out, onExpire receives the ownership back on
+    // the dispatcher thread (the owner runs the real teardown); a
+    // tab reclaimed by PopNewest first never expires. Sliding
+    // window: every Park re-arms all existing entries' timers.
+    void Park(std::unique_ptr<Tab> tab, uint32_t index, uint64_t timeoutMs,
+              Microsoft::UI::Dispatching::DispatcherQueue const& dq,
+              std::function<void(std::unique_ptr<Tab>)> onExpire)
+    {
+        if (!tab || !dq) return;
+
+        // Set to 0 to restore upstream semantics (macOS
+        // ExpiringUndoManager: each entry expires on its own clock,
+        // counted from its own close) — upstream behavior is simply
+        // this block's absence.
+#if 1  // 1 = sliding window, 0 = upstream per-entry expiry
+        for (auto& entry : m_entries) {
+            if (entry.timer) {
+                entry.timer.Stop();
+                entry.timer.Interval(std::chrono::milliseconds{ timeoutMs });
+                entry.timer.Start();
+            }
+        }
+        if (!m_entries.empty()) {
+            UNDO_PARK_TRACE(L"UndoPark[%llu]: re-armed %zu parked timer(s)\n",
+                            GetTickCount64() % 100'000, m_entries.size());
+        }
+#endif
+
+        Entry entry;
+        entry.tab = std::move(tab);
+        entry.index = index;
+        entry.onExpire = std::move(onExpire);
+        Tab* key = entry.tab.get();
+        auto timer = dq.CreateTimer();
+        timer.Interval(std::chrono::milliseconds{ timeoutMs });
+        timer.IsRepeating(false);
+        // The alive token outlives neither this object nor the
+        // dispatcher thread's serialization: a tick that fires
+        // after ~ParkedTabs finds an expired weak_ptr and no-ops.
+        // `key` is only ever a lookup token — if PopNewest already
+        // reclaimed the tab, the lookup misses and the tick no-ops.
+        timer.Tick([alive = std::weak_ptr<int>(m_alive), this, key](
+                       auto const&, auto const&) {
+            if (alive.lock()) Expire(key);
+        });
+        entry.timer = timer;
+        m_entries.push_back(std::move(entry));
+        timer.Start();
+        UNDO_PARK_TRACE(L"UndoPark[%llu]: parked tab=%p idx=%u timeout=%llums "
+                        L"(parked total: %zu)\n",
+                        GetTickCount64() % 100'000, static_cast<void*>(key),
+                        index, timeoutMs, m_entries.size());
+    }
+
+    // Reclaim the most recently parked tab (LIFO), stopping its
+    // timer. Empty stack returns nullopt.
+    struct Restored {
+        std::unique_ptr<Tab> tab;
+        uint32_t index;
+    };
+    std::optional<Restored> PopNewest()
+    {
+        if (m_entries.empty()) {
+            UNDO_PARK_TRACE(L"UndoPark[%llu]: undo requested, stack empty\n",
+                            GetTickCount64() % 100'000);
+            return std::nullopt;
+        }
+        Entry entry = std::move(m_entries.back());
+        m_entries.pop_back();
+        if (entry.timer) entry.timer.Stop();
+        UNDO_PARK_TRACE(L"UndoPark[%llu]: undo tab=%p (parked left: %zu)\n",
+                        GetTickCount64() % 100'000,
+                        static_cast<void*>(entry.tab.get()), m_entries.size());
+        return Restored{ std::move(entry.tab), entry.index };
+    }
+
+    bool Empty() const noexcept { return m_entries.empty(); }
+
+    // ----- redo bookkeeping -----
+    // Redo = "close that tab again": remember the items most
+    // recently restored by an undo. Weak because the user can close
+    // the tab through any normal path meanwhile; a fresh
+    // user-initiated close invalidates the whole history (standard
+    // undo semantics — a new action clears redo).
+
+    void RememberRedoCandidate(Microsoft::UI::Xaml::Controls::TabViewItem const& item)
+    {
+        m_redoItems.push_back(winrt::make_weak(item));
+    }
+
+    void ClearRedoCandidates() noexcept { m_redoItems.clear(); }
+
+    // Newest still-resolvable redo candidate, consuming dead ones.
+    // The caller re-checks that the item still maps to a live tab.
+    std::optional<Microsoft::UI::Xaml::Controls::TabViewItem> PopRedoCandidate()
+    {
+        while (!m_redoItems.empty()) {
+            auto weakItem = m_redoItems.back();
+            m_redoItems.pop_back();
+            if (auto item = weakItem.get()) return item;
+        }
+        return std::nullopt;
+    }
+
+    // Stop every timer and drop the entries (each ~Tab runs its
+    // DetachAll catch-all). Called from the owner's destructor for
+    // explicit ordering; idempotent.
+    void Shutdown() noexcept
+    {
+        for (auto& entry : m_entries) {
+            if (entry.timer) entry.timer.Stop();
+        }
+        m_entries.clear();
+        m_redoItems.clear();
+    }
+
+private:
+    struct Entry {
+        std::unique_ptr<Tab> tab;
+        uint32_t index{ 0 };
+        Microsoft::UI::Dispatching::DispatcherQueueTimer timer{ nullptr };
+        std::function<void(std::unique_ptr<Tab>)> onExpire;
+    };
+
+    void Expire(Tab* key)
+    {
+        auto it = std::find_if(
+            m_entries.begin(), m_entries.end(),
+            [key](Entry const& e) { return e.tab.get() == key; });
+        if (it == m_entries.end()) return;
+        if (it->timer) it->timer.Stop();
+        auto tab = std::move(it->tab);
+        auto onExpire = std::move(it->onExpire);
+        m_entries.erase(it);
+        UNDO_PARK_TRACE(L"UndoPark[%llu]: expired tab=%p (parked left: %zu)\n",
+                        GetTickCount64() % 100'000, static_cast<void*>(key),
+                        m_entries.size());
+        if (onExpire) onExpire(std::move(tab));
+    }
+
+    std::vector<Entry> m_entries;
+    std::vector<winrt::weak_ref<Microsoft::UI::Xaml::Controls::TabViewItem>> m_redoItems;
+    // Liveness token for timer ticks; see Park.
+    std::shared_ptr<int> m_alive = std::make_shared<int>(0);
+};
+
+}  // namespace winrt::GhosttyWin32::implementation

--- a/Core/Ghostty/Actions/Actions.cpp
+++ b/Core/Ghostty/Actions/Actions.cpp
@@ -484,6 +484,22 @@ bool Actions::OnToggleBackgroundOpacity() {
     return true;
 }
 
+bool Actions::OnUndo() {
+    // Empty-stack handling lives in the view (the stack is view
+    // state); the action is acked as delivered either way.
+    DispatchToView([this]() {
+        m_view.Undo();
+    });
+    return true;
+}
+
+bool Actions::OnRedo() {
+    DispatchToView([this]() {
+        m_view.Redo();
+    });
+    return true;
+}
+
 bool Actions::OnReloadConfig(bool soft) {
     // The view-side implementation handles thread placement
     // (soft re-uses UI thread, hard spins a 4MB-stack worker

--- a/Core/Ghostty/Actions/Actions.h
+++ b/Core/Ghostty/Actions/Actions.h
@@ -154,6 +154,8 @@ public:
     bool OnKeyTable(ghostty_surface_t surface,
                     ghostty_action_key_table_s table);
     bool OnToggleBackgroundOpacity();
+    bool OnUndo();
+    bool OnRedo();
     bool OnReloadConfig(bool soft);
     bool OnConfigChange(ghostty_config_t newCfg);
     bool OnDesktopNotification(ghostty_surface_t surface,

--- a/Core/Ghostty/CallbackDispatcher.cpp
+++ b/Core/Ghostty/CallbackDispatcher.cpp
@@ -177,6 +177,12 @@ bool CallbackDispatcher::DispatchAction(ghostty_target_s target, ghostty_action_
             return m_actions.OnFloatWindow(action.action.float_window);
         case GHOSTTY_ACTION_TOGGLE_BACKGROUND_OPACITY:
             return m_actions.OnToggleBackgroundOpacity();
+        // Undo/redo of parked closes (#151). App-scoped: the undo
+        // stack is per-window view state, not per-surface.
+        case GHOSTTY_ACTION_UNDO:
+            return m_actions.OnUndo();
+        case GHOSTTY_ACTION_REDO:
+            return m_actions.OnRedo();
 
         // ----- split-pane (surface-targeted) -----
         case GHOSTTY_ACTION_NEW_SPLIT:
@@ -210,9 +216,7 @@ bool CallbackDispatcher::DispatchAction(ghostty_target_s target, ghostty_action_
         //
         // Feature surfaces intentionally not on this port's plate
         // (search bar, ImGui inspector, tab overview, quick
-        // terminal, command palette, terminal-level undo/redo):
-        case GHOSTTY_ACTION_UNDO:
-        case GHOSTTY_ACTION_REDO:
+        // terminal, command palette):
         case GHOSTTY_ACTION_START_SEARCH:
         case GHOSTTY_ACTION_END_SEARCH:
         case GHOSTTY_ACTION_SEARCH_TOTAL:

--- a/Core/Ghostty/Config.h
+++ b/Core/Ghostty/Config.h
@@ -84,6 +84,20 @@ public:
         return v != 0;
     }
 
+    // How long a closed tab stays parked (live, hidden) before the
+    // real teardown runs — the window in which UNDO can bring it
+    // back. ghostty's Duration crosses the C API via cval() as
+    // MILLISECONDS (same convention as notify-on-command-finish-
+    // after above). 0 disables parking entirely: closes tear down
+    // immediately and UNDO has nothing to restore.
+    uint64_t UndoTimeoutMs() const noexcept {
+        size_t ms = 0;
+        if (!GetRaw("undo-timeout", &ms)) {
+            return 5'000;  // documented default: 5s
+        }
+        return static_cast<uint64_t>(ms);
+    }
+
     // ----- notify-on-command-finish (v1.3.0+, default: never) -----
     // The whole feature is opt-in; every getter falls back to the
     // documented default when the key is unreadable.

--- a/Core/Ghostty/Surface.h
+++ b/Core/Ghostty/Surface.h
@@ -143,6 +143,14 @@ public:
         return m_handle && ghostty_surface_needs_confirm_quit(m_handle);
     }
 
+    // Whether the surface's child process has already exited. Close
+    // paths use this to tell "user closed a live terminal" (park it
+    // for undo) from "the shell exited on its own" (nothing left to
+    // restore — tear down for real).
+    bool ProcessExited() const noexcept {
+        return m_handle && ghostty_surface_process_exited(m_handle);
+    }
+
     // ---- selection ----
     bool HasSelection() const noexcept {
         return m_handle && ghostty_surface_has_selection(m_handle);

--- a/Core/Host/IWindow.h
+++ b/Core/Host/IWindow.h
@@ -152,6 +152,15 @@ struct IWindow {
     // configured) and while fullscreen.
     virtual void ToggleBackgroundOpacity() = 0;
 
+    // Undo the most recent undoable close, or redo the close that
+    // was most recently undone. The whole mechanism is view-owned:
+    // libghostty only delivers the UNDO / REDO keybind actions and
+    // upstream leaves the stack to the apprt (macOS parks the live
+    // surface in an expiring NSUndoManager; this port parks closed
+    // Tabs for `undo-timeout` before really tearing them down).
+    virtual void Undo() = 0;
+    virtual void Redo() = 0;
+
     // Bring the window to the foreground (restoring it from a
     // minimized state first) and give it focus. Used by
     // PRESENT_TERMINAL — typically triggered by an external

--- a/Tests/MockMainWindowView.h
+++ b/Tests/MockMainWindowView.h
@@ -134,6 +134,12 @@ struct MockMainWindowView : core::host::IWindow {
     int toggleBackgroundOpacityCalls = 0;
     void ToggleBackgroundOpacity() override { ++toggleBackgroundOpacityCalls; }
 
+    int undoCalls = 0;
+    void Undo() override { ++undoCalls; }
+
+    int redoCalls = 0;
+    void Redo() override { ++redoCalls; }
+
     int setFloatOnTopCalls = 0;
     ghostty_action_float_window_e lastFloatOnTopMode{};
     void SetFloatOnTop(ghostty_action_float_window_e mode) override {

--- a/Tests/test_ghostty_actions.cpp
+++ b/Tests/test_ghostty_actions.cpp
@@ -532,6 +532,15 @@ TEST(GhosttyActionsTest, OnToggleBackgroundOpacityAsksTheView) {
     EXPECT_EQ(view.toggleBackgroundOpacityCalls, 1);
 }
 
+TEST(GhosttyActionsTest, OnUndoRedoAskTheView) {
+    MockMainWindowView view;
+    Actions actions(view);
+    EXPECT_TRUE(actions.OnUndo());
+    EXPECT_EQ(view.undoCalls, 1);
+    EXPECT_TRUE(actions.OnRedo());
+    EXPECT_EQ(view.redoCalls, 1);
+}
+
 TEST(GhosttyActionsTest, OnReloadConfigPassesSoftFlagThrough) {
     MockMainWindowView view;
     Actions actions(view);

--- a/Tests/test_ghostty_callback_dispatcher.cpp
+++ b/Tests/test_ghostty_callback_dispatcher.cpp
@@ -56,8 +56,6 @@ TEST(GhosttyCallbackDispatcherTest, FeatureSurfaceAcksReturnTrue) {
     MockMainWindowView view;
     auto d = CallbackDispatcher::Create(view);
 
-    EXPECT_TRUE(DispatchTag(*d, GHOSTTY_ACTION_UNDO));
-    EXPECT_TRUE(DispatchTag(*d, GHOSTTY_ACTION_REDO));
     EXPECT_TRUE(DispatchTag(*d, GHOSTTY_ACTION_START_SEARCH));
     EXPECT_TRUE(DispatchTag(*d, GHOSTTY_ACTION_END_SEARCH));
     EXPECT_TRUE(DispatchTag(*d, GHOSTTY_ACTION_SEARCH_TOTAL));
@@ -79,6 +77,19 @@ TEST(GhosttyCallbackDispatcherTest, NoConsumerAcksReturnTrue) {
     EXPECT_TRUE(DispatchTag(*d, GHOSTTY_ACTION_QUIT_TIMER));
     // CELL_SIZE: cached but no host-side consumer yet.
     EXPECT_TRUE(DispatchTag(*d, GHOSTTY_ACTION_CELL_SIZE));
+}
+
+TEST(GhosttyCallbackDispatcherTest, UndoRedoRouteToTheView) {
+    // Formerly feature-surface acks; #151 wires them to the view's
+    // parked-close stack. Empty-stack handling is view state, so
+    // the dispatcher's contract is just delivery.
+    MockMainWindowView view;
+    auto d = CallbackDispatcher::Create(view);
+    EXPECT_TRUE(DispatchTag(*d, GHOSTTY_ACTION_UNDO));
+    EXPECT_EQ(view.undoCalls, 1);
+    EXPECT_EQ(view.redoCalls, 0);
+    EXPECT_TRUE(DispatchTag(*d, GHOSTTY_ACTION_REDO));
+    EXPECT_EQ(view.redoCalls, 1);
 }
 
 TEST(GhosttyCallbackDispatcherTest, ToggleBackgroundOpacityRoutesToTheView) {


### PR DESCRIPTION
Closes #151 (stage 1).

## Why

An accidental `Ctrl+Shift+W` or tab-strip ✕ destroyed the shell, its scrollback, and any running process with no recourse. Undo is the prompt-free safety net that pairs with running `confirm-close-surface = false`.

<details><summary>日本語</summary>

`Ctrl+Shift+W` やタブの ✕ を誤爆すると、シェルも scrollback も実行中のプロセスも戻せないまま消えていた。undo は `confirm-close-surface = false` 運用と対になる、確認ダイアログなしの保険になる。

</details>

## Design (mirrors upstream macOS)

A closed shell process can't be resurrected from any snapshot, so undo keeps the real thing alive — the same design as macOS's expiring NSUndoManager.

- **Park, don't destroy**: the whole-tab close paths move the Tab into `m_parkedTabs` — surfaces, ptys, swap chains intact, panel **Collapsed but still parented** (so the +0x1F8 detach-ordering contract never comes into play; `UpdateActivePanelVisibility` already ignores anything not in the strip)
- **Bounded memory**: every entry self-destructs via a `DispatcherQueueTimer` after ghostty's `undo-timeout` (default 5s, `Config::UndoTimeoutMs()`, ms like every Duration cval); expiry runs the original teardown ordering (DetachAll while parented → unparent → destroy). `undo-timeout = 0` opts out entirely
- **UNDO** reinserts at the recorded strip position (clamped) and selects it; **REDO** re-parks the tab most recently restored; a fresh user close clears redo history
- Both whole-tab close paths park: `CloseTabByItem`, and `RemovePaneByIdApproved` when the pane is the tab's only one — decided **before** the `Detach` that frees the surface
- **Shell-exit closes don't park**: `ghostty_surface_process_exited` (new `Surface::ProcessExited()`) distinguishes "user closed a live terminal" from "the shell exited" — a dead process has nothing to restore
- Dispatcher: `UNDO`/`REDO` move out of the feature-surface ack block into real routes → `Actions::OnUndo/OnRedo` → `IWindow::Undo/Redo`

<details><summary>日本語</summary>

閉じたシェルのプロセスはどんなスナップショットからも復元できない。だから undo は本物を生かしたまま持つ — macOS の expiring NSUndoManager と同じ設計方針。

- **破壊せず park する**: タブ全体を閉じる経路は Tab を `m_parkedTabs` に移す。surface も pty も swap chain もそのまま、panel は **Collapsed のまま親付き** (unparent しないので +0x1F8 の破棄順序契約に触れない。ストリップにない panel は `UpdateActivePanelVisibility` が元から無視する)
- **メモリは有界**: 各エントリは `DispatcherQueueTimer` で `undo-timeout` (既定 5 秒、`Config::UndoTimeoutMs()`、他の Duration cval と同じく ms) 後に自壊する。期限が来たら本来の teardown 順 (親付きのまま DetachAll → unparent → 破棄) を実行。`undo-timeout = 0` で機能ごと無効化できる
- **UNDO** は記録したストリップ位置 (clamp 付き) に再挿入して選択する。**REDO** は直前に undo で戻したタブをもう一度 park する。新しいユーザー操作の close は redo 履歴を無効化する
- park するのはタブ全体を閉じる 2 経路: `CloseTabByItem` と、pane がタブ唯一のときの `RemovePaneByIdApproved`。後者は surface を解放する `Detach` より**前**に判定する
- **シェルの自然 exit は park しない**: `ghostty_surface_process_exited` (新設 `Surface::ProcessExited()`) で「ユーザーが生きた terminal を閉じた」と「シェルが勝手に終了した」を区別する。死んだプロセスには戻すものがない
- dispatcher: `UNDO`/`REDO` を ack ブロックから本物のルートに昇格 → `Actions::OnUndo/OnRedo` → `IWindow::Undo/Redo`

</details>

## Out of scope (stage 1)

- Pane closes **inside a split** (subtree extraction + reinsertion is its own project)
- Last-tab / window close undo (bypasses parking, closes the window as before)
- Windows has no default undo keybinds upstream (the `super+z` block is macOS-only) — users bind e.g. `ctrl+shift+z=undo`

<details><summary>日本語</summary>

- **split 内の pane close** (subtree の抽出と再挿入は独立した課題)
- 最終タブ / ウインドウ close の undo (park を通らず従来どおり窓を閉じる)
- Windows には undo のデフォルト keybind がない (`super+z` 系は macOS 専用ブロック)。`ctrl+shift+z=undo` などを各自 bind する

</details>

## Verification (add: `keybind = ctrl+shift+z=undo`, `keybind = ctrl+shift+y=redo`)

- [x] Tests.exe green
- [x] Close a tab (✕ or Ctrl+Shift+W on unsplit tab) → Ctrl+Shift+Z within 5s → tab returns at its old position, shell state intact (running `ping -t` keeps running through the round trip)
- [x] Ctrl+Shift+Y after an undo → the tab closes again
- [x] Wait >5s after a close → Ctrl+Shift+Z does nothing; no leak (process really gone)
- [x] `exit` in the shell → tab closes → Ctrl+Shift+Z does NOT bring it back
- [x] Close a split pane (pane inside a split) → immediate close as before, undo does nothing
- [x] Close the last tab → window closes as before
- [x] Close tab at index 0 of 3, then undo → returns to position 0
- [x] Toggle background opacity while a tab is parked, undo → restored tab matches the window's current appearance

<details><summary>日本語</summary>

- [x] Tests.exe green
- [x] タブを閉じて (✕ か、未分割タブで Ctrl+Shift+W) 5 秒以内に Ctrl+Shift+Z → 元の位置に戻り、シェルの状態も無傷 (`ping -t` が往復を生き延びる)
- [x] undo 直後の Ctrl+Shift+Y → もう一度閉じる
- [x] 閉じて 5 秒超放置 → Ctrl+Shift+Z は無反応、リークなし (プロセスは本当に消えている)
- [x] シェルで `exit` → タブは閉じるが Ctrl+Shift+Z で戻らない
- [x] split 内の pane close → 従来どおり即破棄、undo は効かない
- [x] 最終タブ close → 従来どおり窓ごと閉じる
- [x] 3 タブ中の先頭 (index 0) を閉じて undo → 先頭に戻る
- [x] park 中に背景透過をトグルして undo → 復帰タブの外観が現在のウインドウ状態に一致

</details>

## Verified (all items above, with debug-output evidence)

- Sliding-window expiry proven by tick log: three closes at ~2s intervals re-armed the stack each time; all three entries expired clustered at *last close + 5.1s* (per-entry semantics would have expired the first at *its own* close + 5s)
- Surface-path park (`close-eval onlyPane=1` → park → undo) and split-pane fall-through (`onlyPane=0`, no park) both observed
- Window teardown with a still-parked tab: clean exit code 0, all surfaces closed

<details><summary>日本語</summary>

- sliding window の期限を tick ログで実証: 約 2 秒間隔の 3 連 close で毎回全タイマーが再アームされ、3 エントリの expire は**最後の close + 5.1 秒**に密集した (per-entry 方式なら 1 個目は自分の close + 5 秒で消えていた)
- surface 経路の park (`close-eval onlyPane=1` → park → undo) と split pane の素通り (`onlyPane=0`、park なし) を両方観測
- park が残ったままの window teardown も exit code 0 でクリーン、全 surface closed

</details>

## Added during verification

- **Sliding window**: each new close re-arms every parked entry's timer, so a closing streak stays fully restorable and the clock starts when the user stops closing. Guarded behind a one-character `#if` (`1` = sliding, `0` = upstream per-entry expiry — upstream semantics is simply the block's absence)
- **Debug-build tracing**: park / re-arm / expire / undo and the close-path decision each log a ticked line through `UNDO_PARK_TRACE`, which compiles to nothing outside `_DEBUG`. It already paid for itself by separating a suspected park misfire from the real cause: ghostty's non-macOS defaults bind ctrl+shift+w to BOTH `close_surface` and `close_tab` (Config.zig ~6605 vs ~6625, last write wins), so ctrl+shift+w is `close_tab` and `close_surface` is unreachable without a custom keybind (upstream-report candidate)

<details><summary>日本語</summary>

- **sliding window**: 新しい close のたびに既存エントリのタイマーを全部再アームする。連続 close の間は履歴が丸ごと残り、手を止めた時点からカウントが始まる。1 文字の `#if` で切替可能 (`1` = sliding、`0` = 本家の per-entry 方式 — 本家挙動はこのブロックが無い状態そのもの)
- **Debug ビルド限定トレース**: park / re-arm / expire / undo と close 経路の判定を `UNDO_PARK_TRACE` で tick 付きログに出す。`_DEBUG` 以外では呼び出しごとコンパイルで消える。検証中に早速役に立った — park 誤発動の疑いを追った結果、真因は ghostty の非 macOS デフォルトで ctrl+shift+w が `close_surface` と `close_tab` の**両方に登録**されていて後勝ちで `close_tab` になること (Config.zig ~6605 と ~6625)。つまり `close_surface` は keybind を書かない限り発火できない (本家への報告候補)

</details>

## Structure: the ParkedTabs aggregate

The parked stack, expiry timers, redo candidates, and the sliding re-arm live in `Tabs/ParkedTabs.h` (same aggregation style as `Tabs` / `WindowCloseGate`). MainWindow keeps only what is window-shaped: tab-strip add/remove, panel visibility, appearance restate, and the expiry teardown callback. Timer ticks hold a liveness token, so a tick landing after `~ParkedTabs` no-ops regardless of who owns the aggregate.

<details><summary>日本語</summary>

park スタック・期限タイマー・redo 候補・sliding 再アームは `Tabs/ParkedTabs.h` に集約した (`Tabs` / `WindowCloseGate` と同じ流儀)。MainWindow に残るのはウインドウの形をしたものだけ — タブストリップの出し入れ、panel の表示、外観の restate、期限時の teardown コールバック。タイマーの tick は liveness token を持つので、`~ParkedTabs` 後に着弾しても no-op になる。

</details>

## Why "park", not upstream's "UndoState"

macOS holds a different thing under a different name: its `UndoState` is a snapshot struct (live `surfaceTree` + frame + tab index) captured into the undo closure while the window/controller is **really destroyed** — undo rebuilds the chrome from the state, and expiry is just the closure (and with it the last surface reference) being dropped. This port instead keeps the whole `Tab` alive — item, panel, swap chains — because unparenting a live SwapChainPanel is exactly the teardown-ordering contract (+0x1F8) the close paths exist to respect; hiding is the safe Windows move. That object is not a state snapshot, it is the real thing idling at the curb — hence *parked*. Borrowing `UndoState` for a mechanism this different would mislead more than it aligns.

<details><summary>日本語</summary>

macOS が持っているのは別物で、名前も別。あちらの `UndoState` は生きた `surfaceTree` + frame + タブ位置のスナップショット struct を undo クロージャに捕獲させ、window/controller は**本当に破壊**する。undo は state から chrome を作り直し、期限切れはクロージャ (と surface への最後の参照) が捨てられるだけ。この port は Tab を丸ごと — item も panel も swap chain も — 生かしておく。生きた SwapChainPanel の unparent は close 経路が守っている破棄順序契約 (+0x1F8) にまさに触れる操作で、Windows では「隠す」が安全側だから。あれは状態のスナップショットではなく、実体がエンジンをかけたまま停まっている。だから *park*。仕組みがこれだけ違うのに `UndoState` の名前だけ借りると、揃うより誤解のほうが大きい。

</details>
