### PR TITLE
Show a scrollback scrollbar on each pane

### DIFF
--- a/App/MainWindow.xaml.cpp
+++ b/App/MainWindow.xaml.cpp
@@ -2034,6 +2034,17 @@ namespace winrt::GhosttyWin32::implementation
         });
     }
 
+    void MainWindow::SetScrollbarForSurface(ghostty_surface_t surface,
+                                            ghostty_action_scrollbar_s bar)
+    {
+        // Owning-leaf routing: the viewport belongs to one pane.
+        auto lookup = m_tabs.FindPaneBySurface(surface);
+        if (!lookup.pane) return;
+        if (auto* tc = Tab::PaneToTerminalControl(*lookup.pane)) {
+            tc->SetScrollbar(bar);
+        }
+    }
+
     void MainWindow::SetReadonlyForSurface(ghostty_surface_t surface, bool readonly)
     {
         // Owning-leaf routing: the read-only state belongs to the

--- a/App/MainWindow.xaml.h
+++ b/App/MainWindow.xaml.h
@@ -149,6 +149,8 @@ namespace winrt::GhosttyWin32::implementation
         // belongs to this window.
         void ApplyCellSizeForSurface(ghostty_surface_t surface,
                                      ghostty_action_cell_size_s cell) override;
+        void SetScrollbarForSurface(ghostty_surface_t surface,
+                                    ghostty_action_scrollbar_s bar) override;
         // Shared tail of the surface report and the adopt-time
         // re-arm: update the WM_SIZING snapping tag with the metrics
         // and re-read the window-step-resize gate. No-op on {0,0}

--- a/App/TerminalControl.xaml
+++ b/App/TerminalControl.xaml
@@ -122,5 +122,26 @@
                        TextTrimming="CharacterEllipsis"
                        Foreground="{ThemeResource TextFillColorPrimaryBrush}" />
         </Border>
+        <!--
+          Scrollback scrollbar (SCROLLBAR action, #154). The GTK
+          apprt's overlay scrollbar is the upstream precedent. Unlike
+          every other overlay here this one is hit-test VISIBLE — it
+          is the first in-tree overlay that takes input (thumb drag,
+          track click). Still in-tree, never a popup (#61): an
+          in-tree sibling only intercepts pointer input inside its own
+          narrow bounds, so the SwapChainPanel keeps everything else.
+          Opacity is driven by code: shown on scroll activity and
+          while hovered, faded when idle, and collapsed entirely when
+          there is no scrollback (viewport == total).
+        -->
+        <ScrollBar x:Name="ScrollbackBar"
+                   Orientation="Vertical"
+                   IndicatorMode="MouseIndicator"
+                   HorizontalAlignment="Right"
+                   VerticalAlignment="Stretch"
+                   Visibility="Collapsed"
+                   Opacity="0"
+                   Minimum="0"
+                   SmallChange="1" />
     </Grid>
 </UserControl>

--- a/App/TerminalControl.xaml.cpp
+++ b/App/TerminalControl.xaml.cpp
@@ -309,9 +309,44 @@ namespace winrt::GhosttyWin32::implementation
         // moves over cells) must not resurrect the cursor — the
         // cached value is applied when visibility comes back.
         m_visibleCursor = winrt::Microsoft::UI::Input::InputSystemCursor::Create(mapped);
-        if (!m_cursorHidden) {
-            ProtectedCursor(m_visibleCursor);
+        ApplyCursor();
+    }
+
+    void TerminalControl::ApplyCursor()
+    {
+        // Single writer for ProtectedCursor so the three inputs
+        // compose in one place: the scrollbar's own hover wins with
+        // an Arrow (a text I-beam over a draggable thumb reads wrong
+        // — #170 review), hidden state wins next, else the shape
+        // ghostty last asked for.
+        if (m_scrollbarHovered) {
+            static const auto arrow =
+                winrt::Microsoft::UI::Input::InputSystemCursor::Create(
+                    winrt::Microsoft::UI::Input::InputSystemCursorShape::Arrow);
+            ProtectedCursor(arrow);
+            return;
         }
+        if (m_cursorHidden) {
+            // WinUI 3 has no "hide" on ProtectedCursor: null means
+            // "inherit the parent's cursor" and renders as Arrow
+            // (verified during #60). Hiding is therefore expressed as
+            // showing a fully-transparent cursor embedded as a Win32
+            // resource in the EXE. Created once; UI thread only, so
+            // the local static needs no synchronization.
+            static const auto blank = []() -> winrt::Microsoft::UI::Input::InputCursor {
+                try {
+                    return winrt::Microsoft::UI::Input::InputDesktopResourceCursor::CreateFromModule(
+                        L"GhosttyWin32.exe", IDC_GHOSTTY_BLANK_CURSOR);
+                } catch (winrt::hresult_error const&) {
+                    // Resource lookup failed — degrade to the inherited
+                    // Arrow rather than crashing over a cosmetic feature.
+                    return nullptr;
+                }
+            }();
+            ProtectedCursor(blank);
+            return;
+        }
+        ProtectedCursor(m_visibleCursor);
     }
 
     void TerminalControl::AppendKeySequence(winrt::hstring const& label)
@@ -406,23 +441,7 @@ namespace winrt::GhosttyWin32::implementation
     {
         if (m_cursorHidden == !visible) return;
         m_cursorHidden = !visible;
-        // WinUI 3 has no "hide" on ProtectedCursor: null means
-        // "inherit the parent's cursor" and renders as Arrow
-        // (verified during #60). Hiding is therefore expressed as
-        // showing a fully-transparent cursor embedded as a Win32
-        // resource in the EXE. Created once; UI thread only, so the
-        // local static needs no synchronization.
-        static const auto blank = []() -> winrt::Microsoft::UI::Input::InputCursor {
-            try {
-                return winrt::Microsoft::UI::Input::InputDesktopResourceCursor::CreateFromModule(
-                    L"GhosttyWin32.exe", IDC_GHOSTTY_BLANK_CURSOR);
-            } catch (winrt::hresult_error const&) {
-                // Resource lookup failed — degrade to the inherited
-                // Arrow rather than crashing over a cosmetic feature.
-                return nullptr;
-            }
-        }();
-        ProtectedCursor(visible ? m_visibleCursor : blank);
+        ApplyCursor();
     }
 
     void TerminalControl::SetUnfocusedAppearance(double overlayOpacity,
@@ -481,12 +500,14 @@ namespace winrt::GhosttyWin32::implementation
             if (auto self = weakSelf.get()) {
                 self->m_scrollbarHovered = true;
                 self->RevealScrollbar();
+                self->ApplyCursor();
             }
         });
         bar.PointerExited([weakSelf](auto&&, auto&&) {
             if (auto self = weakSelf.get()) {
                 self->m_scrollbarHovered = false;
                 self->FadeScrollbarIfIdle();
+                self->ApplyCursor();
             }
         });
 

--- a/App/TerminalControl.xaml.cpp
+++ b/App/TerminalControl.xaml.cpp
@@ -8,6 +8,9 @@
 #include "Input/TerminalKeyUp.h"
 #include "Display/PhysicalPixels.h"
 #include "Win32/Clipboard.h"
+#include <algorithm>
+#include <chrono>
+#include <cmath>
 #include <dxgi1_3.h>
 #if __has_include("TerminalControl.g.cpp")
 #include "TerminalControl.g.cpp"
@@ -189,6 +192,8 @@ namespace winrt::GhosttyWin32::implementation
             self->m_surface.MouseScroll(0, scrollY, smods);
             args.Handled(true);
         });
+
+        SetupScrollbar();
 
         // KeyDown / KeyUp on the control itself: the events fire only
         // while focus is inside us, so the handlers feed directly into
@@ -452,6 +457,103 @@ namespace winrt::GhosttyWin32::implementation
         banner.Visibility(winrt::Microsoft::UI::Xaml::Visibility::Visible);
     }
 
+    // ----- scrollback scrollbar (#154) -----
+
+    void TerminalControl::SetupScrollbar()
+    {
+        auto bar = ScrollbackBar();
+        if (!bar) return;
+        auto weakSelf = get_weak();
+
+        // Thumb drag / track click → absolute scroll. Echoes from
+        // SetScrollbar are filtered by m_scrollbarSyncing.
+        bar.ValueChanged([weakSelf](auto&&,
+                Microsoft::UI::Xaml::Controls::Primitives::RangeBaseValueChangedEventArgs const& args) {
+            auto self = weakSelf.get();
+            if (!self || self->m_scrollbarSyncing || !self->m_surface) return;
+            self->m_surface.ScrollToRow(
+                static_cast<uint64_t>(std::llround(args.NewValue())));
+            self->RevealScrollbar();
+        });
+
+        // Hover keeps the bar visible; leaving restarts the idle fade.
+        bar.PointerEntered([weakSelf](auto&&, auto&&) {
+            if (auto self = weakSelf.get()) {
+                self->m_scrollbarHovered = true;
+                self->RevealScrollbar();
+            }
+        });
+        bar.PointerExited([weakSelf](auto&&, auto&&) {
+            if (auto self = weakSelf.get()) {
+                self->m_scrollbarHovered = false;
+                self->FadeScrollbarIfIdle();
+            }
+        });
+
+        // Wheel over the bar itself: forward to the terminal instead
+        // of letting the ScrollBar consume it (its default wheel
+        // handling would scroll by SmallChange and echo through
+        // ValueChanged — correct but jerky).
+        bar.PointerWheelChanged([weakSelf](auto&&,
+                winrt::Microsoft::UI::Xaml::Input::PointerRoutedEventArgs const& args) {
+            auto self = weakSelf.get();
+            if (!self || !self->m_surface) return;
+            auto point = args.GetCurrentPoint(self->Panel());
+            int delta = point.Properties().MouseWheelDelta();
+            ghostty_input_scroll_mods_t smods = {};
+            self->m_surface.MouseScroll(0, static_cast<double>(delta) / 120.0, smods);
+            args.Handled(true);
+        });
+
+        m_scrollbarFadeTimer = DispatcherQueue().CreateTimer();
+        m_scrollbarFadeTimer.Interval(std::chrono::milliseconds{ 1200 });
+        m_scrollbarFadeTimer.IsRepeating(false);
+        m_scrollbarFadeTimer.Tick([weakSelf](auto&&, auto&&) {
+            if (auto self = weakSelf.get()) self->FadeScrollbarIfIdle();
+        });
+    }
+
+    void TerminalControl::SetScrollbar(ghostty_action_scrollbar_s bar)
+    {
+        auto sb = ScrollbackBar();
+        if (!sb) return;
+        // Nothing to scroll: the whole screen fits the viewport.
+        if (bar.total <= bar.len) {
+            sb.Visibility(winrt::Microsoft::UI::Xaml::Visibility::Collapsed);
+            return;
+        }
+        // Range mapping: Value = first visible row, Maximum = the
+        // last first-visible-row (total - len), ViewportSize = len
+        // so the thumb length reflects the visible fraction.
+        const double maximum = static_cast<double>(bar.total - bar.len);
+        const double value = std::min(static_cast<double>(bar.offset), maximum);
+        m_scrollbarSyncing = true;
+        sb.Maximum(maximum);
+        sb.ViewportSize(static_cast<double>(bar.len));
+        sb.LargeChange(static_cast<double>(bar.len));
+        sb.Value(value);
+        m_scrollbarSyncing = false;
+        sb.Visibility(winrt::Microsoft::UI::Xaml::Visibility::Visible);
+        RevealScrollbar();
+    }
+
+    void TerminalControl::RevealScrollbar()
+    {
+        auto sb = ScrollbackBar();
+        if (!sb) return;
+        sb.Opacity(1.0);
+        if (m_scrollbarFadeTimer) {
+            m_scrollbarFadeTimer.Stop();
+            m_scrollbarFadeTimer.Start();
+        }
+    }
+
+    void TerminalControl::FadeScrollbarIfIdle()
+    {
+        if (m_scrollbarHovered) return;
+        if (auto sb = ScrollbackBar()) sb.Opacity(0.0);
+    }
+
     void TerminalControl::ApplyFocusVisual(bool focused)
     {
         auto dim = UnfocusedDim();
@@ -568,6 +670,10 @@ namespace winrt::GhosttyWin32::implementation
 
     void TerminalControl::Detach()
     {
+        // The scrollbar fade timer holds only a weak ref, but stop
+        // it anyway so no tick lands while the control tears down.
+        if (m_scrollbarFadeTimer) m_scrollbarFadeTimer.Stop();
+
         // Cancel the pending SetSwapChainHandle dispatch before we tear
         // down the swap chain — otherwise the queued call could attach
         // a freed handle to the panel after we've destroyed everything.

--- a/App/TerminalControl.xaml.h
+++ b/App/TerminalControl.xaml.h
@@ -214,6 +214,15 @@ namespace winrt::GhosttyWin32::implementation
         // for why this is an in-tree overlay and not a popup (#61).
         void SetHoveredLink(winrt::hstring const& url);
 
+        // Reflect the SCROLLBAR report on the overlay scrollbar
+        // (#154): total scrollback rows, viewport offset, viewport
+        // length. Collapses the bar when nothing is scrollable,
+        // otherwise reveals it and (re)starts the idle fade. UI
+        // thread only. Core-driven updates are guarded so the bar's
+        // ValueChanged does not echo back into a scroll_to_row
+        // (the GTK apprt blocks its adjustment signals the same way).
+        void SetScrollbar(ghostty_action_scrollbar_s bar);
+
         // Set the callback that fires when this control receives
         // keyboard focus. Passed the underlying ghostty surface so
         // the host can update its "currently focused surface"
@@ -313,6 +322,18 @@ namespace winrt::GhosttyWin32::implementation
         void UpdateKeyStateBadge();
         std::vector<winrt::hstring> m_keyTables;
         std::vector<winrt::hstring> m_keySequence;
+
+        // Scrollbar state (#154). m_scrollbarSyncing is set while
+        // SetScrollbar writes the bar's properties so the resulting
+        // ValueChanged is recognised as an echo and not sent back to
+        // ghostty. m_scrollbarHovered keeps the bar visible while the
+        // pointer is over it; the idle timer fades it otherwise.
+        void SetupScrollbar();
+        void RevealScrollbar();
+        void FadeScrollbarIfIdle();
+        bool m_scrollbarSyncing = false;
+        bool m_scrollbarHovered = false;
+        winrt::Microsoft::UI::Dispatching::DispatcherQueueTimer m_scrollbarFadeTimer{ nullptr };
     };
 }
 

--- a/App/TerminalControl.xaml.h
+++ b/App/TerminalControl.xaml.h
@@ -311,6 +311,9 @@ namespace winrt::GhosttyWin32::implementation
         // hidden cursor. See SetMouseVisibility().
         bool m_cursorHidden = false;
         winrt::Microsoft::UI::Input::InputCursor m_visibleCursor{ nullptr };
+        // Single writer for ProtectedCursor: composes the scrollbar
+        // hover (Arrow), hidden state (blank), and ghostty's shape.
+        void ApplyCursor();
 
         // SECURE_INPUT indicator state; owned here so TOGGLE can
         // flip without the dispatcher tracking anything.

--- a/Core/Ghostty/Actions/Actions.cpp
+++ b/Core/Ghostty/Actions/Actions.cpp
@@ -509,6 +509,15 @@ bool Actions::OnCellSize(ghostty_surface_t surface,
     return true;
 }
 
+bool Actions::OnScrollbar(ghostty_surface_t surface,
+                          ghostty_action_scrollbar_s bar) {
+    if (!surface) return true;
+    DispatchToView([this, surface, bar]() {
+        m_view.SetScrollbarForSurface(surface, bar);
+    });
+    return true;
+}
+
 bool Actions::OnReloadConfig(bool soft) {
     // The view-side implementation handles thread placement
     // (soft re-uses UI thread, hard spins a 4MB-stack worker

--- a/Core/Ghostty/Actions/Actions.h
+++ b/Core/Ghostty/Actions/Actions.h
@@ -158,6 +158,8 @@ public:
     bool OnRedo();
     bool OnCellSize(ghostty_surface_t surface,
                     ghostty_action_cell_size_s cell);
+    bool OnScrollbar(ghostty_surface_t surface,
+                     ghostty_action_scrollbar_s bar);
     bool OnReloadConfig(bool soft);
     bool OnConfigChange(ghostty_config_t newCfg);
     bool OnDesktopNotification(ghostty_surface_t surface,

--- a/Core/Ghostty/CallbackDispatcher.cpp
+++ b/Core/Ghostty/CallbackDispatcher.cpp
@@ -229,11 +229,17 @@ bool CallbackDispatcher::DispatchAction(ghostty_target_s target, ghostty_action_
         case GHOSTTY_ACTION_TOGGLE_TAB_OVERVIEW:
         case GHOSTTY_ACTION_TOGGLE_QUICK_TERMINAL:
         case GHOSTTY_ACTION_TOGGLE_COMMAND_PALETTE:
-        // Scroll-position updates — no scrollbar UI to feed:
-        case GHOSTTY_ACTION_SCROLLBAR:
         // macOS-only quit countdown — Windows already quits on
         // last-HWND-gone via CLOSE_WINDOW:
         case GHOSTTY_ACTION_QUIT_TIMER:
+            return true;
+
+        // Scroll-position updates: feeds the pane's overlay
+        // scrollbar (#154). Surface-targeted by construction.
+        case GHOSTTY_ACTION_SCROLLBAR:
+            if (target.tag == GHOSTTY_TARGET_SURFACE)
+                return m_actions.OnScrollbar(target.target.surface,
+                                             action.action.scrollbar);
             return true;
 
         // Cell metrics: feeds snap-to-cell window resizing (#155).

--- a/Core/Ghostty/Surface.h
+++ b/Core/Ghostty/Surface.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "ghostty.h"
+#include <cstdio>
 
 #include <cstdint>
 #include <utility>
@@ -159,6 +160,22 @@ public:
     ghostty_surface_size_s Size() const noexcept {
         return m_handle ? ghostty_surface_size(m_handle)
                         : ghostty_surface_size_s{};
+    }
+
+    // Scroll the viewport to an absolute screen row (0 = the top
+    // of scrollback). Goes through the keybind-action parser
+    // (`scroll_to_row:N`) because that is the only absolute-
+    // position scroll entry point in the C API — the same route
+    // the GTK apprt's scrollbar takes (#154). Returns false if the
+    // action string was rejected.
+    bool ScrollToRow(uint64_t row) noexcept {
+        if (!m_handle) return false;
+        char buf[48];
+        const int n = std::snprintf(buf, sizeof(buf), "scroll_to_row:%llu",
+                                    static_cast<unsigned long long>(row));
+        if (n <= 0) return false;
+        return ghostty_surface_binding_action(
+            m_handle, buf, static_cast<uintptr_t>(n));
     }
 
     // ---- selection ----

--- a/Core/Host/IWindow.h
+++ b/Core/Host/IWindow.h
@@ -236,6 +236,13 @@ struct IWindow {
     virtual void SetReadonlyForSurface(ghostty_surface_t surface,
                                        bool readonly) = 0;
 
+    // Viewport position within the scrollback for a surface this
+    // window owns (SCROLLBAR action: total rows, viewport offset,
+    // viewport length). Feeds the owning pane's overlay scrollbar
+    // (#154). Fires on every scroll and on screen changes.
+    virtual void SetScrollbarForSurface(ghostty_surface_t surface,
+                                        ghostty_action_scrollbar_s bar) = 0;
+
     // COMMAND_FINISHED: a shell-integration-tracked command ended.
     // The view owns the whole policy: it reads the notify-on-
     // command-finish config trio (mode / threshold / actions),

--- a/Tests/MockMainWindowView.h
+++ b/Tests/MockMainWindowView.h
@@ -140,6 +140,16 @@ struct MockMainWindowView : core::host::IWindow {
     int redoCalls = 0;
     void Redo() override { ++redoCalls; }
 
+    int setScrollbarCalls = 0;
+    ghostty_surface_t lastScrollbarSurface = nullptr;
+    ghostty_action_scrollbar_s lastScrollbar{};
+    void SetScrollbarForSurface(ghostty_surface_t surface,
+                                ghostty_action_scrollbar_s bar) override {
+        ++setScrollbarCalls;
+        lastScrollbarSurface = surface;
+        lastScrollbar = bar;
+    }
+
     int applyCellSizeCalls = 0;
     ghostty_surface_t lastCellSizeSurface = nullptr;
     ghostty_action_cell_size_s lastCellSize{};

--- a/Tests/test_ghostty_actions.cpp
+++ b/Tests/test_ghostty_actions.cpp
@@ -552,6 +552,25 @@ TEST(GhosttyActionsTest, OnCellSizePassesSurfaceAndMetrics) {
     EXPECT_EQ(view.lastCellSize.height, 21u);
 }
 
+TEST(GhosttyActionsTest, OnScrollbarPassesSurfaceAndMetrics) {
+    MockMainWindowView view;
+    Actions actions(view);
+    auto surface = reinterpret_cast<ghostty_surface_t>(0xBEEF);
+    EXPECT_TRUE(actions.OnScrollbar(surface, { 1000, 940, 60 }));
+    EXPECT_EQ(view.setScrollbarCalls, 1);
+    EXPECT_EQ(view.lastScrollbarSurface, surface);
+    EXPECT_EQ(view.lastScrollbar.total, 1000u);
+    EXPECT_EQ(view.lastScrollbar.offset, 940u);
+    EXPECT_EQ(view.lastScrollbar.len, 60u);
+}
+
+TEST(GhosttyActionsTest, OnScrollbarNullSurfaceIsAckedNotDelivered) {
+    MockMainWindowView view;
+    Actions actions(view);
+    EXPECT_TRUE(actions.OnScrollbar(nullptr, { 1000, 940, 60 }));
+    EXPECT_EQ(view.setScrollbarCalls, 0);
+}
+
 TEST(GhosttyActionsTest, OnCellSizeNullSurfaceIsAckedNotDelivered) {
     MockMainWindowView view;
     Actions actions(view);

--- a/Tests/test_ghostty_callback_dispatcher.cpp
+++ b/Tests/test_ghostty_callback_dispatcher.cpp
@@ -71,10 +71,33 @@ TEST(GhosttyCallbackDispatcherTest, NoConsumerAcksReturnTrue) {
     MockMainWindowView view;
     auto d = CallbackDispatcher::Create(view);
 
-    // SCROLLBAR: no scrollbar UI to feed.
-    EXPECT_TRUE(DispatchTag(*d, GHOSTTY_ACTION_SCROLLBAR));
     // QUIT_TIMER: macOS-only quit countdown.
     EXPECT_TRUE(DispatchTag(*d, GHOSTTY_ACTION_QUIT_TIMER));
+}
+
+TEST(GhosttyCallbackDispatcherTest, ScrollbarRoutesToTheView) {
+    // Formerly a no-consumer ack; #154 feeds the pane's overlay
+    // scrollbar. Surface-targeted delivery routes; the app-target
+    // form has no owning pane and stays an ack.
+    MockMainWindowView view;
+    auto d = CallbackDispatcher::Create(view);
+
+    ghostty_target_s target{};
+    target.tag = GHOSTTY_TARGET_SURFACE;
+    target.target.surface = reinterpret_cast<ghostty_surface_t>(0xBEEF);
+    ghostty_action_s action{};
+    action.tag = GHOSTTY_ACTION_SCROLLBAR;
+    action.action.scrollbar = { 1000, 940, 60 };
+
+    EXPECT_TRUE(d->DispatchAction(target, action));
+    EXPECT_EQ(view.setScrollbarCalls, 1);
+    EXPECT_EQ(view.lastScrollbarSurface, target.target.surface);
+    EXPECT_EQ(view.lastScrollbar.total, 1000u);
+    EXPECT_EQ(view.lastScrollbar.offset, 940u);
+    EXPECT_EQ(view.lastScrollbar.len, 60u);
+
+    EXPECT_TRUE(DispatchTag(*d, GHOSTTY_ACTION_SCROLLBAR));
+    EXPECT_EQ(view.setScrollbarCalls, 1);
 }
 
 TEST(GhosttyCallbackDispatcherTest, CellSizeRoutesToTheView) {


### PR DESCRIPTION
Closes #154.

## Why

`SCROLLBAR` reports the viewport position on every scroll and the host dropped it — nothing showed where the viewport sat in the scrollback, and the mouse had no way to jump there.

<details><summary>日本語</summary>

`SCROLLBAR` はスクロールのたびに viewport の位置を報告してくるのに、この port は捨てていた。scrollback の中で今どこを見ているかが分からず、マウスで飛ぶ手段もなかった。

</details>

## Design

- **Overlay `ScrollBar`** on `TerminalControl` (right edge, vertical) — the GTK apprt's overlay scrollbar is the upstream precedent. Mapping: `Maximum = total − len`, `ViewportSize = len` (thumb length = visible fraction), `Value = offset`; **collapsed** when the screen fits (`total ≤ len`)
- **First in-tree overlay that takes input** (hit-test visible) — still in-tree, never a popup (#61): a sibling only intercepts pointer input inside its own narrow bounds, so the SwapChainPanel keeps everything else
- **Drag → `scroll_to_row`**: thumb drag / track click land in `ValueChanged` → new `Surface::ScrollToRow(row)` → `ghostty_surface_binding_action("scroll_to_row:N")`. That is the only absolute-position scroll entry in the C API, and the same route the GTK apprt takes
- **Echo guard**: core-driven updates set `m_scrollbarSyncing` around the property writes so the resulting `ValueChanged` is not sent back as a scroll (GTK blocks its adjustment signals the same way — otherwise every report round-trips)
- **Auto-hide**: reveal on any report or drag, keep visible while hovered, fade after 1.2s idle (`DispatcherQueueTimer`, weak-ref tick, stopped in `Detach`)
- Wheel over the bar itself forwards to the terminal instead of the ScrollBar's own SmallChange stepping
- Dispatcher: surface-targeted `SCROLLBAR` routes → `Actions::OnScrollbar` → `IWindow::SetScrollbarForSurface` → owning pane; app-target stays an ack

<details><summary>日本語</summary>

- **`TerminalControl` 右端に縦のオーバーレイ `ScrollBar`** (本家の前例は GTK の overlay scrollbar)。対応は `Maximum = total − len`、`ViewportSize = len` (つまみの長さ = 可視割合)、`Value = offset`。画面が収まるとき (`total ≤ len`) は Collapsed
- **入力を受け取る初めての in-tree オーバーレイ** (hit-test 可視)。それでも in-tree で popup ではない (#61): 兄弟要素は自分の細い矩形内のポインタしか取らないので、SwapChainPanel は他を全部保持する
- **ドラッグ → `scroll_to_row`**: つまみのドラッグ / トラッククリックは `ValueChanged` → 新設 `Surface::ScrollToRow(row)` → `ghostty_surface_binding_action("scroll_to_row:N")`。C API で唯一の絶対位置スクロール入口で、GTK apprt と同じ経路
- **エコー防止**: core からの更新はプロパティ書き込みを `m_scrollbarSyncing` で囲み、その `ValueChanged` をスクロールとして送り返さない (GTK は adjustment の signal を block している。無いと報告のたびに往復する)
- **auto-hide**: 報告やドラッグで表示、ホバー中は維持、1.2 秒アイドルでフェード (`DispatcherQueueTimer`、weak-ref tick、`Detach` で停止)
- バーの上でのホイールは ScrollBar 自身の SmallChange 刻みではなく terminal に転送
- dispatcher: surface ターゲットの `SCROLLBAR` を `Actions::OnScrollbar` → `IWindow::SetScrollbarForSurface` → 所有 pane へルーティング。app ターゲットは ack のまま

</details>

## Verification

- [x] Tests.exe green (routing + null-surface tests added)
- [x] Fresh shell (no scrollback): no bar
- [x] `1..500 | % { $_ }` → bar appears at the right edge, thumb at the bottom, then fades after ~1s
- [x] Wheel scroll up → bar reveals, thumb tracks the viewport; wheel back down → thumb returns to bottom
- [x] Drag the thumb → terminal viewport follows the drag (no lag, no oscillation)
- [x] Click the track above/below the thumb → page jump
- [x] Pointer over the bar shows an Arrow, not the terminal's I-beam (found in review; fixed via a single ApplyCursor writer)
- [x] Hover the bar → stays visible; move away → fades
- [x] Drag then keep typing → new output auto-scrolls to bottom, thumb follows (ghostty's own behavior, verifies no echo loop)
- [x] Split panes: each pane has its own bar, tracking independently
- [x] Bar does not steal focus / typing continues after a drag
- [x] Background transparency + blur: bar renders over the pane, no visual glitch

<details><summary>日本語</summary>

- [x] Tests.exe green (ルーティング + null surface のテスト追加済み)
- [x] 新規シェル (scrollback なし): バーは出ない
- [x] `1..500 | % { $_ }` → 右端にバーが出て、つまみは最下部、約 1 秒でフェード
- [x] ホイールで上へ → バーが現れ、つまみが viewport に追従。下に戻す → つまみが最下部に戻る
- [x] つまみをドラッグ → terminal の viewport が追従 (遅延・振動なし)
- [x] つまみの上下のトラックをクリック → ページ単位でジャンプ
- [x] バー上のポインタは terminal の I ビームではなく矢印 (レビューで発見、ApplyCursor 一本化で修正)
- [x] バーにホバー → 表示維持。離れる → フェード
- [x] ドラッグ後にタイプを続ける → 新しい出力で自動的に最下部へ、つまみも追従 (ghostty 本来の挙動。エコーループが無いことの確認)
- [x] split pane: 各 pane に独立したバーが付き、別々に追従
- [x] バーがフォーカスを奪わない / ドラッグ後もタイプが続く
- [x] 背景透過 + blur: バーが pane の上に描かれ、描画の乱れなし

</details>

