### PR TITLE
Snap interactive window resizing to the cell grid

### DIFF
--- a/App/MainWindow.xaml.cpp
+++ b/App/MainWindow.xaml.cpp
@@ -1647,6 +1647,17 @@ namespace winrt::GhosttyWin32::implementation
         m_sizeLimit.Apply(m_hwnd, limit);
     }
 
+    void MainWindow::ApplyCellSizeForSurface(ghostty_surface_t surface,
+                                             ghostty_action_cell_size_s cell)
+    {
+        // Multi-window routing: every window sees the dispatched
+        // call; only the owner of the surface updates its snap
+        // step. Panes within one window share the font config, so
+        // whichever pane reported last is the right step anyway.
+        if (!m_tabs.FindBySurface(surface)) return;
+        m_cellSize.Apply(m_hwnd, cell);
+    }
+
     void MainWindow::ToggleFullscreen()
     {
         m_fullscreen.Toggle(m_hwnd);

--- a/App/MainWindow.xaml.cpp
+++ b/App/MainWindow.xaml.cpp
@@ -1656,6 +1656,10 @@ namespace winrt::GhosttyWin32::implementation
         // whichever pane reported last is the right step anyway.
         if (!m_tabs.FindBySurface(surface)) return;
         m_cellSize.Apply(m_hwnd, cell);
+        if (m_ghosttyApp) {
+            m_cellSize.SetEnabled(ghostty::Config(m_ghosttyApp->ConfigHandle())
+                                      .WindowStepResize());
+        }
     }
 
     void MainWindow::ToggleFullscreen()
@@ -2101,6 +2105,11 @@ namespace winrt::GhosttyWin32::implementation
     void MainWindow::ReplaceConfig(ghostty_config_t cloned)
     {
         m_ghosttyApp->ReplaceConfig(cloned);
+        // window-step-resize can be toggled by itself; CELL_SIZE
+        // only re-fires on metric changes, so re-read the gate here
+        // so a reload flips snapping immediately (#155).
+        m_cellSize.SetEnabled(ghostty::Config(m_ghosttyApp->ConfigHandle())
+                                  .WindowStepResize());
     }
 
     void MainWindow::ReloadConfig(bool soft)

--- a/App/MainWindow.xaml.cpp
+++ b/App/MainWindow.xaml.cpp
@@ -94,6 +94,11 @@ namespace winrt::GhosttyWin32::implementation
             if (App::g_app) App::g_app->Windows().Register(this);
             auto windowNative = this->try_as<::IWindowNative>();
             if (windowNative) windowNative->get_WindowHandle(&m_hwnd);
+            // A drop-outside tear-out host adopts its tab (which
+            // arms the cell-snap metrics) BEFORE this first
+            // activation assigns the HWND — complete the deferred
+            // subclass install now (#155).
+            m_cellSize.Attach(m_hwnd);
             // The pre-first-frame hide avoids flashing an empty window
             // before ghostty presents. A drop host receives a tab that
             // is already presenting, so it has frames to show from the
@@ -1650,10 +1655,12 @@ namespace winrt::GhosttyWin32::implementation
     void MainWindow::ApplyCellSizeForSurface(ghostty_surface_t surface,
                                              ghostty_action_cell_size_s cell)
     {
-        // Multi-window routing: every window sees the dispatched
-        // call; only the owner of the surface updates its snap
-        // step. Panes within one window share the font config, so
-        // whichever pane reported last is the right step anyway.
+        // MainWindowRuntime routes surface-targeted actions to the
+        // owning window, so this call already lands on the right
+        // MainWindow; the FindBySurface guard only screens the brief
+        // creation window before the tab is registered. Panes within
+        // one window share the font config, so whichever pane
+        // reported last is the right step anyway.
         if (!m_tabs.FindBySurface(surface)) {
             UNDO_PARK_TRACE(L"CellSnap[%llu]: CELL_SIZE %ux%u for surface=%p "
                             L"not in this window, skipped\n",
@@ -1661,6 +1668,12 @@ namespace winrt::GhosttyWin32::implementation
                             cell.height, static_cast<void*>(surface));
             return;
         }
+        ArmCellSnap(cell);
+    }
+
+    void MainWindow::ArmCellSnap(ghostty_action_cell_size_s cell)
+    {
+        if (cell.width == 0 || cell.height == 0) return;
         m_cellSize.Apply(m_hwnd, cell);
         if (m_ghosttyApp) {
             const bool enabled =
@@ -2718,6 +2731,14 @@ namespace winrt::GhosttyWin32::implementation
         tab->Panel().Visibility(winrt::Microsoft::UI::Xaml::Visibility::Collapsed);
         AppContent().Children().Append(tab->Panel());
         auto selected = tab->Item();
+        // Query before the move below: the adopted surfaces are the
+        // source of truth for their own cell metrics
+        // (ghostty_surface_size), no carried state needed.
+        ghostty_action_cell_size_s adoptedCell{};
+        if (auto* tc = tab->ActiveControl()) {
+            auto size = tc->Surface().Size();
+            adoptedCell = { size.cell_width_px, size.cell_height_px };
+        }
         m_tabs.Add(std::move(tab));
         tv.SelectedItem(selected);
         UpdateActivePanelVisibility();
@@ -2731,6 +2752,11 @@ namespace winrt::GhosttyWin32::implementation
         // opacity mode (#69 — window-scoped state); restate this
         // window's mode over the whole tab set.
         ApplyBackgroundOpacityAppearance();
+        // Arm resize snapping from the queried metrics: the adopted
+        // surfaces already reported CELL_SIZE in their previous
+        // window and ghostty won't re-report on a move, so a fresh
+        // tear-out window would otherwise never snap (#155).
+        ArmCellSnap(adoptedCell);
     }
 
     void MainWindow::CloseIfTornOutEmpty()

--- a/App/MainWindow.xaml.cpp
+++ b/App/MainWindow.xaml.cpp
@@ -1654,11 +1654,21 @@ namespace winrt::GhosttyWin32::implementation
         // call; only the owner of the surface updates its snap
         // step. Panes within one window share the font config, so
         // whichever pane reported last is the right step anyway.
-        if (!m_tabs.FindBySurface(surface)) return;
+        if (!m_tabs.FindBySurface(surface)) {
+            UNDO_PARK_TRACE(L"CellSnap[%llu]: CELL_SIZE %ux%u for surface=%p "
+                            L"not in this window, skipped\n",
+                            GetTickCount64() % 100'000, cell.width,
+                            cell.height, static_cast<void*>(surface));
+            return;
+        }
         m_cellSize.Apply(m_hwnd, cell);
         if (m_ghosttyApp) {
-            m_cellSize.SetEnabled(ghostty::Config(m_ghosttyApp->ConfigHandle())
-                                      .WindowStepResize());
+            const bool enabled =
+                ghostty::Config(m_ghosttyApp->ConfigHandle()).WindowStepResize();
+            m_cellSize.SetEnabled(enabled);
+            UNDO_PARK_TRACE(L"CellSnap[%llu]: applied %ux%u enabled=%d\n",
+                            GetTickCount64() % 100'000, cell.width,
+                            cell.height, enabled ? 1 : 0);
         }
     }
 
@@ -2108,8 +2118,11 @@ namespace winrt::GhosttyWin32::implementation
         // window-step-resize can be toggled by itself; CELL_SIZE
         // only re-fires on metric changes, so re-read the gate here
         // so a reload flips snapping immediately (#155).
-        m_cellSize.SetEnabled(ghostty::Config(m_ghosttyApp->ConfigHandle())
-                                  .WindowStepResize());
+        const bool enabled =
+            ghostty::Config(m_ghosttyApp->ConfigHandle()).WindowStepResize();
+        m_cellSize.SetEnabled(enabled);
+        UNDO_PARK_TRACE(L"CellSnap[%llu]: config replaced, enabled=%d\n",
+                        GetTickCount64() % 100'000, enabled ? 1 : 0);
     }
 
     void MainWindow::ReloadConfig(bool soft)

--- a/App/MainWindow.xaml.h
+++ b/App/MainWindow.xaml.h
@@ -149,6 +149,11 @@ namespace winrt::GhosttyWin32::implementation
         // belongs to this window.
         void ApplyCellSizeForSurface(ghostty_surface_t surface,
                                      ghostty_action_cell_size_s cell) override;
+        // Shared tail of the surface report and the adopt-time
+        // re-arm: update the WM_SIZING snapping tag with the metrics
+        // and re-read the window-step-resize gate. No-op on {0,0}
+        // (nothing reported yet).
+        void ArmCellSnap(ghostty_action_cell_size_s cell);
 
         // Terminal-driven appearance / lifecycle overrides. Bodies
         // are in MainWindow.xaml.cpp; the logic moved verbatim

--- a/App/MainWindow.xaml.h
+++ b/App/MainWindow.xaml.h
@@ -2,6 +2,7 @@
 
 #include "MainWindow.g.h"
 #include "ghostty.h"
+#include "Ghostty/Actions/Tags/CellSize.h"
 #include "Ghostty/Actions/Tags/Fullscreen.h"
 #include "Ghostty/Actions/Tags/SizeLimit.h"
 #include "Ghostty/Actions/Tags/WindowDecorations.h"
@@ -142,6 +143,12 @@ namespace winrt::GhosttyWin32::implementation
         // most recently restored.
         void Undo() override;
         void Redo() override;
+
+        // Snap-to-cell window resizing (#155): route the CELL_SIZE
+        // report to the WM_SIZING snapping tag when the surface
+        // belongs to this window.
+        void ApplyCellSizeForSurface(ghostty_surface_t surface,
+                                     ghostty_action_cell_size_s cell) override;
 
         // Terminal-driven appearance / lifecycle overrides. Bodies
         // are in MainWindow.xaml.cpp; the logic moved verbatim
@@ -365,6 +372,7 @@ namespace winrt::GhosttyWin32::implementation
         // by SizeLimit are auto-removed by Win32 when m_hwnd is
         // destroyed, so no explicit teardown ordering is needed.
         ghostty::actions::tags::SizeLimit          m_sizeLimit;
+        ghostty::actions::tags::CellSize           m_cellSize;
         ghostty::actions::tags::Fullscreen         m_fullscreen;
         ghostty::actions::tags::WindowDecorations  m_windowDecorations;
         Tabs m_tabs;

--- a/Core/Core.vcxproj
+++ b/Core/Core.vcxproj
@@ -86,6 +86,7 @@
   <ItemGroup>
     <ClInclude Include="Ghostty\Actions\Actions.h" />
     <ClInclude Include="Ghostty\Actions\Tags\Fullscreen.h" />
+    <ClInclude Include="Ghostty\Actions\Tags\CellSize.h" />
     <ClInclude Include="Ghostty\Actions\Tags\SizeLimit.h" />
     <ClInclude Include="Ghostty\Actions\Tags\TriggerLabel.h" />
     <ClInclude Include="Ghostty\Actions\Tags\WindowDecorations.h" />
@@ -106,6 +107,7 @@
   <ItemGroup>
     <ClCompile Include="Ghostty\Actions\Actions.cpp" />
     <ClCompile Include="Ghostty\Actions\Tags\Fullscreen.cpp" />
+    <ClCompile Include="Ghostty\Actions\Tags\CellSize.cpp" />
     <ClCompile Include="Ghostty\Actions\Tags\SizeLimit.cpp" />
     <ClCompile Include="Ghostty\Actions\Tags\TriggerLabel.cpp" />
     <ClCompile Include="Ghostty\CallbackDispatcher.cpp" />

--- a/Core/Ghostty/Actions/Actions.cpp
+++ b/Core/Ghostty/Actions/Actions.cpp
@@ -500,6 +500,15 @@ bool Actions::OnRedo() {
     return true;
 }
 
+bool Actions::OnCellSize(ghostty_surface_t surface,
+                         ghostty_action_cell_size_s cell) {
+    if (!surface) return true;
+    DispatchToView([this, surface, cell]() {
+        m_view.ApplyCellSizeForSurface(surface, cell);
+    });
+    return true;
+}
+
 bool Actions::OnReloadConfig(bool soft) {
     // The view-side implementation handles thread placement
     // (soft re-uses UI thread, hard spins a 4MB-stack worker

--- a/Core/Ghostty/Actions/Actions.h
+++ b/Core/Ghostty/Actions/Actions.h
@@ -156,6 +156,8 @@ public:
     bool OnToggleBackgroundOpacity();
     bool OnUndo();
     bool OnRedo();
+    bool OnCellSize(ghostty_surface_t surface,
+                    ghostty_action_cell_size_s cell);
     bool OnReloadConfig(bool soft);
     bool OnConfigChange(ghostty_config_t newCfg);
     bool OnDesktopNotification(ghostty_surface_t surface,

--- a/Core/Ghostty/Actions/Tags/CellSize.cpp
+++ b/Core/Ghostty/Actions/Tags/CellSize.cpp
@@ -33,7 +33,13 @@ LONG SnapEdge(LONG anchor, LONG moving, LONG step, int direction) noexcept
 void CellSize::Apply(HWND hwnd, ghostty_action_cell_size_s cell) noexcept
 {
     m_value = cell;
+    Attach(hwnd);
+}
+
+void CellSize::Attach(HWND hwnd) noexcept
+{
     if (m_subclassed || !hwnd) return;
+    if (m_value.width == 0 || m_value.height == 0) return;
     if (SetWindowSubclass(hwnd, &SubclassProc, 1,
                           reinterpret_cast<DWORD_PTR>(this))) {
         m_subclassed = true;

--- a/Core/Ghostty/Actions/Tags/CellSize.cpp
+++ b/Core/Ghostty/Actions/Tags/CellSize.cpp
@@ -43,6 +43,20 @@ LRESULT CALLBACK CellSize::SubclassProc(
     HWND hwnd, UINT msg, WPARAM wp, LPARAM lp,
     UINT_PTR /*id*/, DWORD_PTR ref) noexcept
 {
+#if defined(_DEBUG)
+    // Diagnostic (pre-merge): one line per interactive sizing loop
+    // showing what the subclass sees, to pin down why snapping can
+    // go quiet after a new tab even though the gate reads enabled.
+    if (msg == WM_ENTERSIZEMOVE) {
+        auto* self = reinterpret_cast<CellSize*>(ref);
+        wchar_t buf[128];
+        swprintf_s(buf, L"CellSnap: sizing loop enter, enabled=%d cell=%ux%u\n",
+                   self && self->m_enabled ? 1 : 0,
+                   self ? self->m_value.width : 0,
+                   self ? self->m_value.height : 0);
+        OutputDebugStringW(buf);
+    }
+#endif
     if (msg == WM_SIZING) {
         auto* self = reinterpret_cast<CellSize*>(ref);
         auto* drag = reinterpret_cast<RECT*>(lp);

--- a/Core/Ghostty/Actions/Tags/CellSize.cpp
+++ b/Core/Ghostty/Actions/Tags/CellSize.cpp
@@ -47,7 +47,7 @@ LRESULT CALLBACK CellSize::SubclassProc(
         auto* self = reinterpret_cast<CellSize*>(ref);
         auto* drag = reinterpret_cast<RECT*>(lp);
         RECT cur{};
-        if (self && drag && GetWindowRect(hwnd, &cur)) {
+        if (self && self->m_enabled && drag && GetWindowRect(hwnd, &cur)) {
             const LONG cw = static_cast<LONG>(self->m_value.width);
             const LONG ch = static_cast<LONG>(self->m_value.height);
             // Snap the delta from the current rect on whichever

--- a/Core/Ghostty/Actions/Tags/CellSize.cpp
+++ b/Core/Ghostty/Actions/Tags/CellSize.cpp
@@ -1,5 +1,6 @@
 #include "CellSize.h"
 #include <cmath>
+#include <cwchar>
 #include <commctrl.h>
 
 #pragma comment(lib, "comctl32.lib")

--- a/Core/Ghostty/Actions/Tags/CellSize.cpp
+++ b/Core/Ghostty/Actions/Tags/CellSize.cpp
@@ -1,4 +1,5 @@
 #include "CellSize.h"
+#include <cmath>
 #include <commctrl.h>
 
 #pragma comment(lib, "comctl32.lib")
@@ -11,14 +12,18 @@ namespace {
 // `step`, rounding to the nearest multiple. `direction` is +1 when
 // the moving edge grows away from the anchor toward positive
 // coordinates (right/bottom edges), -1 otherwise (left/top).
+//
+// `span` is the DRAG DELTA, not a size: it is legitimately
+// negative when the user is shrinking the window, so it must not
+// be clamped (clamping made resize grow-only) and the rounding
+// must be symmetric around zero — integer division truncates
+// toward zero and would bias the negative side, hence lround.
 LONG SnapEdge(LONG anchor, LONG moving, LONG step, int direction) noexcept
 {
     if (step <= 0) return moving;
     LONG span = (moving - anchor) * direction;
-    // Round half up to the nearest step; span is a window size so
-    // it is non-negative in practice, but guard anyway.
-    if (span < 0) span = 0;
-    LONG snapped = ((span + step / 2) / step) * step;
+    LONG snapped = static_cast<LONG>(
+        std::lround(static_cast<double>(span) / step) * step);
     return anchor + snapped * direction;
 }
 

--- a/Core/Ghostty/Actions/Tags/CellSize.cpp
+++ b/Core/Ghostty/Actions/Tags/CellSize.cpp
@@ -1,0 +1,90 @@
+#include "CellSize.h"
+#include <commctrl.h>
+
+#pragma comment(lib, "comctl32.lib")
+
+namespace core::ghostty::actions::tags {
+
+namespace {
+
+// Snap `moving` so that (moving - anchor) is a whole multiple of
+// `step`, rounding to the nearest multiple. `direction` is +1 when
+// the moving edge grows away from the anchor toward positive
+// coordinates (right/bottom edges), -1 otherwise (left/top).
+LONG SnapEdge(LONG anchor, LONG moving, LONG step, int direction) noexcept
+{
+    if (step <= 0) return moving;
+    LONG span = (moving - anchor) * direction;
+    // Round half up to the nearest step; span is a window size so
+    // it is non-negative in practice, but guard anyway.
+    if (span < 0) span = 0;
+    LONG snapped = ((span + step / 2) / step) * step;
+    return anchor + snapped * direction;
+}
+
+}  // namespace
+
+void CellSize::Apply(HWND hwnd, ghostty_action_cell_size_s cell) noexcept
+{
+    m_value = cell;
+    if (m_subclassed || !hwnd) return;
+    if (SetWindowSubclass(hwnd, &SubclassProc, 1,
+                          reinterpret_cast<DWORD_PTR>(this))) {
+        m_subclassed = true;
+    }
+}
+
+LRESULT CALLBACK CellSize::SubclassProc(
+    HWND hwnd, UINT msg, WPARAM wp, LPARAM lp,
+    UINT_PTR /*id*/, DWORD_PTR ref) noexcept
+{
+    if (msg == WM_SIZING) {
+        auto* self = reinterpret_cast<CellSize*>(ref);
+        auto* drag = reinterpret_cast<RECT*>(lp);
+        RECT cur{};
+        if (self && drag && GetWindowRect(hwnd, &cur)) {
+            const LONG cw = static_cast<LONG>(self->m_value.width);
+            const LONG ch = static_cast<LONG>(self->m_value.height);
+            // Snap the delta from the current rect on whichever
+            // edges this drag moves. The current rect was itself
+            // produced by the previous snapped WM_SIZING, so the
+            // grid stays coherent through the whole sizing loop.
+            switch (wp) {
+                case WMSZ_LEFT:
+                case WMSZ_TOPLEFT:
+                case WMSZ_BOTTOMLEFT:
+                    drag->left = SnapEdge(cur.left, drag->left, cw, -1);
+                    break;
+                default: break;
+            }
+            switch (wp) {
+                case WMSZ_RIGHT:
+                case WMSZ_TOPRIGHT:
+                case WMSZ_BOTTOMRIGHT:
+                    drag->right = SnapEdge(cur.right, drag->right, cw, +1);
+                    break;
+                default: break;
+            }
+            switch (wp) {
+                case WMSZ_TOP:
+                case WMSZ_TOPLEFT:
+                case WMSZ_TOPRIGHT:
+                    drag->top = SnapEdge(cur.top, drag->top, ch, -1);
+                    break;
+                default: break;
+            }
+            switch (wp) {
+                case WMSZ_BOTTOM:
+                case WMSZ_BOTTOMLEFT:
+                case WMSZ_BOTTOMRIGHT:
+                    drag->bottom = SnapEdge(cur.bottom, drag->bottom, ch, +1);
+                    break;
+                default: break;
+            }
+            return TRUE;  // WM_SIZING contract: TRUE = rect adjusted
+        }
+    }
+    return DefSubclassProc(hwnd, msg, wp, lp);
+}
+
+}  // namespace core::ghostty::actions::tags

--- a/Core/Ghostty/Actions/Tags/CellSize.h
+++ b/Core/Ghostty/Actions/Tags/CellSize.h
@@ -36,12 +36,18 @@ public:
     // that axis (defensive — the renderer always reports both).
     void Apply(HWND hwnd, ghostty_action_cell_size_s cell) noexcept;
 
+    // Gate from `window-step-resize` (upstream default: false).
+    // The metrics keep flowing regardless so a config toggle takes
+    // effect instantly without waiting for the next CELL_SIZE.
+    void SetEnabled(bool enabled) noexcept { m_enabled = enabled; }
+
 private:
     static LRESULT CALLBACK SubclassProc(
         HWND hwnd, UINT msg, WPARAM wp, LPARAM lp,
         UINT_PTR id, DWORD_PTR ref) noexcept;
 
     ghostty_action_cell_size_s m_value{};
+    bool m_enabled = false;
     bool m_subclassed = false;
 };
 

--- a/Core/Ghostty/Actions/Tags/CellSize.h
+++ b/Core/Ghostty/Actions/Tags/CellSize.h
@@ -34,7 +34,17 @@ public:
     // Update the active cell metrics and install the subclass on
     // first use. Zero in either dimension disables snapping on
     // that axis (defensive — the renderer always reports both).
+    // A null hwnd still records the metrics; call Attach once the
+    // HWND exists to complete the install.
     void Apply(HWND hwnd, ghostty_action_cell_size_s cell) noexcept;
+
+    // Late subclass install for the adopt-before-activation order:
+    // a fresh tear-out host adopts its tab (and arms the metrics)
+    // BEFORE first activation assigns the HWND, so the owner calls
+    // this when the HWND finally exists. No-op when already
+    // installed or when no metrics have been recorded yet (windows
+    // that never saw a CELL_SIZE keep paying no subclass cost).
+    void Attach(HWND hwnd) noexcept;
 
     // Gate from `window-step-resize` (upstream default: false).
     // The metrics keep flowing regardless so a config toggle takes

--- a/Core/Ghostty/Actions/Tags/CellSize.h
+++ b/Core/Ghostty/Actions/Tags/CellSize.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include "ghostty.h"
+#include <windows.h>
+
+namespace core::ghostty::actions::tags {
+
+// CELL_SIZE action value (the cell's pixel dimensions) plus the
+// WM_SIZING subclass that snaps interactive window resizing to the
+// cell grid — the Win32 counterpart of macOS's
+// contentResizeIncrements (#155). Named after the ghostty action
+// tag, same convention as SizeLimit: the class is "the CELL_SIZE
+// thing".
+//
+// Snapping is RELATIVE: each WM_SIZING adjusts the dragged edge so
+// the size delta from the current window rect is a whole number of
+// cells. That gives the increment "detent" feel without the tag
+// having to know anything about window chrome, the tab strip, or
+// padding — and because the renderer reports the cell size in
+// physical pixels for the current DPI, per-monitor DPI changes are
+// handled by ghostty re-reporting CELL_SIZE.
+//
+// The subclass installs lazily on the first Apply so windows that
+// never receive a CELL_SIZE don't pay the subclass cost. Win32
+// auto-removes subclasses when the HWND is destroyed, so no
+// explicit teardown is needed. Maximize and fullscreen never enter
+// the interactive sizing loop, so no guard is needed there.
+class CellSize {
+public:
+    CellSize() = default;
+    CellSize(const CellSize&) = delete;
+    CellSize& operator=(const CellSize&) = delete;
+
+    // Update the active cell metrics and install the subclass on
+    // first use. Zero in either dimension disables snapping on
+    // that axis (defensive — the renderer always reports both).
+    void Apply(HWND hwnd, ghostty_action_cell_size_s cell) noexcept;
+
+private:
+    static LRESULT CALLBACK SubclassProc(
+        HWND hwnd, UINT msg, WPARAM wp, LPARAM lp,
+        UINT_PTR id, DWORD_PTR ref) noexcept;
+
+    ghostty_action_cell_size_s m_value{};
+    bool m_subclassed = false;
+};
+
+}  // namespace core::ghostty::actions::tags

--- a/Core/Ghostty/CallbackDispatcher.cpp
+++ b/Core/Ghostty/CallbackDispatcher.cpp
@@ -234,8 +234,13 @@ bool CallbackDispatcher::DispatchAction(ghostty_target_s target, ghostty_action_
         // macOS-only quit countdown — Windows already quits on
         // last-HWND-gone via CLOSE_WINDOW:
         case GHOSTTY_ACTION_QUIT_TIMER:
-        // Cell metrics — no host-side consumer today:
+            return true;
+
+        // Cell metrics: feeds snap-to-cell window resizing (#155).
         case GHOSTTY_ACTION_CELL_SIZE:
+            if (target.tag == GHOSTTY_TARGET_SURFACE)
+                return m_actions.OnCellSize(target.target.surface,
+                                            action.action.cell_size);
             return true;
 
         default:

--- a/Core/Ghostty/Config.h
+++ b/Core/Ghostty/Config.h
@@ -98,6 +98,16 @@ public:
         return static_cast<uint64_t>(ms);
     }
 
+    // `window-step-resize` — snap interactive window resizing to
+    // the cell grid (#155). Upstream default is false (smooth
+    // pixel resizing) with snapping as an opt-in, and this port
+    // matches that.
+    bool WindowStepResize() const noexcept {
+        bool v = false;
+        GetRaw("window-step-resize", &v);
+        return v;
+    }
+
     // ----- notify-on-command-finish (v1.3.0+, default: never) -----
     // The whole feature is opt-in; every getter falls back to the
     // documented default when the key is unreadable.

--- a/Core/Ghostty/Surface.h
+++ b/Core/Ghostty/Surface.h
@@ -151,6 +151,16 @@ public:
         return m_handle && ghostty_surface_process_exited(m_handle);
     }
 
+    // Current grid/pixel dimensions, including the cell's pixel
+    // size. The PULL counterpart of the CELL_SIZE action: hosts
+    // that gain an already-running surface (tear-out adoption)
+    // query here instead of waiting for a report that will never
+    // re-fire (#155).
+    ghostty_surface_size_s Size() const noexcept {
+        return m_handle ? ghostty_surface_size(m_handle)
+                        : ghostty_surface_size_s{};
+    }
+
     // ---- selection ----
     bool HasSelection() const noexcept {
         return m_handle && ghostty_surface_has_selection(m_handle);

--- a/Core/Host/IWindow.h
+++ b/Core/Host/IWindow.h
@@ -161,6 +161,13 @@ struct IWindow {
     virtual void Undo() = 0;
     virtual void Redo() = 0;
 
+    // Latest cell pixel dimensions for a surface this window owns
+    // (CELL_SIZE action). Feeds snap-to-cell window resizing: the
+    // window that owns the surface updates its WM_SIZING snapping
+    // step; windows that don't own it ignore the call (#155).
+    virtual void ApplyCellSizeForSurface(ghostty_surface_t surface,
+                                         ghostty_action_cell_size_s cell) = 0;
+
     // Bring the window to the foreground (restoring it from a
     // minimized state first) and give it focus. Used by
     // PRESENT_TERMINAL — typically triggered by an external

--- a/Tests/MockMainWindowView.h
+++ b/Tests/MockMainWindowView.h
@@ -140,6 +140,16 @@ struct MockMainWindowView : core::host::IWindow {
     int redoCalls = 0;
     void Redo() override { ++redoCalls; }
 
+    int applyCellSizeCalls = 0;
+    ghostty_surface_t lastCellSizeSurface = nullptr;
+    ghostty_action_cell_size_s lastCellSize{};
+    void ApplyCellSizeForSurface(ghostty_surface_t surface,
+                                 ghostty_action_cell_size_s cell) override {
+        ++applyCellSizeCalls;
+        lastCellSizeSurface = surface;
+        lastCellSize = cell;
+    }
+
     int setFloatOnTopCalls = 0;
     ghostty_action_float_window_e lastFloatOnTopMode{};
     void SetFloatOnTop(ghostty_action_float_window_e mode) override {

--- a/Tests/test_ghostty_actions.cpp
+++ b/Tests/test_ghostty_actions.cpp
@@ -541,6 +541,24 @@ TEST(GhosttyActionsTest, OnUndoRedoAskTheView) {
     EXPECT_EQ(view.redoCalls, 1);
 }
 
+TEST(GhosttyActionsTest, OnCellSizePassesSurfaceAndMetrics) {
+    MockMainWindowView view;
+    Actions actions(view);
+    auto surface = reinterpret_cast<ghostty_surface_t>(0xBEEF);
+    EXPECT_TRUE(actions.OnCellSize(surface, { 9, 21 }));
+    EXPECT_EQ(view.applyCellSizeCalls, 1);
+    EXPECT_EQ(view.lastCellSizeSurface, surface);
+    EXPECT_EQ(view.lastCellSize.width, 9u);
+    EXPECT_EQ(view.lastCellSize.height, 21u);
+}
+
+TEST(GhosttyActionsTest, OnCellSizeNullSurfaceIsAckedNotDelivered) {
+    MockMainWindowView view;
+    Actions actions(view);
+    EXPECT_TRUE(actions.OnCellSize(nullptr, { 9, 21 }));
+    EXPECT_EQ(view.applyCellSizeCalls, 0);
+}
+
 TEST(GhosttyActionsTest, OnReloadConfigPassesSoftFlagThrough) {
     MockMainWindowView view;
     Actions actions(view);

--- a/Tests/test_ghostty_callback_dispatcher.cpp
+++ b/Tests/test_ghostty_callback_dispatcher.cpp
@@ -75,8 +75,30 @@ TEST(GhosttyCallbackDispatcherTest, NoConsumerAcksReturnTrue) {
     EXPECT_TRUE(DispatchTag(*d, GHOSTTY_ACTION_SCROLLBAR));
     // QUIT_TIMER: macOS-only quit countdown.
     EXPECT_TRUE(DispatchTag(*d, GHOSTTY_ACTION_QUIT_TIMER));
-    // CELL_SIZE: cached but no host-side consumer yet.
+}
+
+TEST(GhosttyCallbackDispatcherTest, CellSizeRoutesToTheView) {
+    // Formerly a no-consumer ack; #155 wires it to the snap-to-cell
+    // resize step. Surface-targeted delivery routes; the app-target
+    // form has no owning window and stays an ack.
+    MockMainWindowView view;
+    auto d = CallbackDispatcher::Create(view);
+
+    ghostty_target_s target{};
+    target.tag = GHOSTTY_TARGET_SURFACE;
+    target.target.surface = reinterpret_cast<ghostty_surface_t>(0xBEEF);
+    ghostty_action_s action{};
+    action.tag = GHOSTTY_ACTION_CELL_SIZE;
+    action.action.cell_size = { 9, 21 };
+
+    EXPECT_TRUE(d->DispatchAction(target, action));
+    EXPECT_EQ(view.applyCellSizeCalls, 1);
+    EXPECT_EQ(view.lastCellSizeSurface, target.target.surface);
+    EXPECT_EQ(view.lastCellSize.width, 9u);
+    EXPECT_EQ(view.lastCellSize.height, 21u);
+
     EXPECT_TRUE(DispatchTag(*d, GHOSTTY_ACTION_CELL_SIZE));
+    EXPECT_EQ(view.applyCellSizeCalls, 1);
 }
 
 TEST(GhosttyCallbackDispatcherTest, UndoRedoRouteToTheView) {


### PR DESCRIPTION
Closes #155.

## Why

ghostty reports the cell's pixel dimensions (`CELL_SIZE`) after every font/DPI change; macOS feeds it to `contentResizeIncrements` so window resizing steps by whole cells. This port dropped the value — resizing landed on arbitrary pixel sizes with a partial cell at the edge.

<details><summary>日本語</summary>

ghostty はフォント/DPI が変わるたびにセルのピクセル寸法 (`CELL_SIZE`) を報告してくる。macOS はこれを `contentResizeIncrements` に渡してリサイズをセル単位にしている。この port は値を捨てていたので、リサイズは常に中途半端なピクセルサイズに着地して端に欠けたセルが出ていた。

</details>

## Design

- **`CellSize` tag** (`Core/Ghostty/Actions/Tags/CellSize.{h,cpp}`, same shape as `SizeLimit`): lazily-installed `WM_SIZING` subclass that snaps the dragged edges so each size delta is a whole number of cells
- **Relative snapping**: the delta is measured against the current window rect, which the previous snapped `WM_SIZING` produced — the increment "detent" feel with **zero knowledge of window chrome, tab strip, or padding**
- **DPI-safe for free**: the renderer reports the cell size in physical pixels for the current DPI and re-reports on changes; `WM_SIZING` rects are physical pixels
- **Gated on `window-step-resize`** (upstream default: **false** — smooth pixel resizing stays the default, snapping is opt-in, matching upstream's own choice). The gate refreshes on CELL_SIZE arrival and on config replace, so a reload toggles it immediately
- Maximize / fullscreen never enter the interactive sizing loop, so no guard is needed; composes with the `SizeLimit` subclass on the same HWND (min/max clamping happens outside `WM_SIZING`)
- Dispatcher: surface-targeted `CELL_SIZE` routes → `Actions::OnCellSize` → `IWindow::ApplyCellSizeForSurface`; the owning window updates its snap step, other windows ignore the call, and the app-target form stays an ack

<details><summary>日本語</summary>

- **`CellSize` tag** (`SizeLimit` と同形): 初回 Apply で遅延インストールされる `WM_SIZING` subclass が、ドラッグ中の辺を「サイズ差分がセルの整数倍」になるよう丸める
- **相対スナップ**: 差分は現在のウインドウ矩形 (= 直前の snapped `WM_SIZING` の産物) 基準。インクリメントの「カクカク」感が出て、しかも **chrome・タブストリップ・padding の知識が一切不要**
- **DPI はタダで正しい**: renderer は現在 DPI の物理ピクセルでセル寸法を報告し、変化のたびに再報告する。`WM_SIZING` の矩形も物理ピクセル
- **`window-step-resize` でゲート** (本家デフォルト **false** — スムーズなピクセルリサイズが既定で、スナップはオプトイン。本家自身の設計判断に一致)。ゲートは CELL_SIZE 到着時と config 差し替え時に更新されるので、reload だけで即切り替わる
- 最大化 / フルスクリーンは対話リサイズのループ自体に入らないのでガード不要。同じ HWND の `SizeLimit` subclass とも合成される (min/max のクランプは `WM_SIZING` の外側)
- dispatcher: surface ターゲットの `CELL_SIZE` を `Actions::OnCellSize` → `IWindow::ApplyCellSizeForSurface` にルーティング。surface を所有するウインドウだけが snap 步幅を更新し、他のウインドウは無視。app ターゲットは従来どおり ack

</details>

## Found during verification: adopting windows never snapped

`CELL_SIZE` is push-only (surface creation and metric changes) — a torn-out tab moves existing surfaces into a fresh window with no re-report, so the second window's tag had no metrics and no `WM_SIZING` subclass (the sizing-loop trace showed its enter lines simply didn't exist). Fixed without any carried state: `ghostty_surface_size` exposes the cell pixel size as a pull API, so `AdoptTornOutTab` queries the adopted surface (new `Surface::Size`) and arms the tag from the answer — the surface stays the single source of truth. One ordering wrinkle: a drop-outside host adopts **before** its first activation assigns the HWND, so the tag records the metrics and `CellSize::Attach` completes the subclass install once the HWND exists.

<details><summary>日本語</summary>

`CELL_SIZE` は push 型 (surface 生成時と metric 変化時のみ) で、tear-out は既存 surface の引っ越しなので再報告されない。養子先の窓は tag に寸法も `WM_SIZING` subclass も無く、窓 2 だけ永遠にスムーズだった (sizing-loop トレースで enter 行が存在しないことから特定)。持ち回りの状態は作らず、`ghostty_surface_size` (pull API) で養子 surface に直接問い合わせて武装する方式にした — 真実の在処は常に surface 本人。drop-outside の新窓は初回 Activated で HWND が付く**前**に adopt が走るので、tag は寸法だけ記録し、HWND 取得直後に `CellSize::Attach` で subclass を後付けする。

</details>

## Verification

- [x] Tests.exe green (routing + null-surface tests added)
- [x] `window-step-resize` absent/false → resizing is smooth (default unchanged from before this PR)
- [x] `window-step-resize = true` + reload → snapping turns on without restart; comment out + reload → smooth again
- [x] Drag the right/bottom edge slowly → the window steps in cell-sized detents instead of moving smoothly
- [x] Drag the left/top edge → same stepping (opposite edge stays put)
- [x] `font-size` change (e.g. 15 → 24) + reload → the detent step visibly grows
- [x] Maximize, restore, F11 fullscreen and back → unaffected
- [x] Second window (tear-out or new_window) → snaps independently with its own step

<details><summary>日本語</summary>

- [x] Tests.exe green (ルーティング + null surface のテスト追加済み)
- [x] `window-step-resize` なし/false → リサイズはスムーズ (この PR 以前と同じ既定)
- [x] `window-step-resize = true` + reload → 再起動なしでスナップ ON、コメントアウト + reload → スムーズに戻る
- [x] 右/下端をゆっくりドラッグ → 滑らかではなくセル幅/高さ刻みのカクカクで動く
- [x] 左/上端をドラッグ → 同じ刻み (反対側の辺は動かない)
- [x] `font-size` を変えて reload (例: 15 → 24) → 刻みの一歩が目に見えて大きくなる
- [x] 最大化・復元・F11 フルスクリーン往復 → 影響なし
- [x] 2 枚目のウインドウ (tear-out や new_window) → それぞれ独立に自分の步幅でスナップ

</details>





