### PR TITLE
Show a search bar on each pane

### DIFF
--- a/App/MainWindow.xaml.cpp
+++ b/App/MainWindow.xaml.cpp
@@ -2034,6 +2034,47 @@ namespace winrt::GhosttyWin32::implementation
         });
     }
 
+    // ----- search bar: owning-leaf routing for all four actions -----
+
+    void MainWindow::StartSearchForSurface(ghostty_surface_t surface,
+                                           std::wstring needle)
+    {
+        auto lookup = m_tabs.FindPaneBySurface(surface);
+        if (!lookup.pane) return;
+        if (auto* tc = Tab::PaneToTerminalControl(*lookup.pane)) {
+            tc->StartSearch(needle);
+        }
+    }
+
+    void MainWindow::EndSearchForSurface(ghostty_surface_t surface)
+    {
+        auto lookup = m_tabs.FindPaneBySurface(surface);
+        if (!lookup.pane) return;
+        if (auto* tc = Tab::PaneToTerminalControl(*lookup.pane)) {
+            tc->EndSearch();
+        }
+    }
+
+    void MainWindow::SetSearchTotalForSurface(ghostty_surface_t surface,
+                                              ptrdiff_t total)
+    {
+        auto lookup = m_tabs.FindPaneBySurface(surface);
+        if (!lookup.pane) return;
+        if (auto* tc = Tab::PaneToTerminalControl(*lookup.pane)) {
+            tc->SetSearchTotal(total);
+        }
+    }
+
+    void MainWindow::SetSearchSelectedForSurface(ghostty_surface_t surface,
+                                                 ptrdiff_t selected)
+    {
+        auto lookup = m_tabs.FindPaneBySurface(surface);
+        if (!lookup.pane) return;
+        if (auto* tc = Tab::PaneToTerminalControl(*lookup.pane)) {
+            tc->SetSearchSelected(selected);
+        }
+    }
+
     void MainWindow::SetScrollbarForSurface(ghostty_surface_t surface,
                                             ghostty_action_scrollbar_s bar)
     {

--- a/App/MainWindow.xaml.cpp
+++ b/App/MainWindow.xaml.cpp
@@ -284,6 +284,15 @@ namespace winrt::GhosttyWin32::implementation
                                         if (popups && popups.Size() > 0) return;
                                     }
                                 }
+                                // An open search bar owns the keyboard
+                                // the same way a dialog does: restore
+                                // focus to its input box, not to the
+                                // terminal behind it (#171 review —
+                                // alt-tab away and back mid-search
+                                // dropped focus on the pty).
+                                if (auto* tc = self->ActiveControl()) {
+                                    if (tc->FocusSearchIfOpen()) return;
+                                }
                                 if (auto* tab = self->ActiveTab()) {
                                     tab->Focus();
                                 }

--- a/App/MainWindow.xaml.h
+++ b/App/MainWindow.xaml.h
@@ -151,6 +151,13 @@ namespace winrt::GhosttyWin32::implementation
                                      ghostty_action_cell_size_s cell) override;
         void SetScrollbarForSurface(ghostty_surface_t surface,
                                     ghostty_action_scrollbar_s bar) override;
+        void StartSearchForSurface(ghostty_surface_t surface,
+                                   std::wstring needle) override;
+        void EndSearchForSurface(ghostty_surface_t surface) override;
+        void SetSearchTotalForSurface(ghostty_surface_t surface,
+                                      ptrdiff_t total) override;
+        void SetSearchSelectedForSurface(ghostty_surface_t surface,
+                                         ptrdiff_t selected) override;
         // Shared tail of the surface report and the adopt-time
         // re-arm: update the WM_SIZING snapping tag with the metrics
         // and re-read the window-step-resize gate. No-op on {0,0}

--- a/App/TerminalControl.xaml
+++ b/App/TerminalControl.xaml
@@ -134,6 +134,48 @@
           while hovered, faded when idle, and collapsed entirely when
           there is no scrollback (viewport == total).
         -->
+        <!--
+          Search bar (START_SEARCH / END_SEARCH / SEARCH_TOTAL /
+          SEARCH_SELECTED). ghostty owns the matching and the
+          lifecycle; this is the input box and the "3 / 12" readout,
+          talking back through binding actions (search:, navigate_
+          search:, end_search) like the macOS SurfaceView. First
+          overlay that takes KEYBOARD focus — while it is open,
+          keystrokes go to the TextBox, and closing it hands focus
+          back to the terminal. Top-right so it never collides with
+          the status badges below it or the link banner.
+        -->
+        <Border x:Name="SearchBar"
+                Visibility="Collapsed"
+                HorizontalAlignment="Right"
+                VerticalAlignment="Top"
+                Margin="0,0,16,0"
+                CornerRadius="0,0,6,6"
+                Padding="8,6,8,6"
+                Background="{ThemeResource SolidBackgroundFillColorSecondaryBrush}">
+            <StackPanel Orientation="Horizontal" Spacing="6">
+                <TextBox x:Name="SearchInput"
+                         MinWidth="200"
+                         PlaceholderText="Search"
+                         IsSpellCheckEnabled="False"
+                         IsTextPredictionEnabled="False" />
+                <TextBlock x:Name="SearchCount"
+                           VerticalAlignment="Center"
+                           MinWidth="48"
+                           TextAlignment="Center"
+                           FontSize="12"
+                           Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+                <Button x:Name="SearchPrev" Padding="6,2,6,2" ToolTipService.ToolTip="Previous (Shift+Enter)">
+                    <FontIcon Glyph="&#xE70E;" FontSize="12" />
+                </Button>
+                <Button x:Name="SearchNext" Padding="6,2,6,2" ToolTipService.ToolTip="Next (Enter)">
+                    <FontIcon Glyph="&#xE70D;" FontSize="12" />
+                </Button>
+                <Button x:Name="SearchClose" Padding="6,2,6,2" ToolTipService.ToolTip="Close (Esc)">
+                    <FontIcon Glyph="&#xE711;" FontSize="12" />
+                </Button>
+            </StackPanel>
+        </Border>
         <ScrollBar x:Name="ScrollbackBar"
                    Orientation="Vertical"
                    IndicatorMode="MouseIndicator"

--- a/App/TerminalControl.xaml.cpp
+++ b/App/TerminalControl.xaml.cpp
@@ -206,6 +206,12 @@ namespace winrt::GhosttyWin32::implementation
         KeyDown([weakSelf](auto&&, muxi::KeyRoutedEventArgs const& args) {
             auto self = weakSelf.get();
             if (!self || !self->m_surface) return;
+            // The search bar's TextBox is a child of this control, so
+            // its keystrokes bubble up here as well. While the bar is
+            // open the box owns the keyboard — never forward to the
+            // pty (typing "abc" in the box also typed "abc" into the
+            // shell before this guard, #171 review).
+            if (self->m_searchOpen) return;
 
             input::TerminalKeyDown key(args, self->m_ime.composing());
 
@@ -261,6 +267,7 @@ namespace winrt::GhosttyWin32::implementation
         KeyUp([weakSelf](auto&&, muxi::KeyRoutedEventArgs const& args) {
             auto self = weakSelf.get();
             if (!self || !self->m_surface) return;
+            if (self->m_searchOpen) return;  // see KeyDown
             input::TerminalKeyUp key(args);
             auto raw = key.toRawKeyRelease();
             auto keyEvent = core::input::Translate(raw);
@@ -628,6 +635,15 @@ namespace winrt::GhosttyWin32::implementation
                 self->CloseSearchFromUi();
                 args.Handled(true);
             }
+            // Everything else is the TextBox's own editing; the
+            // control-level KeyDown also gates on m_searchOpen, so
+            // nothing reaches the pty either way.
+        });
+        // Belt and braces for KeyUp: the release of a key typed in
+        // the box must not bubble into the terminal's KeyUp.
+        input.KeyUp([weakSelf](auto&&, muxi::KeyRoutedEventArgs const& args) {
+            if (auto self = weakSelf.get(); self && self->m_searchOpen)
+                args.Handled(true);
         });
 
         SearchNext().Click([weakSelf](auto&&, auto&&) {

--- a/App/TerminalControl.xaml.cpp
+++ b/App/TerminalControl.xaml.cpp
@@ -8,6 +8,7 @@
 #include "Input/TerminalKeyUp.h"
 #include "Display/PhysicalPixels.h"
 #include "Win32/Clipboard.h"
+#include <winrt/Windows.System.h>
 #include <algorithm>
 #include <chrono>
 #include <cmath>
@@ -194,6 +195,7 @@ namespace winrt::GhosttyWin32::implementation
         });
 
         SetupScrollbar();
+        SetupSearchBar();
 
         // KeyDown / KeyUp on the control itself: the events fire only
         // while focus is inside us, so the handlers feed directly into
@@ -575,6 +577,159 @@ namespace winrt::GhosttyWin32::implementation
         if (auto sb = ScrollbackBar()) sb.Opacity(0.0);
     }
 
+    // ----- search bar -----
+
+    void TerminalControl::SetupSearchBar()
+    {
+        namespace muxi = winrt::Microsoft::UI::Xaml::Input;
+        auto input = SearchInput();
+        if (!input) return;
+        auto weakSelf = get_weak();
+
+        // Debounce timer (macOS SurfaceView rule: <3 chars wait
+        // 300ms, otherwise immediate — see the header comment).
+        m_searchDebounce = DispatcherQueue().CreateTimer();
+        m_searchDebounce.Interval(std::chrono::milliseconds{ 300 });
+        m_searchDebounce.IsRepeating(false);
+        m_searchDebounce.Tick([weakSelf](auto&&, auto&&) {
+            if (auto self = weakSelf.get()) self->SendSearchNeedle();
+        });
+
+        input.TextChanged([weakSelf](auto&&, auto&&) {
+            auto self = weakSelf.get();
+            if (!self || self->m_searchSyncing || !self->m_searchOpen) return;
+            auto text = self->SearchInput().Text();
+            const bool immediate = text.empty() || text.size() >= 3;
+            self->m_searchDebounce.Stop();
+            if (immediate) self->SendSearchNeedle();
+            else self->m_searchDebounce.Start();
+        });
+
+        // Enter = next, Shift+Enter = previous, Esc = close. Handled
+        // so the keys never bubble into the terminal's own KeyDown
+        // (which would type them into the pty).
+        input.KeyDown([weakSelf](auto&&, muxi::KeyRoutedEventArgs const& args) {
+            auto self = weakSelf.get();
+            if (!self || !self->m_surface) return;
+            using winrt::Windows::System::VirtualKey;
+            const auto key = args.Key();
+            if (key == VirtualKey::Enter) {
+                const bool shift = (GetKeyState(VK_SHIFT) & 0x8000) != 0;
+                // Make sure a pending debounced needle lands before
+                // navigating, else Enter on a fresh 1-2 char needle
+                // navigates the previous search.
+                if (self->m_searchDebounce.IsRunning()) {
+                    self->m_searchDebounce.Stop();
+                    self->SendSearchNeedle();
+                }
+                self->m_surface.NavigateSearch(!shift);
+                args.Handled(true);
+            } else if (key == VirtualKey::Escape) {
+                self->CloseSearchFromUi();
+                args.Handled(true);
+            }
+        });
+
+        SearchNext().Click([weakSelf](auto&&, auto&&) {
+            if (auto self = weakSelf.get(); self && self->m_surface)
+                self->m_surface.NavigateSearch(true);
+        });
+        SearchPrev().Click([weakSelf](auto&&, auto&&) {
+            if (auto self = weakSelf.get(); self && self->m_surface)
+                self->m_surface.NavigateSearch(false);
+        });
+        SearchClose().Click([weakSelf](auto&&, auto&&) {
+            if (auto self = weakSelf.get()) self->CloseSearchFromUi();
+        });
+    }
+
+    void TerminalControl::StartSearch(std::wstring const& needle)
+    {
+        auto bar = SearchBar();
+        auto input = SearchInput();
+        if (!bar || !input) return;
+        m_searchOpen = true;
+        m_searchTotal = -1;
+        m_searchSelected = -1;
+        UpdateSearchCount();
+        bar.Visibility(winrt::Microsoft::UI::Xaml::Visibility::Visible);
+        // A non-empty needle came from search_selection: ghostty has
+        // already started that search, so pre-fill without echoing
+        // it back. An empty needle (bare start_search) leaves the
+        // box as-is — re-opening keeps the last query, which matches
+        // every editor's find bar.
+        if (!needle.empty()) {
+            m_searchSyncing = true;
+            input.Text(needle);
+            m_searchSyncing = false;
+        }
+        input.Focus(winrt::Microsoft::UI::Xaml::FocusState::Programmatic);
+        input.SelectAll();
+    }
+
+    void TerminalControl::EndSearch()
+    {
+        auto bar = SearchBar();
+        if (!bar) return;
+        if (m_searchDebounce) m_searchDebounce.Stop();
+        const bool wasOpen = m_searchOpen;
+        m_searchOpen = false;
+        bar.Visibility(winrt::Microsoft::UI::Xaml::Visibility::Collapsed);
+        // Hand focus back to the terminal only if the bar had it;
+        // ghostty can END_SEARCH while focus is elsewhere (another
+        // pane), and stealing it then would be a surprise.
+        if (wasOpen) {
+            Focus(winrt::Microsoft::UI::Xaml::FocusState::Programmatic);
+        }
+    }
+
+    void TerminalControl::CloseSearchFromUi()
+    {
+        // The UI closes by asking ghostty to end the search; the
+        // resulting END_SEARCH action performs the actual hide, so
+        // core and host never disagree about whether a search is on.
+        if (m_surface) m_surface.EndSearch();
+        else EndSearch();
+    }
+
+    void TerminalControl::SendSearchNeedle()
+    {
+        if (!m_surface || !m_searchOpen) return;
+        std::wstring text{ SearchInput().Text() };
+        m_surface.Search(interop::Encoding::toUtf8(text));
+    }
+
+    void TerminalControl::SetSearchTotal(ptrdiff_t total)
+    {
+        m_searchTotal = total;
+        UpdateSearchCount();
+    }
+
+    void TerminalControl::SetSearchSelected(ptrdiff_t selected)
+    {
+        m_searchSelected = selected;
+        UpdateSearchCount();
+    }
+
+    void TerminalControl::UpdateSearchCount()
+    {
+        auto count = SearchCount();
+        if (!count) return;
+        wchar_t buf[48];
+        if (m_searchTotal < 0) {
+            buf[0] = L'\0';
+        } else if (m_searchTotal == 0) {
+            wcscpy_s(buf, L"0 / 0");
+        } else if (m_searchSelected < 1) {
+            swprintf_s(buf, L"– / %lld", static_cast<long long>(m_searchTotal));
+        } else {
+            swprintf_s(buf, L"%lld / %lld",
+                       static_cast<long long>(m_searchSelected),
+                       static_cast<long long>(m_searchTotal));
+        }
+        count.Text(buf);
+    }
+
     void TerminalControl::ApplyFocusVisual(bool focused)
     {
         auto dim = UnfocusedDim();
@@ -694,6 +849,7 @@ namespace winrt::GhosttyWin32::implementation
         // The scrollbar fade timer holds only a weak ref, but stop
         // it anyway so no tick lands while the control tears down.
         if (m_scrollbarFadeTimer) m_scrollbarFadeTimer.Stop();
+        if (m_searchDebounce) m_searchDebounce.Stop();
 
         // Cancel the pending SetSwapChainHandle dispatch before we tear
         // down the swap chain — otherwise the queued call could attach

--- a/App/TerminalControl.xaml.cpp
+++ b/App/TerminalControl.xaml.cpp
@@ -699,6 +699,15 @@ namespace winrt::GhosttyWin32::implementation
         }
     }
 
+    bool TerminalControl::FocusSearchIfOpen()
+    {
+        if (!m_searchOpen) return false;
+        auto input = SearchInput();
+        if (!input) return false;
+        input.Focus(winrt::Microsoft::UI::Xaml::FocusState::Programmatic);
+        return true;
+    }
+
     void TerminalControl::CloseSearchFromUi()
     {
         // The UI closes by asking ghostty to end the search; the

--- a/App/TerminalControl.xaml.cpp
+++ b/App/TerminalControl.xaml.cpp
@@ -92,8 +92,11 @@ namespace winrt::GhosttyWin32::implementation
             // on its parent too. Engaging the CoreTextEditContext then
             // would route the box's text through the terminal's IME
             // path and into the pty — leave it disengaged while the
-            // bar is open (#171 review: box input reached the shell).
-            if (self->m_editContext && !self->m_searchOpen) {
+            // box holds focus (#171 review: box input reached the
+            // shell). Clicking back into the terminal with the bar
+            // still open fires GotFocus again with the box unfocused,
+            // which re-engages the context.
+            if (self->m_editContext && !self->SearchBoxHasFocus()) {
                 self->m_editContext.NotifyFocusEnter();
             }
             // The UnfocusedDim overlay is driven by Tab.SetActivePane,
@@ -214,17 +217,18 @@ namespace winrt::GhosttyWin32::implementation
             auto self = weakSelf.get();
             if (!self || !self->m_surface) return;
             // The search bar's TextBox is a child of this control, so
-            // its keystrokes bubble up here as well. While the bar is
-            // open the box owns the keyboard — never forward to the
+            // its keystrokes bubble up here as well. While the box
+            // holds focus it owns the keyboard — never forward to the
             // pty (typing "abc" in the box also typed "abc" into the
-            // shell before this guard, #171 review).
-            if (self->m_searchOpen) return;
+            // shell before this guard, #171 review). Gating on focus
+            // rather than on the bar being open lets the user click
+            // back into the terminal and keep typing with the bar up.
+            if (self->SearchBoxHasFocus()) return;
 #if defined(_DEBUG)
             {
                 wchar_t buf[96];
-                swprintf_s(buf, L"SearchLeak: control KeyDown vk=%u searchOpen=%d\n",
-                           static_cast<unsigned>(args.Key()),
-                           self->m_searchOpen ? 1 : 0);
+                swprintf_s(buf, L"SearchLeak: control KeyDown vk=%u boxFocused=0\n",
+                           static_cast<unsigned>(args.Key()));
                 OutputDebugStringW(buf);
             }
 #endif
@@ -283,7 +287,7 @@ namespace winrt::GhosttyWin32::implementation
         KeyUp([weakSelf](auto&&, muxi::KeyRoutedEventArgs const& args) {
             auto self = weakSelf.get();
             if (!self || !self->m_surface) return;
-            if (self->m_searchOpen) return;  // see KeyDown
+            if (self->SearchBoxHasFocus()) return;  // see KeyDown
             input::TerminalKeyUp key(args);
             auto raw = key.toRawKeyRelease();
             auto keyEvent = core::input::Translate(raw);
@@ -659,7 +663,7 @@ namespace winrt::GhosttyWin32::implementation
         // Belt and braces for KeyUp: the release of a key typed in
         // the box must not bubble into the terminal's KeyUp.
         input.KeyUp([weakSelf](auto&&, muxi::KeyRoutedEventArgs const& args) {
-            if (auto self = weakSelf.get(); self && self->m_searchOpen)
+            if (auto self = weakSelf.get(); self && self->SearchBoxHasFocus())
                 args.Handled(true);
         });
 
@@ -731,6 +735,14 @@ namespace winrt::GhosttyWin32::implementation
         if (wasOpen) {
             Focus(winrt::Microsoft::UI::Xaml::FocusState::Programmatic);
         }
+    }
+
+    bool TerminalControl::SearchBoxHasFocus()
+    {
+        if (!m_searchOpen) return false;
+        auto input = SearchInput();
+        if (!input) return false;
+        return input.FocusState() != winrt::Microsoft::UI::Xaml::FocusState::Unfocused;
     }
 
     bool TerminalControl::FocusSearchIfOpen()
@@ -1046,15 +1058,15 @@ namespace winrt::GhosttyWin32::implementation
 #if defined(_DEBUG)
                 {
                     wchar_t buf[96];
-                    swprintf_s(buf, L"SearchLeak: EditContext commit len=%zu searchOpen=%d\n",
-                               utf8.size(), self->m_searchOpen ? 1 : 0);
+                    swprintf_s(buf, L"SearchLeak: EditContext commit len=%zu boxFocused=%d\n",
+                               utf8.size(), self->SearchBoxHasFocus() ? 1 : 0);
                     OutputDebugStringW(buf);
                 }
 #endif
-                // The search box owns text input while it is open —
-                // a composition committed there must not land in
-                // the pty (see the GotFocus guard).
-                if (!utf8.empty() && !self->m_searchOpen) {
+                // The search box owns text input while it holds
+                // focus — a composition committed there must not
+                // land in the pty (see the GotFocus guard).
+                if (!utf8.empty() && !self->SearchBoxHasFocus()) {
                     self->m_surface.Text(utf8.c_str(), utf8.size());
                 }
                 if (self->m_app) ghostty_app_tick(self->m_app);
@@ -1093,8 +1105,8 @@ namespace winrt::GhosttyWin32::implementation
     void TerminalControl::NotifyImeFocusEnter()
     {
         // Same guard as GotFocus: the search box owns text input
-        // while the bar is open.
-        if (m_editContext && !m_searchOpen) m_editContext.NotifyFocusEnter();
+        // while it holds focus.
+        if (m_editContext && !SearchBoxHasFocus()) m_editContext.NotifyFocusEnter();
     }
 
     void TerminalControl::NotifyImeFocusLeave()

--- a/App/TerminalControl.xaml.cpp
+++ b/App/TerminalControl.xaml.cpp
@@ -88,7 +88,14 @@ namespace winrt::GhosttyWin32::implementation
         GotFocus([weakSelf](auto&&, auto&&) {
             auto self = weakSelf.get();
             if (!self) return;
-            if (self->m_editContext) self->m_editContext.NotifyFocusEnter();
+            // GotFocus bubbles: the search box taking focus fires this
+            // on its parent too. Engaging the CoreTextEditContext then
+            // would route the box's text through the terminal's IME
+            // path and into the pty — leave it disengaged while the
+            // bar is open (#171 review: box input reached the shell).
+            if (self->m_editContext && !self->m_searchOpen) {
+                self->m_editContext.NotifyFocusEnter();
+            }
             // The UnfocusedDim overlay is driven by Tab.SetActivePane,
             // not by XAML focus events. Reason: the dim represents
             // "this leaf is the active split in its tab", which has
@@ -212,6 +219,15 @@ namespace winrt::GhosttyWin32::implementation
             // pty (typing "abc" in the box also typed "abc" into the
             // shell before this guard, #171 review).
             if (self->m_searchOpen) return;
+#if defined(_DEBUG)
+            {
+                wchar_t buf[96];
+                swprintf_s(buf, L"SearchLeak: control KeyDown vk=%u searchOpen=%d\n",
+                           static_cast<unsigned>(args.Key()),
+                           self->m_searchOpen ? 1 : 0);
+                OutputDebugStringW(buf);
+            }
+#endif
 
             input::TerminalKeyDown key(args, self->m_ime.composing());
 
@@ -1009,7 +1025,18 @@ namespace winrt::GhosttyWin32::implementation
             if (self->m_surface) {
                 self->m_surface.Preedit(nullptr, 0);
                 auto utf8 = interop::Encoding::toUtf8(self->m_ime.text());
-                if (!utf8.empty()) {
+#if defined(_DEBUG)
+                {
+                    wchar_t buf[96];
+                    swprintf_s(buf, L"SearchLeak: EditContext commit len=%zu searchOpen=%d\n",
+                               utf8.size(), self->m_searchOpen ? 1 : 0);
+                    OutputDebugStringW(buf);
+                }
+#endif
+                // The search box owns text input while it is open —
+                // a composition committed there must not land in
+                // the pty (see the GotFocus guard).
+                if (!utf8.empty() && !self->m_searchOpen) {
                     self->m_surface.Text(utf8.c_str(), utf8.size());
                 }
                 if (self->m_app) ghostty_app_tick(self->m_app);
@@ -1047,7 +1074,9 @@ namespace winrt::GhosttyWin32::implementation
 
     void TerminalControl::NotifyImeFocusEnter()
     {
-        if (m_editContext) m_editContext.NotifyFocusEnter();
+        // Same guard as GotFocus: the search box owns text input
+        // while the bar is open.
+        if (m_editContext && !m_searchOpen) m_editContext.NotifyFocusEnter();
     }
 
     void TerminalControl::NotifyImeFocusLeave()

--- a/App/TerminalControl.xaml.cpp
+++ b/App/TerminalControl.xaml.cpp
@@ -340,11 +340,12 @@ namespace winrt::GhosttyWin32::implementation
     void TerminalControl::ApplyCursor()
     {
         // Single writer for ProtectedCursor so the three inputs
-        // compose in one place: the scrollbar's own hover wins with
-        // an Arrow (a text I-beam over a draggable thumb reads wrong
-        // — #170 review), hidden state wins next, else the shape
+        // compose in one place: hovering an interactive overlay
+        // (scrollbar, search bar) wins with an Arrow (a text I-beam
+        // over a draggable thumb or a button reads wrong — #170 /
+        // #171 review), hidden state wins next, else the shape
         // ghostty last asked for.
-        if (m_scrollbarHovered) {
+        if (m_scrollbarHovered || m_overlayHovered) {
             static const auto arrow =
                 winrt::Microsoft::UI::Input::InputSystemCursor::Create(
                     winrt::Microsoft::UI::Input::InputSystemCursorShape::Arrow);
@@ -660,6 +661,23 @@ namespace winrt::GhosttyWin32::implementation
         input.KeyUp([weakSelf](auto&&, muxi::KeyRoutedEventArgs const& args) {
             if (auto self = weakSelf.get(); self && self->m_searchOpen)
                 args.Handled(true);
+        });
+
+        // The control-wide ProtectedCursor (ghostty's TEXT shape) is
+        // inherited by the bar; show an Arrow over it like over the
+        // scrollbar — same ApplyCursor composition.
+        auto bar = SearchBar();
+        bar.PointerEntered([weakSelf](auto&&, auto&&) {
+            if (auto self = weakSelf.get()) {
+                self->m_overlayHovered = true;
+                self->ApplyCursor();
+            }
+        });
+        bar.PointerExited([weakSelf](auto&&, auto&&) {
+            if (auto self = weakSelf.get()) {
+                self->m_overlayHovered = false;
+                self->ApplyCursor();
+            }
         });
 
         SearchNext().Click([weakSelf](auto&&, auto&&) {

--- a/App/TerminalControl.xaml.h
+++ b/App/TerminalControl.xaml.h
@@ -223,6 +223,17 @@ namespace winrt::GhosttyWin32::implementation
         // (the GTK apprt blocks its adjustment signals the same way).
         void SetScrollbar(ghostty_action_scrollbar_s bar);
 
+        // ----- search bar -----
+        // ghostty drives open/close and the counts; the pane owns
+        // the input box. Open focuses the box (pre-filled from
+        // search_selection when `needle` is non-empty), close hides
+        // it and returns focus to the terminal. Counts are -1 while
+        // unknown; `selected` is 1-based. UI thread only.
+        void StartSearch(std::wstring const& needle);
+        void EndSearch();
+        void SetSearchTotal(ptrdiff_t total);
+        void SetSearchSelected(ptrdiff_t selected);
+
         // Set the callback that fires when this control receives
         // keyboard focus. Passed the underlying ghostty surface so
         // the host can update its "currently focused surface"
@@ -337,6 +348,23 @@ namespace winrt::GhosttyWin32::implementation
         bool m_scrollbarSyncing = false;
         bool m_scrollbarHovered = false;
         winrt::Microsoft::UI::Dispatching::DispatcherQueueTimer m_scrollbarFadeTimer{ nullptr };
+
+        // Search bar state. m_searchSyncing guards the programmatic
+        // pre-fill in StartSearch so TextChanged doesn't fire a
+        // redundant search for text ghostty just handed us. The
+        // debounce mirrors the macOS SurfaceView: needles under 3
+        // chars wait 300ms (cheap keystrokes, expensive short-needle
+        // scans); 3+ chars and empty go immediately. m_searchTotal /
+        // m_searchSelected feed the readout.
+        void SetupSearchBar();
+        void SendSearchNeedle();
+        void UpdateSearchCount();
+        void CloseSearchFromUi();
+        bool m_searchOpen = false;
+        bool m_searchSyncing = false;
+        ptrdiff_t m_searchTotal = -1;
+        ptrdiff_t m_searchSelected = -1;
+        winrt::Microsoft::UI::Dispatching::DispatcherQueueTimer m_searchDebounce{ nullptr };
     };
 }
 

--- a/App/TerminalControl.xaml.h
+++ b/App/TerminalControl.xaml.h
@@ -233,6 +233,12 @@ namespace winrt::GhosttyWin32::implementation
         void EndSearch();
         void SetSearchTotal(ptrdiff_t total);
         void SetSearchSelected(ptrdiff_t selected);
+        // If the bar is open, put keyboard focus on its input box and
+        // return true; otherwise do nothing and return false. Lets
+        // the window's activation focus-restore keep the bar in
+        // charge instead of dropping focus back on the terminal
+        // behind it (alt-tab away and back while searching).
+        bool FocusSearchIfOpen();
 
         // Set the callback that fires when this control receives
         // keyboard focus. Passed the underlying ghostty surface so

--- a/App/TerminalControl.xaml.h
+++ b/App/TerminalControl.xaml.h
@@ -353,6 +353,9 @@ namespace winrt::GhosttyWin32::implementation
         void FadeScrollbarIfIdle();
         bool m_scrollbarSyncing = false;
         bool m_scrollbarHovered = false;
+        // Pointer is over an interactive overlay other than the
+        // scrollbar (the search bar); ApplyCursor shows an Arrow.
+        bool m_overlayHovered = false;
         winrt::Microsoft::UI::Dispatching::DispatcherQueueTimer m_scrollbarFadeTimer{ nullptr };
 
         // Search bar state. m_searchSyncing guards the programmatic

--- a/App/TerminalControl.xaml.h
+++ b/App/TerminalControl.xaml.h
@@ -239,6 +239,13 @@ namespace winrt::GhosttyWin32::implementation
         // charge instead of dropping focus back on the terminal
         // behind it (alt-tab away and back while searching).
         bool FocusSearchIfOpen();
+        // Whether the search box currently holds keyboard focus. This
+        // — not "the bar is open" — is what gates terminal input: the
+        // bar can stay open while the user clicks back into the
+        // terminal to keep typing (#171 review), and only while the
+        // box actually has focus must keystrokes and IME commits stay
+        // out of the pty.
+        bool SearchBoxHasFocus();
 
         // Set the callback that fires when this control receives
         // keyboard focus. Passed the underlying ghostty surface so

--- a/Core/Ghostty/Actions/Actions.cpp
+++ b/Core/Ghostty/Actions/Actions.cpp
@@ -518,6 +518,48 @@ bool Actions::OnScrollbar(ghostty_surface_t surface,
     return true;
 }
 
+bool Actions::OnStartSearch(ghostty_surface_t surface,
+                            ghostty_action_start_search_s search) {
+    if (!surface) return true;
+    // The needle is NUL-terminated (StartSearch.C uses [*:0]) and
+    // empty for the bare start_search keybind; search_selection
+    // pre-fills it with the selected text. Convert before crossing
+    // threads — ghostty owns the pointer only for this call.
+    std::wstring needle;
+    if (search.needle && *search.needle)
+        needle = interop::Encoding::toUtf16(search.needle);
+    DispatchToView([this, surface, needle = std::move(needle)]() mutable {
+        m_view.StartSearchForSurface(surface, std::move(needle));
+    });
+    return true;
+}
+
+bool Actions::OnEndSearch(ghostty_surface_t surface) {
+    if (!surface) return true;
+    DispatchToView([this, surface]() {
+        m_view.EndSearchForSurface(surface);
+    });
+    return true;
+}
+
+bool Actions::OnSearchTotal(ghostty_surface_t surface,
+                            ghostty_action_search_total_s total) {
+    if (!surface) return true;
+    DispatchToView([this, surface, total]() {
+        m_view.SetSearchTotalForSurface(surface, total.total);
+    });
+    return true;
+}
+
+bool Actions::OnSearchSelected(ghostty_surface_t surface,
+                               ghostty_action_search_selected_s selected) {
+    if (!surface) return true;
+    DispatchToView([this, surface, selected]() {
+        m_view.SetSearchSelectedForSurface(surface, selected.selected);
+    });
+    return true;
+}
+
 bool Actions::OnReloadConfig(bool soft) {
     // The view-side implementation handles thread placement
     // (soft re-uses UI thread, hard spins a 4MB-stack worker

--- a/Core/Ghostty/Actions/Actions.h
+++ b/Core/Ghostty/Actions/Actions.h
@@ -160,6 +160,13 @@ public:
                     ghostty_action_cell_size_s cell);
     bool OnScrollbar(ghostty_surface_t surface,
                      ghostty_action_scrollbar_s bar);
+    bool OnStartSearch(ghostty_surface_t surface,
+                       ghostty_action_start_search_s search);
+    bool OnEndSearch(ghostty_surface_t surface);
+    bool OnSearchTotal(ghostty_surface_t surface,
+                       ghostty_action_search_total_s total);
+    bool OnSearchSelected(ghostty_surface_t surface,
+                          ghostty_action_search_selected_s selected);
     bool OnReloadConfig(bool soft);
     bool OnConfigChange(ghostty_config_t newCfg);
     bool OnDesktopNotification(ghostty_surface_t surface,

--- a/Core/Ghostty/CallbackDispatcher.cpp
+++ b/Core/Ghostty/CallbackDispatcher.cpp
@@ -217,10 +217,6 @@ bool CallbackDispatcher::DispatchAction(ghostty_target_s target, ghostty_action_
         // Feature surfaces intentionally not on this port's plate
         // (search bar, ImGui inspector, tab overview, quick
         // terminal, command palette):
-        case GHOSTTY_ACTION_START_SEARCH:
-        case GHOSTTY_ACTION_END_SEARCH:
-        case GHOSTTY_ACTION_SEARCH_TOTAL:
-        case GHOSTTY_ACTION_SEARCH_SELECTED:
         case GHOSTTY_ACTION_INSPECTOR:
         case GHOSTTY_ACTION_RENDER_INSPECTOR:
         // GTK-only, will never fire on Windows. Acked so it doesn't
@@ -240,6 +236,31 @@ bool CallbackDispatcher::DispatchAction(ghostty_target_s target, ghostty_action_
             if (target.tag == GHOSTTY_TARGET_SURFACE)
                 return m_actions.OnScrollbar(target.target.surface,
                                              action.action.scrollbar);
+            return true;
+
+        // ----- search bar (surface-targeted) -----
+        // ghostty opens/closes the UI and reports match counts; the
+        // host owns the input box and sends needle / navigation back
+        // through binding actions (search:, navigate_search:,
+        // end_search) — the same route the macOS SurfaceView takes.
+        case GHOSTTY_ACTION_START_SEARCH:
+            if (target.tag == GHOSTTY_TARGET_SURFACE)
+                return m_actions.OnStartSearch(target.target.surface,
+                                               action.action.start_search);
+            return true;
+        case GHOSTTY_ACTION_END_SEARCH:
+            if (target.tag == GHOSTTY_TARGET_SURFACE)
+                return m_actions.OnEndSearch(target.target.surface);
+            return true;
+        case GHOSTTY_ACTION_SEARCH_TOTAL:
+            if (target.tag == GHOSTTY_TARGET_SURFACE)
+                return m_actions.OnSearchTotal(target.target.surface,
+                                               action.action.search_total);
+            return true;
+        case GHOSTTY_ACTION_SEARCH_SELECTED:
+            if (target.tag == GHOSTTY_TARGET_SURFACE)
+                return m_actions.OnSearchSelected(target.target.surface,
+                                                  action.action.search_selected);
             return true;
 
         // Cell metrics: feeds snap-to-cell window resizing (#155).

--- a/Core/Ghostty/Surface.h
+++ b/Core/Ghostty/Surface.h
@@ -2,6 +2,8 @@
 
 #include "ghostty.h"
 #include <cstdio>
+#include <cstring>
+#include <string>
 
 #include <cstdint>
 #include <utility>
@@ -176,6 +178,31 @@ public:
         if (n <= 0) return false;
         return ghostty_surface_binding_action(
             m_handle, buf, static_cast<uintptr_t>(n));
+    }
+
+    // ---- search (host-owned UI, core-owned matching) ----
+    // There is no dedicated search C API; like the macOS SurfaceView
+    // the host drives it through binding actions. `needle` is UTF-8;
+    // empty cancels the current search without closing the UI.
+    bool Search(std::string const& needleUtf8) noexcept {
+        if (!m_handle) return false;
+        std::string action = "search:" + needleUtf8;
+        return ghostty_surface_binding_action(
+            m_handle, action.c_str(), static_cast<uintptr_t>(action.size()));
+    }
+    bool NavigateSearch(bool next) noexcept {
+        if (!m_handle) return false;
+        static constexpr char kNext[] = "navigate_search:next";
+        static constexpr char kPrev[] = "navigate_search:previous";
+        const char* a = next ? kNext : kPrev;
+        return ghostty_surface_binding_action(
+            m_handle, a, static_cast<uintptr_t>(std::strlen(a)));
+    }
+    bool EndSearch() noexcept {
+        if (!m_handle) return false;
+        static constexpr char kEnd[] = "end_search";
+        return ghostty_surface_binding_action(
+            m_handle, kEnd, static_cast<uintptr_t>(std::strlen(kEnd)));
     }
 
     // ---- selection ----

--- a/Core/Host/IWindow.h
+++ b/Core/Host/IWindow.h
@@ -243,6 +243,22 @@ struct IWindow {
     virtual void SetScrollbarForSurface(ghostty_surface_t surface,
                                         ghostty_action_scrollbar_s bar) = 0;
 
+    // ----- search bar (START_SEARCH / END_SEARCH / SEARCH_TOTAL /
+    // SEARCH_SELECTED, all surface-targeted) -----
+    // ghostty drives the lifecycle and the counts; the host owns
+    // the input box and talks back through binding actions
+    // (Surface::Search / NavigateSearch / EndSearch). `needle` is
+    // empty for a bare open and pre-filled by search_selection.
+    // `total` / `selected` are -1 while unknown; `selected` is
+    // 1-based.
+    virtual void StartSearchForSurface(ghostty_surface_t surface,
+                                       std::wstring needle) = 0;
+    virtual void EndSearchForSurface(ghostty_surface_t surface) = 0;
+    virtual void SetSearchTotalForSurface(ghostty_surface_t surface,
+                                          ptrdiff_t total) = 0;
+    virtual void SetSearchSelectedForSurface(ghostty_surface_t surface,
+                                             ptrdiff_t selected) = 0;
+
     // COMMAND_FINISHED: a shell-integration-tracked command ended.
     // The view owns the whole policy: it reads the notify-on-
     // command-finish config trio (mode / threshold / actions),

--- a/Tests/MockMainWindowView.h
+++ b/Tests/MockMainWindowView.h
@@ -140,6 +140,34 @@ struct MockMainWindowView : core::host::IWindow {
     int redoCalls = 0;
     void Redo() override { ++redoCalls; }
 
+    int startSearchCalls = 0;
+    ghostty_surface_t lastStartSearchSurface = nullptr;
+    std::wstring lastStartSearchNeedle;
+    void StartSearchForSurface(ghostty_surface_t surface,
+                               std::wstring needle) override {
+        ++startSearchCalls;
+        lastStartSearchSurface = surface;
+        lastStartSearchNeedle = std::move(needle);
+    }
+    int endSearchCalls = 0;
+    ghostty_surface_t lastEndSearchSurface = nullptr;
+    void EndSearchForSurface(ghostty_surface_t surface) override {
+        ++endSearchCalls;
+        lastEndSearchSurface = surface;
+    }
+    int setSearchTotalCalls = 0;
+    ptrdiff_t lastSearchTotal = -99;
+    void SetSearchTotalForSurface(ghostty_surface_t, ptrdiff_t total) override {
+        ++setSearchTotalCalls;
+        lastSearchTotal = total;
+    }
+    int setSearchSelectedCalls = 0;
+    ptrdiff_t lastSearchSelected = -99;
+    void SetSearchSelectedForSurface(ghostty_surface_t, ptrdiff_t selected) override {
+        ++setSearchSelectedCalls;
+        lastSearchSelected = selected;
+    }
+
     int setScrollbarCalls = 0;
     ghostty_surface_t lastScrollbarSurface = nullptr;
     ghostty_action_scrollbar_s lastScrollbar{};

--- a/Tests/test_ghostty_actions.cpp
+++ b/Tests/test_ghostty_actions.cpp
@@ -564,6 +564,36 @@ TEST(GhosttyActionsTest, OnScrollbarPassesSurfaceAndMetrics) {
     EXPECT_EQ(view.lastScrollbar.len, 60u);
 }
 
+TEST(GhosttyActionsTest, OnStartSearchConvertsNeedleAndEmptyIsEmpty) {
+    MockMainWindowView view;
+    Actions actions(view);
+    auto surface = reinterpret_cast<ghostty_surface_t>(0xBEEF);
+    // UTF-8 needle crosses to UTF-16 (a search_selection pre-fill
+    // can carry any text the terminal showed).
+    EXPECT_TRUE(actions.OnStartSearch(surface, { "\xE3\x81\x82" }));  // あ
+    EXPECT_EQ(view.startSearchCalls, 1);
+    EXPECT_EQ(view.lastStartSearchNeedle, L"あ");
+    // Bare start_search: ghostty passes "" — the bar opens empty.
+    EXPECT_TRUE(actions.OnStartSearch(surface, { "" }));
+    EXPECT_EQ(view.startSearchCalls, 2);
+    EXPECT_TRUE(view.lastStartSearchNeedle.empty());
+    // Defensive: a null needle pointer also opens empty.
+    EXPECT_TRUE(actions.OnStartSearch(surface, { nullptr }));
+    EXPECT_EQ(view.startSearchCalls, 3);
+    EXPECT_TRUE(view.lastStartSearchNeedle.empty());
+}
+
+TEST(GhosttyActionsTest, SearchActionsNullSurfaceAreAckedNotDelivered) {
+    MockMainWindowView view;
+    Actions actions(view);
+    EXPECT_TRUE(actions.OnStartSearch(nullptr, { "x" }));
+    EXPECT_TRUE(actions.OnEndSearch(nullptr));
+    EXPECT_TRUE(actions.OnSearchTotal(nullptr, { 1 }));
+    EXPECT_TRUE(actions.OnSearchSelected(nullptr, { 1 }));
+    EXPECT_EQ(view.startSearchCalls + view.endSearchCalls +
+              view.setSearchTotalCalls + view.setSearchSelectedCalls, 0);
+}
+
 TEST(GhosttyActionsTest, OnScrollbarNullSurfaceIsAckedNotDelivered) {
     MockMainWindowView view;
     Actions actions(view);

--- a/Tests/test_ghostty_callback_dispatcher.cpp
+++ b/Tests/test_ghostty_callback_dispatcher.cpp
@@ -56,10 +56,6 @@ TEST(GhosttyCallbackDispatcherTest, FeatureSurfaceAcksReturnTrue) {
     MockMainWindowView view;
     auto d = CallbackDispatcher::Create(view);
 
-    EXPECT_TRUE(DispatchTag(*d, GHOSTTY_ACTION_START_SEARCH));
-    EXPECT_TRUE(DispatchTag(*d, GHOSTTY_ACTION_END_SEARCH));
-    EXPECT_TRUE(DispatchTag(*d, GHOSTTY_ACTION_SEARCH_TOTAL));
-    EXPECT_TRUE(DispatchTag(*d, GHOSTTY_ACTION_SEARCH_SELECTED));
     EXPECT_TRUE(DispatchTag(*d, GHOSTTY_ACTION_INSPECTOR));
     EXPECT_TRUE(DispatchTag(*d, GHOSTTY_ACTION_RENDER_INSPECTOR));
     EXPECT_TRUE(DispatchTag(*d, GHOSTTY_ACTION_TOGGLE_TAB_OVERVIEW));
@@ -73,6 +69,47 @@ TEST(GhosttyCallbackDispatcherTest, NoConsumerAcksReturnTrue) {
 
     // QUIT_TIMER: macOS-only quit countdown.
     EXPECT_TRUE(DispatchTag(*d, GHOSTTY_ACTION_QUIT_TIMER));
+}
+
+TEST(GhosttyCallbackDispatcherTest, SearchActionsRouteToTheView) {
+    // Formerly feature-surface acks; the search bar consumes all
+    // four. Surface-targeted delivery routes; app-target stays an
+    // ack (no owning pane to show a bar on).
+    MockMainWindowView view;
+    auto d = CallbackDispatcher::Create(view);
+    auto surface = reinterpret_cast<ghostty_surface_t>(0xBEEF);
+
+    ghostty_target_s target{};
+    target.tag = GHOSTTY_TARGET_SURFACE;
+    target.target.surface = surface;
+
+    ghostty_action_s action{};
+    action.tag = GHOSTTY_ACTION_START_SEARCH;
+    action.action.start_search = { "needle" };
+    EXPECT_TRUE(d->DispatchAction(target, action));
+    EXPECT_EQ(view.startSearchCalls, 1);
+    EXPECT_EQ(view.lastStartSearchSurface, surface);
+    EXPECT_EQ(view.lastStartSearchNeedle, L"needle");
+
+    action.tag = GHOSTTY_ACTION_SEARCH_TOTAL;
+    action.action.search_total = { 12 };
+    EXPECT_TRUE(d->DispatchAction(target, action));
+    EXPECT_EQ(view.lastSearchTotal, 12);
+
+    action.tag = GHOSTTY_ACTION_SEARCH_SELECTED;
+    action.action.search_selected = { 3 };
+    EXPECT_TRUE(d->DispatchAction(target, action));
+    EXPECT_EQ(view.lastSearchSelected, 3);
+
+    action.tag = GHOSTTY_ACTION_END_SEARCH;
+    EXPECT_TRUE(d->DispatchAction(target, action));
+    EXPECT_EQ(view.endSearchCalls, 1);
+    EXPECT_EQ(view.lastEndSearchSurface, surface);
+
+    EXPECT_TRUE(DispatchTag(*d, GHOSTTY_ACTION_START_SEARCH));
+    EXPECT_TRUE(DispatchTag(*d, GHOSTTY_ACTION_END_SEARCH));
+    EXPECT_EQ(view.startSearchCalls, 1);
+    EXPECT_EQ(view.endSearchCalls, 1);
 }
 
 TEST(GhosttyCallbackDispatcherTest, ScrollbarRoutesToTheView) {


### PR DESCRIPTION
Closes the search-bar item in #57 (START_SEARCH / END_SEARCH / SEARCH_TOTAL / SEARCH_SELECTED).

## Why

The four search actions were acked as feature-surface no-ops: ghostty could open, close, and count a search, but nothing on screen showed it — `ctrl+shift+f` did nothing visible.

<details><summary>日本語</summary>

検索の 4 action は「UI 未実装」として ack だけしていた。ghostty 側は検索を開始・終了・件数報告できるのに画面には何も出ず、`ctrl+shift+f` を押しても見た目は無反応だった。

</details>

## Design

- **Search bar overlay** on `TerminalControl` (top-right): input box, `N / total` readout, prev / next / close. **First overlay that takes keyboard focus** — while open, keystrokes go to the TextBox; closing hands focus back to the terminal
- **ghostty owns matching and lifecycle**; the host only reflects the four actions and talks back through binding actions — `search:<needle>`, `navigate_search:next|previous`, `end_search` (new `Surface::Search` / `NavigateSearch` / `EndSearch`). The C API has no dedicated search entry point; this is exactly the macOS SurfaceView's route
- **Debounce mirrors macOS**: needles under 3 chars wait 300ms, 3+ chars and empty go immediately; Enter flushes a pending debounce before navigating
- **Single close path**: the UI closes by asking ghostty (`end_search`); the resulting `END_SEARCH` is the one place the bar hides, so core and host never disagree about whether a search is on
- `search_selection` pre-fills the box (guarded so it isn't echoed back as a second search); a bare `start_search` keeps the previous query, like every editor's find bar
- Match numbering is libghostty's: `1` is the **newest** match (nearest the prompt) and `next` walks **upward** into history (`terminal/search/screen.zig`: "matches are ordered from most recent to oldest"). Same numbers macOS and GTK show; not reversed here so the readout and `navigate_search` agree with upstream
- Keys inside the bar: **Enter** = next, **Shift+Enter** = previous, **Esc** = close — Handled so they never reach the pty
- Dispatcher: the four actions move out of the feature-surface ack block into surface-targeted routes → `Actions::OnStartSearch/OnEndSearch/OnSearchTotal/OnSearchSelected` → `IWindow::*ForSurface` → owning pane. Needle is NUL-terminated (`StartSearch.C` uses `[*:0]`), converted before crossing threads

<details><summary>日本語</summary>

- **`TerminalControl` 右上に検索バー**: 入力箱、`N / total` 表示、前へ / 次へ / 閉じる。**キーボードフォーカスを取る初めてのオーバーレイ** — 開いている間はキー入力が TextBox に行き、閉じると terminal にフォーカスが戻る
- **マッチングとライフサイクルは ghostty が所有**。host は 4 action を反映するだけで、返事は binding action — `search:<needle>`、`navigate_search:next|previous`、`end_search` (新設 `Surface::Search` / `NavigateSearch` / `EndSearch`)。C API に専用の検索入口は無く、macOS SurfaceView とまったく同じ経路
- **debounce は macOS と同じ**: 3 文字未満は 300ms 待ち、3 文字以上と空は即時。Enter は保留中の debounce を先に flush してからナビゲート
- **閉じる経路は 1 本**: UI は ghostty に `end_search` を頼むだけで、返ってくる `END_SEARCH` がバーを隠す唯一の場所。core と host の「検索中か」が食い違わない
- `search_selection` は箱を pre-fill (2 回目の検索として echo しないようガード)。素の `start_search` は前回のクエリを保持 (エディタの検索バーと同じ)
- マッチ番号は libghostty の仕様: `1` が**最新** (プロンプトに一番近い) マッチで、`next` は**上 (過去) へ**進む (`terminal/search/screen.zig`: "matches are ordered from most recent to oldest")。macOS / GTK と同じ数字。表示と `navigate_search` の向きを本家と揃えるため、ホスト側で反転しない
- バー内のキー: **Enter** = 次、**Shift+Enter** = 前、**Esc** = 閉じる — Handled にして pty に届かせない
- dispatcher: 4 action を ack ブロックから surface ターゲットのルートへ → `Actions::OnStartSearch/OnEndSearch/OnSearchTotal/OnSearchSelected` → `IWindow::*ForSurface` → 所有 pane。needle は NUL 終端 (`StartSearch.C` は `[*:0]`) で、スレッドを跨ぐ前に変換

</details>

## Verification (config: `ctrl+f=start_search`, `ctrl+shift+g=search_selection`, `ctrl+shift+n/p=navigate_search`)

- [x] Tests.exe green (routing, needle conversion incl. UTF-8, null-surface)
- [x] `1..300 | % { "line $_" }` then **Ctrl+F** → bar opens top-right, input focused
- [x] Type `line 1` → matches highlight in the terminal, readout shows `1 / N` (N = 111: 1, 10-19, 100-199)
- [x] Type 1 char (e.g. `l`) → search kicks in only after ~300ms; 3+ chars → immediate
- [x] **Enter** → next match, readout increments; **Shift+Enter** → previous; wraps at the ends
- [x] ▲ / ▼ buttons do the same; **Ctrl+Shift+N/P** from the terminal (bar open, focus in terminal) also navigate
- [x] Typing in the box does NOT reach the shell (found in review: child TextBox keystrokes bubbled into the terminal's KeyDown; fixed by gating on the bar being open)
- [x] Alt-tab away and back while the bar is open → focus lands on the search box, not the terminal (found in review; the Activated focus-restore now treats an open bar like an open dialog)
- [x] **Esc** → bar closes, focus returns to the terminal, typing goes to the shell again; highlights cleared
- [x] Pointer over the bar shows an Arrow, not the I-beam (found in review; wired into the ApplyCursor composition from #170)
- [x] ✕ button same as Esc
- [x] Select some text with the mouse, **Ctrl+Shift+G** → bar opens pre-filled with the selection and already searching (readout non-empty)
- [x] Bar open, click into the terminal → typing reaches the shell again (found in review: the input gate keyed on the bar being open and locked the terminal out; now keyed on the box holding focus)
- [x] Ctrl+F while open → re-focuses the box, keeps the previous query
- [x] Split panes: each pane has its own bar; opening in one does not affect the other
- [x] No match (`zzzz`) → readout `0 / 0`
- [x] IME (Japanese) input in the box works (composition doesn't leak to the pty)

<details><summary>日本語</summary>

- [x] Tests.exe green (ルーティング、needle 変換 (UTF-8 含む)、null surface)
- [x] `1..300 | % { "line $_" }` の後に **Ctrl+F** → 右上にバー、入力箱にフォーカス
- [x] `line 1` と打つ → terminal 内のマッチがハイライト、表示は `1 / N` (N = 111: 1、10-19、100-199)
- [x] 1 文字 (例 `l`) → 約 300ms 後に検索開始。3 文字以上 → 即時
- [x] **Enter** → 次のマッチ、表示が増える。**Shift+Enter** → 前。端で wrap する
- [x] ▲ / ▼ ボタンも同じ。terminal 側にフォーカスがある状態 (バーは開いたまま) で **Ctrl+Shift+N/P** でもナビゲート
- [x] 箱への入力がシェルに届かない (レビューで発見: 子 TextBox のキーが terminal の KeyDown にバブルしていた。バー表示中はゲートして修正)
- [x] バーを開いたまま alt-tab で離れて戻る → フォーカスは terminal ではなく検索箱に (レビューで発見。Activated のフォーカス復元がダイアログと同じ扱いをするよう修正)
- [x] **Esc** → バーが閉じ、terminal にフォーカスが戻り、タイプがシェルに届く。ハイライトが消える
- [x] バー上のポインタは I ビームではなく矢印 (レビューで発見。#170 の ApplyCursor 合成に接続)
- [x] ✕ ボタンも Esc と同じ
- [x] マウスでテキスト選択して **Ctrl+Shift+G** → 選択文字列が pre-fill された状態でバーが開き、既に検索済み (表示が空でない)
- [x] バーを開いたまま terminal をクリック → タイプがシェルに届く (レビューで発見: 入力ゲートが「バーが開いている」で判定していて terminal が締め出されていた。「箱がフォーカスを持っている」に変更)
- [x] 開いた状態で Ctrl+F → 箱に再フォーカス、前のクエリを保持
- [x] split pane: 各 pane に独立したバー。片方で開いても他方に影響しない
- [x] マッチなし (`zzzz`) → 表示 `0 / 0`
- [x] 箱への IME (日本語) 入力が動く (変換中の文字が pty に漏れない)

</details>








