### PR TITLE
Collapse keyboard-ownership guards into TerminalOwnsInput

### DIFF
--- a/App/TerminalControl.xaml.cpp
+++ b/App/TerminalControl.xaml.cpp
@@ -88,17 +88,10 @@ namespace winrt::GhosttyWin32::implementation
         GotFocus([weakSelf](auto&&, auto&&) {
             auto self = weakSelf.get();
             if (!self) return;
-            // GotFocus bubbles: the search box taking focus fires this
-            // on its parent too. Engaging the CoreTextEditContext then
-            // would route the box's text through the terminal's IME
-            // path and into the pty — leave it disengaged while the
-            // box holds focus (#171 review: box input reached the
-            // shell). Clicking back into the terminal with the bar
-            // still open fires GotFocus again with the box unfocused,
-            // which re-engages the context.
-            if (self->m_editContext && !self->SearchBoxHasFocus()) {
-                self->m_editContext.NotifyFocusEnter();
-            }
+            // GotFocus bubbles: an overlay's TextBox taking focus
+            // fires this on its parent too, so decide from the
+            // current owner rather than from the event itself.
+            self->SyncImeEngagement();
             // The UnfocusedDim overlay is driven by Tab.SetActivePane,
             // not by XAML focus events. Reason: the dim represents
             // "this leaf is the active split in its tab", which has
@@ -216,22 +209,12 @@ namespace winrt::GhosttyWin32::implementation
         KeyDown([weakSelf](auto&&, muxi::KeyRoutedEventArgs const& args) {
             auto self = weakSelf.get();
             if (!self || !self->m_surface) return;
-            // The search bar's TextBox is a child of this control, so
-            // its keystrokes bubble up here as well. While the box
-            // holds focus it owns the keyboard — never forward to the
-            // pty (typing "abc" in the box also typed "abc" into the
-            // shell before this guard, #171 review). Gating on focus
-            // rather than on the bar being open lets the user click
-            // back into the terminal and keep typing with the bar up.
-            if (self->SearchBoxHasFocus()) return;
-#if defined(_DEBUG)
-            {
-                wchar_t buf[96];
-                swprintf_s(buf, L"SearchLeak: control KeyDown vk=%u boxFocused=0\n",
-                           static_cast<unsigned>(args.Key()));
-                OutputDebugStringW(buf);
-            }
-#endif
+            // Overlay TextBoxes are children of this control, so
+            // their keystrokes bubble up here as well. Only forward
+            // to the pty while the terminal owns input (typing in
+            // the search box also typed into the shell before this
+            // guard, #171 review).
+            if (!self->TerminalOwnsInput()) return;
 
             input::TerminalKeyDown key(args, self->m_ime.composing());
 
@@ -287,7 +270,7 @@ namespace winrt::GhosttyWin32::implementation
         KeyUp([weakSelf](auto&&, muxi::KeyRoutedEventArgs const& args) {
             auto self = weakSelf.get();
             if (!self || !self->m_surface) return;
-            if (self->SearchBoxHasFocus()) return;  // see KeyDown
+            if (!self->TerminalOwnsInput()) return;  // see KeyDown
             input::TerminalKeyUp key(args);
             auto raw = key.toRawKeyRelease();
             auto keyEvent = core::input::Translate(raw);
@@ -657,13 +640,21 @@ namespace winrt::GhosttyWin32::implementation
                 args.Handled(true);
             }
             // Everything else is the TextBox's own editing; the
-            // control-level KeyDown also gates on m_searchOpen, so
-            // nothing reaches the pty either way.
+            // control-level KeyDown also gates on TerminalOwnsInput,
+            // so nothing reaches the pty either way.
+        });
+        // Focus moving into or out of the box is an ownership
+        // transition: keep the IME edit context in step with it.
+        input.GotFocus([weakSelf](auto&&, auto&&) {
+            if (auto self = weakSelf.get()) self->SyncImeEngagement();
+        });
+        input.LostFocus([weakSelf](auto&&, auto&&) {
+            if (auto self = weakSelf.get()) self->SyncImeEngagement();
         });
         // Belt and braces for KeyUp: the release of a key typed in
         // the box must not bubble into the terminal's KeyUp.
         input.KeyUp([weakSelf](auto&&, muxi::KeyRoutedEventArgs const& args) {
-            if (auto self = weakSelf.get(); self && self->SearchBoxHasFocus())
+            if (auto self = weakSelf.get(); self && !self->TerminalOwnsInput())
                 args.Handled(true);
         });
 
@@ -737,12 +728,39 @@ namespace winrt::GhosttyWin32::implementation
         }
     }
 
-    bool TerminalControl::SearchBoxHasFocus()
+    // ----- keyboard ownership -----
+
+    winrt::Microsoft::UI::Xaml::Controls::Control TerminalControl::FocusedOverlay()
     {
-        if (!m_searchOpen) return false;
-        auto input = SearchInput();
-        if (!input) return false;
-        return input.FocusState() != winrt::Microsoft::UI::Xaml::FocusState::Unfocused;
+        // Overlays that can take keyboard focus, checked in order.
+        // Today that is only the search box; a future command
+        // palette or rename field joins this list and nothing else.
+        if (m_searchOpen) {
+            if (auto input = SearchInput();
+                input && input.FocusState() != winrt::Microsoft::UI::Xaml::FocusState::Unfocused) {
+                return input;
+            }
+        }
+        return nullptr;
+    }
+
+    bool TerminalControl::TerminalOwnsInput()
+    {
+        return FocusedOverlay() == nullptr;
+    }
+
+    void TerminalControl::SyncImeEngagement()
+    {
+        // Engage the CoreTextEditContext only while the terminal owns
+        // input. Engaging it while an overlay's TextBox has focus
+        // would route that box's text through the terminal's IME
+        // path into the pty. Called on every focus transition (the
+        // control's GotFocus, the window's activation restore, and
+        // the overlay's own focus changes), so the context always
+        // reflects the current owner rather than the last event.
+        if (!m_editContext) return;
+        if (TerminalOwnsInput()) m_editContext.NotifyFocusEnter();
+        else m_editContext.NotifyFocusLeave();
     }
 
     bool TerminalControl::FocusSearchIfOpen()
@@ -1055,18 +1073,12 @@ namespace winrt::GhosttyWin32::implementation
             if (self->m_surface) {
                 self->m_surface.Preedit(nullptr, 0);
                 auto utf8 = interop::Encoding::toUtf8(self->m_ime.text());
-#if defined(_DEBUG)
-                {
-                    wchar_t buf[96];
-                    swprintf_s(buf, L"SearchLeak: EditContext commit len=%zu boxFocused=%d\n",
-                               utf8.size(), self->SearchBoxHasFocus() ? 1 : 0);
-                    OutputDebugStringW(buf);
-                }
-#endif
-                // The search box owns text input while it holds
-                // focus — a composition committed there must not
-                // land in the pty (see the GotFocus guard).
-                if (!utf8.empty() && !self->SearchBoxHasFocus()) {
+                // A composition committed while an overlay owns input
+                // must not land in the pty (SyncImeEngagement keeps
+                // the context released then, but guard the commit
+                // too — an in-flight composition can complete after
+                // ownership changed).
+                if (!utf8.empty() && self->TerminalOwnsInput()) {
                     self->m_surface.Text(utf8.c_str(), utf8.size());
                 }
                 if (self->m_app) ghostty_app_tick(self->m_app);
@@ -1104,9 +1116,7 @@ namespace winrt::GhosttyWin32::implementation
 
     void TerminalControl::NotifyImeFocusEnter()
     {
-        // Same guard as GotFocus: the search box owns text input
-        // while it holds focus.
-        if (m_editContext && !SearchBoxHasFocus()) m_editContext.NotifyFocusEnter();
+        SyncImeEngagement();
     }
 
     void TerminalControl::NotifyImeFocusLeave()

--- a/App/TerminalControl.xaml.h
+++ b/App/TerminalControl.xaml.h
@@ -239,13 +239,26 @@ namespace winrt::GhosttyWin32::implementation
         // charge instead of dropping focus back on the terminal
         // behind it (alt-tab away and back while searching).
         bool FocusSearchIfOpen();
-        // Whether the search box currently holds keyboard focus. This
-        // — not "the bar is open" — is what gates terminal input: the
-        // bar can stay open while the user clicks back into the
-        // terminal to keep typing (#171 review), and only while the
-        // box actually has focus must keystrokes and IME commits stay
-        // out of the pty.
-        bool SearchBoxHasFocus();
+
+        // ----- keyboard ownership -----
+        // Exactly one thing consumes keyboard input at a time: the
+        // terminal (pty + IME edit context) or an in-tree overlay
+        // that took focus (today: the search box). The rule is
+        // "who holds focus", not "which overlay is open" — the search
+        // bar can stay visible while the user clicks back into the
+        // terminal and keeps typing (#171 review).
+        //
+        // Every input entry point — KeyDown / KeyUp, the IME edit
+        // context's engagement and its composition commit, and the
+        // window's activation focus-restore — asks TerminalOwnsInput()
+        // instead of knowing which overlay exists. SyncImeEngagement()
+        // is the single place the CoreTextEditContext is engaged or
+        // released, called from every focus transition. A future
+        // overlay that takes focus only has to be listed in
+        // FocusedOverlay(); it cannot leak into the pty by forgetting
+        // one of the guards (the search bar initially did, twice).
+        bool TerminalOwnsInput();
+        void SyncImeEngagement();
 
         // Set the callback that fires when this control receives
         // keyboard focus. Passed the underlying ghostty surface so
@@ -376,6 +389,10 @@ namespace winrt::GhosttyWin32::implementation
         void SendSearchNeedle();
         void UpdateSearchCount();
         void CloseSearchFromUi();
+        // The overlay element that currently holds keyboard focus,
+        // or null when the terminal does. The one enumeration point
+        // for focus-taking overlays — see TerminalOwnsInput().
+        winrt::Microsoft::UI::Xaml::Controls::Control FocusedOverlay();
         bool m_searchOpen = false;
         bool m_searchSyncing = false;
         ptrdiff_t m_searchTotal = -1;


### PR DESCRIPTION
Follow-up to #171 (the "別 PR で統一" item). **Behavior is unchanged** — this only restructures the guards.

## Why

The search bar's focus checks ended up spread over **six entry points** (control KeyDown, control KeyUp, the box's KeyUp, GotFocus, the activation re-arm, the IME composition commit), and the CoreTextEditContext was engaged from two of them independently. Every one of those guards was discovered by a leak into the pty during #171 review — the structure guaranteed the next overlay would repeat the cycle.

<details><summary>日本語</summary>

検索バーのフォーカス判定が **6 つの入口** (control の KeyDown / KeyUp、箱の KeyUp、GotFocus、activation 時の再武装、IME の composition commit) に散らばり、CoreTextEditContext の武装も 2 箇所から独立に行われていた。どのガードも #171 のレビューで「pty に漏れた」から後付けしたもので、この構造だと次のオーバーレイで同じサイクルを繰り返す。

</details>

## What

- **`TerminalOwnsInput()`** — the rule, named once: true when no focus-taking overlay holds focus. All six entry points ask this and nothing else
- **`FocusedOverlay()`** — the single enumeration point for overlays that can take keyboard focus (today: the search box). A future command palette / rename field joins this list and inherits every guard
- **`SyncImeEngagement()`** — the single place the edit context is engaged or released, called on every focus transition (control GotFocus, activation re-arm, and now the box's own GotFocus / LostFocus). The context reflects the current owner, not the last event
- `SearchBoxHasFocus()` and the `SearchLeak` debug traces are gone (superseded)
- The composition-commit guard stays as belt-and-braces: an in-flight composition can complete after ownership changed

<details><summary>日本語</summary>

- **`TerminalOwnsInput()`** — ルールを 1 回だけ命名: フォーカスを持つオーバーレイが無いとき true。6 入口はこれを聞くだけ
- **`FocusedOverlay()`** — キーボードフォーカスを取れるオーバーレイの唯一の列挙点 (今は検索箱のみ)。将来のコマンドパレットやリネーム欄はここに加えるだけで全ガードを継承する
- **`SyncImeEngagement()`** — edit context の武装/解除の唯一の場所。全フォーカス遷移 (control の GotFocus、activation 再武装、箱自身の GotFocus / LostFocus) から呼ばれ、「最後のイベント」ではなく「今の所有者」を反映する
- `SearchBoxHasFocus()` と `SearchLeak` デバッグトレースは撤去 (役目終了)
- composition commit のガードは保険として残す (所有権が変わった後に進行中の変換が確定することがある)

</details>

## Verification (regression only — same as #171's input items)

- [ ] Tests.exe green
- [ ] Ctrl+F → type in the box → nothing reaches the shell; paste in the box → nothing reaches the shell
- [ ] Bar open, click into the terminal → typing reaches the shell; IME works there
- [ ] Ctrl+F again → focus returns to the box, query kept
- [ ] IME (Japanese) in the box → nothing reaches the shell
- [ ] Esc → focus back on the terminal, typing works
- [ ] Alt-tab away and back with the bar open → focus on the box

<details><summary>日本語</summary>

- [ ] Tests.exe green
- [ ] Ctrl+F → 箱にタイプ → シェルに届かない。箱に貼り付け → 届かない
- [ ] バーを開いたまま terminal をクリック → タイプがシェルに届く。そこで IME も使える
- [ ] もう一度 Ctrl+F → 箱にフォーカスが戻り、クエリ保持
- [ ] 箱で IME (日本語) → シェルに届かない
- [ ] Esc → terminal にフォーカスが戻りタイプできる
- [ ] バーを開いたまま alt-tab で離れて戻る → 箱にフォーカス

</details>