### PR TITLE
Route surface actions to the pane through a directory, not window relays

### DIFF
--- a/App/MainWindow.xaml.cpp
+++ b/App/MainWindow.xaml.cpp
@@ -1780,7 +1780,18 @@ namespace winrt::GhosttyWin32::implementation
                       nullptr, nullptr, SW_SHOWNORMAL);
     }
 
-    // ----- IMainWindowView: terminal-driven appearance + lifecycle -----
+    // ----- IWindow: surface directory + terminal-driven appearance -----
+
+    host::ISurfaceView* MainWindow::FindSurfaceView(ghostty_surface_t surface)
+    {
+        // Owning-leaf resolution for every surface-targeted action.
+        // Null when the surface was closed or torn out to another
+        // window before the dispatched call landed — the caller
+        // drops the action, as the old per-action relays did.
+        auto lookup = m_tabs.FindPaneBySurface(surface);
+        if (!lookup.pane) return nullptr;
+        return Tab::PaneToTerminalControl(*lookup.pane);
+    }
 
     void MainWindow::ApplyBackgroundColor(uint8_t r, uint8_t g, uint8_t b)
     {
@@ -1890,35 +1901,6 @@ namespace winrt::GhosttyWin32::implementation
         const bool underlay = !translucent && m_bgOpaque;
         for (auto& tab : m_tabs) {
             if (tab) tab->ApplyBackgroundOpacity(underlay, m_bgColor);
-        }
-    }
-
-    void MainWindow::SetCursorShapeForSurface(ghostty_surface_t surface,
-                                              ghostty_action_mouse_shape_e shape)
-    {
-        // Route the shape to the leaf that actually owns `surface`, not
-        // the tab's active leaf. MOUSE_SHAPE carries the originating
-        // surface, and with split panes the pointer can be over a
-        // non-active pane — using ActiveControl() landed the shape on
-        // the wrong pane (#65). FindPaneBySurface walks the pane tree
-        // and returns the owning leaf; in the single-pane case it
-        // resolves to the same control ActiveControl() would.
-        auto lookup = m_tabs.FindPaneBySurface(surface);
-        if (!lookup.pane) return;
-        if (auto* tc = Tab::PaneToTerminalControl(*lookup.pane)) {
-            tc->SetCursorShape(shape);
-        }
-    }
-
-    void MainWindow::SetSecureInputForSurface(ghostty_surface_t surface,
-                                              ghostty_action_secure_input_e mode)
-    {
-        // Owning-leaf routing: the password prompt lives in a
-        // specific pane, and the badge belongs there.
-        auto lookup = m_tabs.FindPaneBySurface(surface);
-        if (!lookup.pane) return;
-        if (auto* tc = Tab::PaneToTerminalControl(*lookup.pane)) {
-            tc->SetSecureInput(mode);
         }
     }
 
@@ -2045,67 +2027,6 @@ namespace winrt::GhosttyWin32::implementation
 
     // ----- search bar: owning-leaf routing for all four actions -----
 
-    void MainWindow::StartSearchForSurface(ghostty_surface_t surface,
-                                           std::wstring needle)
-    {
-        auto lookup = m_tabs.FindPaneBySurface(surface);
-        if (!lookup.pane) return;
-        if (auto* tc = Tab::PaneToTerminalControl(*lookup.pane)) {
-            tc->StartSearch(needle);
-        }
-    }
-
-    void MainWindow::EndSearchForSurface(ghostty_surface_t surface)
-    {
-        auto lookup = m_tabs.FindPaneBySurface(surface);
-        if (!lookup.pane) return;
-        if (auto* tc = Tab::PaneToTerminalControl(*lookup.pane)) {
-            tc->EndSearch();
-        }
-    }
-
-    void MainWindow::SetSearchTotalForSurface(ghostty_surface_t surface,
-                                              ptrdiff_t total)
-    {
-        auto lookup = m_tabs.FindPaneBySurface(surface);
-        if (!lookup.pane) return;
-        if (auto* tc = Tab::PaneToTerminalControl(*lookup.pane)) {
-            tc->SetSearchTotal(total);
-        }
-    }
-
-    void MainWindow::SetSearchSelectedForSurface(ghostty_surface_t surface,
-                                                 ptrdiff_t selected)
-    {
-        auto lookup = m_tabs.FindPaneBySurface(surface);
-        if (!lookup.pane) return;
-        if (auto* tc = Tab::PaneToTerminalControl(*lookup.pane)) {
-            tc->SetSearchSelected(selected);
-        }
-    }
-
-    void MainWindow::SetScrollbarForSurface(ghostty_surface_t surface,
-                                            ghostty_action_scrollbar_s bar)
-    {
-        // Owning-leaf routing: the viewport belongs to one pane.
-        auto lookup = m_tabs.FindPaneBySurface(surface);
-        if (!lookup.pane) return;
-        if (auto* tc = Tab::PaneToTerminalControl(*lookup.pane)) {
-            tc->SetScrollbar(bar);
-        }
-    }
-
-    void MainWindow::SetReadonlyForSurface(ghostty_surface_t surface, bool readonly)
-    {
-        // Owning-leaf routing: the read-only state belongs to the
-        // pane whose pty stopped accepting writes.
-        auto lookup = m_tabs.FindPaneBySurface(surface);
-        if (!lookup.pane) return;
-        if (auto* tc = Tab::PaneToTerminalControl(*lookup.pane)) {
-            tc->SetReadonly(readonly);
-        }
-    }
-
     void MainWindow::SetPwdForSurface(ghostty_surface_t surface, std::wstring pwd)
     {
         // Tab-level, not pane-level: the tooltip hangs off the
@@ -2116,74 +2037,6 @@ namespace winrt::GhosttyWin32::implementation
         Microsoft::UI::Xaml::Controls::ToolTipService::SetToolTip(
             t->Item(),
             pwd.empty() ? nullptr : box_value(winrt::hstring{ pwd }));
-    }
-
-    // KEY_SEQUENCE / KEY_TABLE: owning-leaf routing like the other
-    // pane-visual actions; the four operations share the lookup and
-    // differ only in which TerminalControl mutator they call.
-    void MainWindow::AppendKeySequenceForSurface(ghostty_surface_t surface,
-                                                 std::wstring triggerLabel)
-    {
-        auto lookup = m_tabs.FindPaneBySurface(surface);
-        if (!lookup.pane) return;
-        if (auto* tc = Tab::PaneToTerminalControl(*lookup.pane)) {
-            tc->AppendKeySequence(winrt::hstring{ triggerLabel });
-        }
-    }
-
-    void MainWindow::ClearKeySequenceForSurface(ghostty_surface_t surface)
-    {
-        auto lookup = m_tabs.FindPaneBySurface(surface);
-        if (!lookup.pane) return;
-        if (auto* tc = Tab::PaneToTerminalControl(*lookup.pane)) {
-            tc->ClearKeySequence();
-        }
-    }
-
-    void MainWindow::PushKeyTableForSurface(ghostty_surface_t surface,
-                                            std::wstring name)
-    {
-        auto lookup = m_tabs.FindPaneBySurface(surface);
-        if (!lookup.pane) return;
-        if (auto* tc = Tab::PaneToTerminalControl(*lookup.pane)) {
-            tc->PushKeyTable(winrt::hstring{ name });
-        }
-    }
-
-    void MainWindow::PopKeyTableForSurface(ghostty_surface_t surface, bool all)
-    {
-        auto lookup = m_tabs.FindPaneBySurface(surface);
-        if (!lookup.pane) return;
-        if (auto* tc = Tab::PaneToTerminalControl(*lookup.pane)) {
-            tc->PopKeyTable(all);
-        }
-    }
-
-    void MainWindow::SetMouseVisibilityForSurface(ghostty_surface_t surface,
-                                                  bool visible)
-    {
-        // Owning-leaf routing, same as the other pointer-adjacent
-        // actions: the hide belongs to the pane the user is typing
-        // in, which with splits is not necessarily the active leaf
-        // of every tab.
-        auto lookup = m_tabs.FindPaneBySurface(surface);
-        if (!lookup.pane) return;
-        if (auto* tc = Tab::PaneToTerminalControl(*lookup.pane)) {
-            tc->SetMouseVisibility(visible);
-        }
-    }
-
-    void MainWindow::SetHoveredLinkForSurface(ghostty_surface_t surface,
-                                              std::wstring url)
-    {
-        // Same owning-leaf routing as SetCursorShapeForSurface: the
-        // pointer can hover a link in a non-active pane, and the
-        // banner belongs to the pane the link lives in.
-        auto lookup = m_tabs.FindPaneBySurface(surface);
-        if (!lookup.pane) return;
-        if (auto* tc = Tab::PaneToTerminalControl(*lookup.pane)) {
-            tc->SetHoveredLink(winrt::hstring{ url });
-        }
     }
 
     void MainWindow::ReplaceConfig(ghostty_config_t cloned)

--- a/App/MainWindow.xaml.h
+++ b/App/MainWindow.xaml.h
@@ -149,15 +149,6 @@ namespace winrt::GhosttyWin32::implementation
         // belongs to this window.
         void ApplyCellSizeForSurface(ghostty_surface_t surface,
                                      ghostty_action_cell_size_s cell) override;
-        void SetScrollbarForSurface(ghostty_surface_t surface,
-                                    ghostty_action_scrollbar_s bar) override;
-        void StartSearchForSurface(ghostty_surface_t surface,
-                                   std::wstring needle) override;
-        void EndSearchForSurface(ghostty_surface_t surface) override;
-        void SetSearchTotalForSurface(ghostty_surface_t surface,
-                                      ptrdiff_t total) override;
-        void SetSearchSelectedForSurface(ghostty_surface_t surface,
-                                         ptrdiff_t selected) override;
         // Shared tail of the surface report and the adopt-time
         // re-arm: update the WM_SIZING snapping tag with the metrics
         // and re-read the window-step-resize gate. No-op on {0,0}
@@ -167,29 +158,17 @@ namespace winrt::GhosttyWin32::implementation
         // Terminal-driven appearance / lifecycle overrides. Bodies
         // are in MainWindow.xaml.cpp; the logic moved verbatim
         // from the old inline action_cb chunks.
+        // Surface directory (IWindow::FindSurfaceView): the one lookup
+        // through which every surface-targeted action reaches its
+        // pane. Replaces fourteen identical relay overrides.
+        host::ISurfaceView* FindSurfaceView(ghostty_surface_t surface) override;
         void ApplyBackgroundColor(uint8_t r, uint8_t g, uint8_t b) override;
-        void SetCursorShapeForSurface(ghostty_surface_t surface,
-                                      ghostty_action_mouse_shape_e shape) override;
-        void SetHoveredLinkForSurface(ghostty_surface_t surface,
-                                      std::wstring url) override;
-        void SetMouseVisibilityForSurface(ghostty_surface_t surface,
-                                          bool visible) override;
-        void SetSecureInputForSurface(ghostty_surface_t surface,
-                                      ghostty_action_secure_input_e mode) override;
         void SetPwdForSurface(ghostty_surface_t surface,
                               std::wstring pwd) override;
         void NotifyCommandFinishedForSurface(ghostty_surface_t surface,
                                              int exitCode,
                                              uint64_t durationNs) override;
-        void SetReadonlyForSurface(ghostty_surface_t surface,
-                                   bool readonly) override;
         void PromptTitleForSurface(ghostty_surface_t surface) override;
-        void AppendKeySequenceForSurface(ghostty_surface_t surface,
-                                         std::wstring triggerLabel) override;
-        void ClearKeySequenceForSurface(ghostty_surface_t surface) override;
-        void PushKeyTableForSurface(ghostty_surface_t surface,
-                                    std::wstring name) override;
-        void PopKeyTableForSurface(ghostty_surface_t surface, bool all) override;
         void ReplaceConfig(ghostty_config_t cloned) override;
         void ReloadConfig(bool soft) override;
         void ShowDesktopNotification(ghostty_surface_t surface,

--- a/App/TerminalControl.xaml.cpp
+++ b/App/TerminalControl.xaml.cpp
@@ -697,7 +697,7 @@ namespace winrt::GhosttyWin32::implementation
         });
     }
 
-    void TerminalControl::StartSearch(std::wstring const& needle)
+    void TerminalControl::StartSearch(std::wstring needle)
     {
         auto bar = SearchBar();
         auto input = SearchInput();

--- a/App/TerminalControl.xaml.h
+++ b/App/TerminalControl.xaml.h
@@ -2,6 +2,7 @@
 
 #include "TerminalControl.g.h"
 #include "Ghostty/Surface.h"
+#include "Host/ISurfaceView.h"
 #include "Host/ImeBuffer.h"
 #include "Interop/Encoding.h"
 #include "Win32/Clipboard.h"
@@ -80,7 +81,10 @@ namespace winrt::GhosttyWin32::implementation
     // lifetimes for one tab: TabFactory::Make() calls Attach() once
     // surface_new succeeds, and Tab's destructor calls Detach() to tear
     // everything down in the right order.
-    struct TerminalControl : TerminalControlT<TerminalControl>
+    // Implements core::host::ISurfaceView: libghostty's surface-
+    // targeted actions reach this control directly through the
+    // window's FindSurfaceView directory (no per-window relays).
+    struct TerminalControl : TerminalControlT<TerminalControl>, host::ISurfaceView
     {
         TerminalControl();
         ~TerminalControl();
@@ -173,16 +177,22 @@ namespace winrt::GhosttyWin32::implementation
         // Used both for the initial IBeam set in the ctor and for live
         // updates as the pointer moves over/off cells, links, resize
         // borders, etc.
-        void SetCursorShape(ghostty_action_mouse_shape_e shape);
+        void SetCursorShape(ghostty_action_mouse_shape_e shape) override;
 
         // ----- key-state badge (KEY_SEQUENCE / KEY_TABLE) -----
         // The pane owns the accumulated state (pending chord labels,
         // key-table name stack) because the actions only carry
         // deltas. All UI thread only.
         void AppendKeySequence(winrt::hstring const& label);
-        void ClearKeySequence();
+        void AppendKeySequence(std::wstring label) override {
+            AppendKeySequence(winrt::hstring{ label });
+        }
+        void ClearKeySequence() override;
         void PushKeyTable(winrt::hstring const& name);
-        void PopKeyTable(bool all);
+        void PushKeyTable(std::wstring name) override {
+            PushKeyTable(winrt::hstring{ name });
+        }
+        void PopKeyTable(bool all) override;
 
         // Show/hide the opaque background underlay beneath the swap
         // chain (#69 — see the XAML comment on OpaqueUnderlay for
@@ -193,26 +203,29 @@ namespace winrt::GhosttyWin32::implementation
 
         // Show/hide the read-only chip (READONLY action). The write
         // blocking is core-side; this is indicator only. UI thread.
-        void SetReadonly(bool readonly);
+        void SetReadonly(bool readonly) override;
 
         // Reflect SECURE_INPUT on this pane's badge. ON/OFF set the
         // state directly; TOGGLE flips it here because the pane owns
         // the indicator state (ghostty's toggle keybind carries no
         // absolute value). UI thread only.
-        void SetSecureInput(ghostty_action_secure_input_e mode);
+        void SetSecureInput(ghostty_action_secure_input_e mode) override;
 
         // Mirror ghostty's MOUSE_VISIBILITY on this pane: false hides
         // the pointer (mouse-hide-while-typing), true restores the
         // last MOUSE_SHAPE. UI thread only. ghostty drives both
         // directions (hide on keypress, show on pointer move), so
         // this holds no policy — just the ProtectedCursor mechanics.
-        void SetMouseVisibility(bool visible);
+        void SetMouseVisibility(bool visible) override;
 
         // Show the hovered-link banner with `url`, or hide it when
         // `url` is empty. UI thread only — the caller dispatches from
         // the renderer thread. See the LinkBanner comment in the XAML
         // for why this is an in-tree overlay and not a popup (#61).
         void SetHoveredLink(winrt::hstring const& url);
+        void SetHoveredLink(std::wstring url) override {
+            SetHoveredLink(winrt::hstring{ url });
+        }
 
         // Reflect the SCROLLBAR report on the overlay scrollbar
         // (#154): total scrollback rows, viewport offset, viewport
@@ -221,7 +234,7 @@ namespace winrt::GhosttyWin32::implementation
         // thread only. Core-driven updates are guarded so the bar's
         // ValueChanged does not echo back into a scroll_to_row
         // (the GTK apprt blocks its adjustment signals the same way).
-        void SetScrollbar(ghostty_action_scrollbar_s bar);
+        void SetScrollbar(ghostty_action_scrollbar_s bar) override;
 
         // ----- search bar -----
         // ghostty drives open/close and the counts; the pane owns
@@ -229,10 +242,10 @@ namespace winrt::GhosttyWin32::implementation
         // search_selection when `needle` is non-empty), close hides
         // it and returns focus to the terminal. Counts are -1 while
         // unknown; `selected` is 1-based. UI thread only.
-        void StartSearch(std::wstring const& needle);
-        void EndSearch();
-        void SetSearchTotal(ptrdiff_t total);
-        void SetSearchSelected(ptrdiff_t selected);
+        void StartSearch(std::wstring needle) override;
+        void EndSearch() override;
+        void SetSearchTotal(ptrdiff_t total) override;
+        void SetSearchSelected(ptrdiff_t selected) override;
         // If the bar is open, put keyboard focus on its input box and
         // return true; otherwise do nothing and return false. Lets
         // the window's activation focus-restore keep the bar in

--- a/Core/Core.vcxproj
+++ b/Core/Core.vcxproj
@@ -96,6 +96,7 @@
     <ClInclude Include="Ghostty\IGhosttyRuntime.h" />
     <ClInclude Include="Ghostty\RuntimeConfigFactory.h" />
     <ClInclude Include="Ghostty\Surface.h" />
+    <ClInclude Include="Host\ISurfaceView.h" />
     <ClInclude Include="Host\IWindow.h" />
     <ClInclude Include="Host\ImeBuffer.h" />
     <ClInclude Include="Host\KeyModifiers.h" />

--- a/Core/Ghostty/Actions/Actions.cpp
+++ b/Core/Ghostty/Actions/Actions.cpp
@@ -346,8 +346,8 @@ bool Actions::OnColorChange(ghostty_action_color_change_s cc) {
 bool Actions::OnMouseShape(ghostty_surface_t surface,
                                   ghostty_action_mouse_shape_e shape) {
     if (!surface) return true;
-    DispatchToView([this, surface, shape]() {
-        m_view.SetCursorShapeForSurface(surface, shape);
+    DispatchToSurface(surface, [shape](host::ISurfaceView& v) {
+        v.SetCursorShape(shape);
     });
     return true;
 }
@@ -356,8 +356,8 @@ bool Actions::OnMouseVisibility(ghostty_surface_t surface,
                                 ghostty_action_mouse_visibility_e visibility) {
     if (!surface) return true;
     const bool visible = visibility == GHOSTTY_MOUSE_VISIBLE;
-    DispatchToView([this, surface, visible]() {
-        m_view.SetMouseVisibilityForSurface(surface, visible);
+    DispatchToSurface(surface, [visible](host::ISurfaceView& v) {
+        v.SetMouseVisibility(visible);
     });
     return true;
 }
@@ -367,8 +367,8 @@ bool Actions::OnSecureInput(ghostty_surface_t surface,
     if (!surface) return true;
     // TOGGLE resolution happens in the view: the indicator is
     // per-pane visual state, so the pane owns the current value.
-    DispatchToView([this, surface, mode]() {
-        m_view.SetSecureInputForSurface(surface, mode);
+    DispatchToSurface(surface, [mode](host::ISurfaceView& v) {
+        v.SetSecureInput(mode);
     });
     return true;
 }
@@ -398,8 +398,8 @@ bool Actions::OnReadonly(ghostty_surface_t surface,
                          ghostty_action_readonly_e readonly) {
     if (!surface) return true;
     const bool on = readonly == GHOSTTY_READONLY_ON;
-    DispatchToView([this, surface, on]() {
-        m_view.SetReadonlyForSurface(surface, on);
+    DispatchToSurface(surface, [on](host::ISurfaceView& v) {
+        v.SetReadonly(on);
     });
     return true;
 }
@@ -419,14 +419,14 @@ bool Actions::OnKeySequence(ghostty_surface_t surface,
                             ghostty_action_key_sequence_s seq) {
     if (!surface) return true;
     if (!seq.active) {
-        DispatchToView([this, surface]() {
-            m_view.ClearKeySequenceForSurface(surface);
+        DispatchToSurface(surface, [](host::ISurfaceView& v) {
+            v.ClearKeySequence();
         });
         return true;
     }
     std::wstring label = TriggerLabel(seq.trigger);
-    DispatchToView([this, surface, label = std::move(label)]() mutable {
-        m_view.AppendKeySequenceForSurface(surface, std::move(label));
+    DispatchToSurface(surface, [label = std::move(label)](host::ISurfaceView& v) mutable {
+        v.AppendKeySequence(std::move(label));
     });
     return true;
 }
@@ -443,16 +443,16 @@ bool Actions::OnKeyTable(ghostty_surface_t surface,
                     table.value.activate.name,
                     static_cast<int>(table.value.activate.len));
             }
-            DispatchToView([this, surface, name = std::move(name)]() mutable {
-                m_view.PushKeyTableForSurface(surface, std::move(name));
+            DispatchToSurface(surface, [name = std::move(name)](host::ISurfaceView& v) mutable {
+                v.PushKeyTable(std::move(name));
             });
             return true;
         }
         case GHOSTTY_KEY_TABLE_DEACTIVATE:
         case GHOSTTY_KEY_TABLE_DEACTIVATE_ALL: {
             const bool all = table.tag == GHOSTTY_KEY_TABLE_DEACTIVATE_ALL;
-            DispatchToView([this, surface, all]() {
-                m_view.PopKeyTableForSurface(surface, all);
+            DispatchToSurface(surface, [all](host::ISurfaceView& v) {
+                v.PopKeyTable(all);
             });
             return true;
         }
@@ -469,8 +469,8 @@ bool Actions::OnMouseOverLink(ghostty_surface_t surface,
     std::wstring wide;
     if (link.url && link.len > 0)
         wide = interop::Encoding::toUtf16(link.url, static_cast<int>(link.len));
-    DispatchToView([this, surface, wide = std::move(wide)]() mutable {
-        m_view.SetHoveredLinkForSurface(surface, std::move(wide));
+    DispatchToSurface(surface, [wide = std::move(wide)](host::ISurfaceView& v) mutable {
+        v.SetHoveredLink(std::move(wide));
     });
     return true;
 }
@@ -512,8 +512,8 @@ bool Actions::OnCellSize(ghostty_surface_t surface,
 bool Actions::OnScrollbar(ghostty_surface_t surface,
                           ghostty_action_scrollbar_s bar) {
     if (!surface) return true;
-    DispatchToView([this, surface, bar]() {
-        m_view.SetScrollbarForSurface(surface, bar);
+    DispatchToSurface(surface, [bar](host::ISurfaceView& v) {
+        v.SetScrollbar(bar);
     });
     return true;
 }
@@ -528,16 +528,16 @@ bool Actions::OnStartSearch(ghostty_surface_t surface,
     std::wstring needle;
     if (search.needle && *search.needle)
         needle = interop::Encoding::toUtf16(search.needle);
-    DispatchToView([this, surface, needle = std::move(needle)]() mutable {
-        m_view.StartSearchForSurface(surface, std::move(needle));
+    DispatchToSurface(surface, [needle = std::move(needle)](host::ISurfaceView& v) mutable {
+        v.StartSearch(std::move(needle));
     });
     return true;
 }
 
 bool Actions::OnEndSearch(ghostty_surface_t surface) {
     if (!surface) return true;
-    DispatchToView([this, surface]() {
-        m_view.EndSearchForSurface(surface);
+    DispatchToSurface(surface, [](host::ISurfaceView& v) {
+        v.EndSearch();
     });
     return true;
 }
@@ -545,8 +545,8 @@ bool Actions::OnEndSearch(ghostty_surface_t surface) {
 bool Actions::OnSearchTotal(ghostty_surface_t surface,
                             ghostty_action_search_total_s total) {
     if (!surface) return true;
-    DispatchToView([this, surface, total]() {
-        m_view.SetSearchTotalForSurface(surface, total.total);
+    DispatchToSurface(surface, [total](host::ISurfaceView& v) {
+        v.SetSearchTotal(total.total);
     });
     return true;
 }
@@ -554,8 +554,8 @@ bool Actions::OnSearchTotal(ghostty_surface_t surface,
 bool Actions::OnSearchSelected(ghostty_surface_t surface,
                                ghostty_action_search_selected_s selected) {
     if (!surface) return true;
-    DispatchToView([this, surface, selected]() {
-        m_view.SetSearchSelectedForSurface(surface, selected.selected);
+    DispatchToSurface(surface, [selected](host::ISurfaceView& v) {
+        v.SetSearchSelected(selected.selected);
     });
     return true;
 }

--- a/Core/Ghostty/Actions/Actions.h
+++ b/Core/Ghostty/Actions/Actions.h
@@ -218,6 +218,22 @@ private:
             });
     }
 
+    // Surface-targeted variant: hop to the UI thread, resolve the
+    // surface to its pane view through the window's directory, and
+    // hand the view to `work`. The lookup and the use happen in the
+    // same dispatched lambda, which is what makes the borrowed
+    // ISurfaceView* safe (the pane cannot be torn down in between).
+    // A surface that no longer maps to a view — closed, or torn out
+    // to another window before the hop landed — is silently dropped,
+    // exactly as the old per-window relays did after their lookup
+    // missed.
+    template <class F>
+    void DispatchToSurface(ghostty_surface_t surface, F&& work) {
+        DispatchToView([this, surface, work = std::forward<F>(work)]() mutable {
+            if (auto* view = m_view.FindSurfaceView(surface)) work(*view);
+        });
+    }
+
     // Initial window size from GHOSTTY_ACTION_INITIAL_SIZE
     // (physical pixels). Zero means "not yet received" —
     // OnResetWindowSize falls back to a DPI-scaled 1280×720 in

--- a/Core/Host/ISurfaceView.h
+++ b/Core/Host/ISurfaceView.h
@@ -1,0 +1,93 @@
+#pragma once
+
+#include "ghostty.h"
+#include <cstddef>
+#include <string>
+
+namespace core::host {
+
+// The host-side view of ONE ghostty surface — what a pane's control
+// must be able to do when libghostty sends a surface-targeted action.
+//
+// Why this exists: ghostty addresses most actions to a surface, but
+// the host used to expose only a per-window interface (IWindow), so
+// every surface action went "dispatcher → window → look the pane up
+// → forward to the control" — fourteen identical five-line relays on
+// MainWindow whose only job was the lookup. The window was acting as
+// a post office. Now the window is a directory instead: Actions asks
+// IWindow::FindSurfaceView(surface) once and talks to the view
+// directly. Adding a surface action means one method here and one
+// implementation on the control, with no window code at all.
+//
+// WinUI-agnostic on purpose (std::wstring, plain enums) so Core can
+// be compiled and unit-tested without XAML; the App layer's
+// TerminalControl implements it. Every method runs on the UI
+// thread — Actions dispatches before calling.
+//
+// Ownership: the pane's control implements this and owns the
+// surface. Pointers handed out by FindSurfaceView are borrowed and
+// valid only for the duration of the dispatched call in which they
+// were obtained (the lookup happens on the UI thread, in the same
+// dispatched lambda that uses the result, so the pane cannot be torn
+// down in between).
+class ISurfaceView {
+public:
+    virtual ~ISurfaceView() = default;
+
+    // ----- pointer -----
+
+    // MOUSE_SHAPE: ghostty asked for a cursor shape over this pane.
+    virtual void SetCursorShape(ghostty_action_mouse_shape_e shape) = 0;
+
+    // MOUSE_VISIBILITY: HIDDEN while the user types (config
+    // `mouse-hide-while-typing`), VISIBLE again on the next pointer
+    // move. ghostty drives both directions; the host only mirrors.
+    virtual void SetMouseVisibility(bool visible) = 0;
+
+    // MOUSE_OVER_LINK: show the hovered-link banner with `url`, or
+    // hide it when `url` is empty (upstream fires an empty payload
+    // when the pointer leaves the link).
+    virtual void SetHoveredLink(std::wstring url) = 0;
+
+    // ----- status indicators -----
+
+    // SECURE_INPUT: ON / OFF from shell integration (password
+    // prompt detected / ended), TOGGLE from the toggle_secure_input
+    // keybind. The view resolves TOGGLE against its own state — the
+    // indicator is pane-visual state, so the pane owns it.
+    virtual void SetSecureInput(ghostty_action_secure_input_e mode) = 0;
+
+    // READONLY: indicator only — the pty-write blocking lives in
+    // libghostty and already works.
+    virtual void SetReadonly(bool readonly) = 0;
+
+    // KEY_SEQUENCE / KEY_TABLE: modal keyboard state, pre-formatted
+    // by Core (TriggerLabel) so the view never touches ghostty
+    // trigger structs. The pane owns the accumulated state (pending
+    // chord list, key-table stack) because that is where it renders.
+    virtual void AppendKeySequence(std::wstring triggerLabel) = 0;
+    virtual void ClearKeySequence() = 0;
+    virtual void PushKeyTable(std::wstring name) = 0;
+    virtual void PopKeyTable(bool all) = 0;
+
+    // ----- scrollback -----
+
+    // SCROLLBAR: total rows, viewport offset, viewport length. Fires
+    // on every scroll and on screen changes; feeds the overlay
+    // scrollbar (#154).
+    virtual void SetScrollbar(ghostty_action_scrollbar_s bar) = 0;
+
+    // ----- search bar -----
+    // ghostty owns matching and the lifecycle; the view owns the
+    // input box and talks back through binding actions
+    // (Surface::Search / NavigateSearch / EndSearch). `needle` is
+    // empty for a bare open and pre-filled by search_selection.
+    // `total` / `selected` are -1 while unknown; `selected` is
+    // 1-based.
+    virtual void StartSearch(std::wstring needle) = 0;
+    virtual void EndSearch() = 0;
+    virtual void SetSearchTotal(ptrdiff_t total) = 0;
+    virtual void SetSearchSelected(ptrdiff_t selected) = 0;
+};
+
+}  // namespace core::host

--- a/Core/Host/IWindow.h
+++ b/Core/Host/IWindow.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "ghostty.h"
+#include "Host/ISurfaceView.h"
 #include <windows.h>
 #include <cstdint>
 #include <functional>
@@ -187,38 +188,23 @@ struct IWindow {
     // remember anything.
     virtual void SetFloatOnTop(ghostty_action_float_window_e mode) = 0;
 
+    // ----- surface directory -----
+
+    // Resolve a ghostty surface to the pane view that owns it, or
+    // nullptr if this window has no such pane (the surface was closed,
+    // or was torn out to another window). This is the ONE place a
+    // surface-targeted action is looked up: Actions calls it on the
+    // UI thread inside the dispatched lambda and then talks to the
+    // ISurfaceView directly, so the window never relays per-surface
+    // state. The returned pointer is borrowed and valid only within
+    // that same dispatched call.
+    virtual ISurfaceView* FindSurfaceView(ghostty_surface_t surface) = 0;
+
     // ----- terminal-driven appearance + lifecycle -----
 
     // Apply a new background colour (caption bar + XAML root) in
     // response to COLOR_CHANGE / DECCC. R/G/B are 0-255.
     virtual void ApplyBackgroundColor(uint8_t r, uint8_t g, uint8_t b) = 0;
-
-    // Set the pointer cursor shape on the pane owning `surface`.
-    // (Currently routes to the active leaf of the tab — issue #65
-    // tracks moving this to the originating leaf.)
-    virtual void SetCursorShapeForSurface(ghostty_surface_t surface,
-                                          ghostty_action_mouse_shape_e shape) = 0;
-
-    // Show or hide the pointer cursor over the pane owning `surface`.
-    // MOUSE_VISIBILITY fires with HIDDEN while the user types (config
-    // `mouse-hide-while-typing`) and with VISIBLE again on the next
-    // pointer move — ghostty drives both directions, the host only
-    // mirrors them. Hiding goes through WinUI's ProtectedCursor
-    // (issue #60: a WM_SETCURSOR subclass loses to WinUI re-asserting
-    // the shape on every pointer move).
-    virtual void SetMouseVisibilityForSurface(ghostty_surface_t surface,
-                                              bool visible) = 0;
-
-    // Reflect SECURE_INPUT on the pane owning `surface`: ghostty's
-    // shell integration fires ON when a password prompt is detected
-    // and OFF when it ends; the toggle_secure_input keybind fires
-    // TOGGLE. The view resolves TOGGLE against its own per-pane
-    // state (the indicator is pane-visual state, so the pane owns
-    // it). App-targeted SECURE_INPUT never reaches this — that
-    // variant is macOS's EnableSecureEventInput, which has no
-    // Windows counterpart and stays acked in the dispatcher.
-    virtual void SetSecureInputForSurface(ghostty_surface_t surface,
-                                          ghostty_action_secure_input_e mode) = 0;
 
     // PROMPT_TITLE: the prompt_surface_title / prompt_tab_title
     // keybind asked for a rename-title prompt. Both variants
@@ -227,37 +213,6 @@ struct IWindow {
     // already use. UI thread hop happens in the handler; the view
     // shows a ContentDialog and applies the result itself.
     virtual void PromptTitleForSurface(ghostty_surface_t surface) = 0;
-
-    // READONLY: the toggle_readonly keybind flipped the surface's
-    // read-only state. The functional half (pty writes blocked)
-    // lives in libghostty and already works — this is purely the
-    // indicator, so the user can tell why their keystrokes stopped
-    // reaching the shell.
-    virtual void SetReadonlyForSurface(ghostty_surface_t surface,
-                                       bool readonly) = 0;
-
-    // Viewport position within the scrollback for a surface this
-    // window owns (SCROLLBAR action: total rows, viewport offset,
-    // viewport length). Feeds the owning pane's overlay scrollbar
-    // (#154). Fires on every scroll and on screen changes.
-    virtual void SetScrollbarForSurface(ghostty_surface_t surface,
-                                        ghostty_action_scrollbar_s bar) = 0;
-
-    // ----- search bar (START_SEARCH / END_SEARCH / SEARCH_TOTAL /
-    // SEARCH_SELECTED, all surface-targeted) -----
-    // ghostty drives the lifecycle and the counts; the host owns
-    // the input box and talks back through binding actions
-    // (Surface::Search / NavigateSearch / EndSearch). `needle` is
-    // empty for a bare open and pre-filled by search_selection.
-    // `total` / `selected` are -1 while unknown; `selected` is
-    // 1-based.
-    virtual void StartSearchForSurface(ghostty_surface_t surface,
-                                       std::wstring needle) = 0;
-    virtual void EndSearchForSurface(ghostty_surface_t surface) = 0;
-    virtual void SetSearchTotalForSurface(ghostty_surface_t surface,
-                                          ptrdiff_t total) = 0;
-    virtual void SetSearchSelectedForSurface(ghostty_surface_t surface,
-                                             ptrdiff_t selected) = 0;
 
     // COMMAND_FINISHED: a shell-integration-tracked command ended.
     // The view owns the whole policy: it reads the notify-on-
@@ -275,39 +230,6 @@ struct IWindow {
     // the user last worked in". An empty pwd clears the tooltip.
     virtual void SetPwdForSurface(ghostty_surface_t surface,
                                   std::wstring pwd) = 0;
-
-    // ----- key-state indicator (KEY_SEQUENCE / KEY_TABLE) -----
-    // Both actions are surface-targeted progress reports about
-    // modal keyboard state; the pane owns the accumulated state
-    // (pending chord list, key-table stack) because that is where
-    // the indicator renders. Labels arrive pre-formatted from the
-    // Core side (TriggerLabel) so the view never touches ghostty
-    // trigger structs.
-
-    // KEY_SEQUENCE active=true: one more trigger was consumed by a
-    // pending multi-chord binding — append its label to the pane's
-    // pending display.
-    virtual void AppendKeySequenceForSurface(ghostty_surface_t surface,
-                                             std::wstring triggerLabel) = 0;
-    // KEY_SEQUENCE active=false: the sequence completed or aborted —
-    // clear the pane's pending display.
-    virtual void ClearKeySequenceForSurface(ghostty_surface_t surface) = 0;
-    // KEY_TABLE ACTIVATE: push a named table onto the pane's stack.
-    virtual void PushKeyTableForSurface(ghostty_surface_t surface,
-                                        std::wstring name) = 0;
-    // KEY_TABLE DEACTIVATE (all=false) / DEACTIVATE_ALL (all=true).
-    virtual void PopKeyTableForSurface(ghostty_surface_t surface,
-                                       bool all) = 0;
-
-    // Show or clear the hovered-link banner on the pane owning
-    // `surface`. MOUSE_OVER_LINK fires with the URL while the pointer
-    // is on a link and with an empty payload when it leaves, so an
-    // empty `url` means hide. The banner mirrors upstream's bottom-
-    // corner URL display (macOS URLHoverBanner / GTK mouse-hover-url
-    // label); issue #61 ruled out a Win32 tooltip popup — a TOPMOST
-    // window over the DComp surface crashed the process on URL click.
-    virtual void SetHoveredLinkForSurface(ghostty_surface_t surface,
-                                          std::wstring url) = 0;
 
     // Replace the GhosttyApp's stored config with `cloned`. Takes
     // ownership: the implementation is responsible for freeing it

--- a/Tests/MockMainWindowView.h
+++ b/Tests/MockMainWindowView.h
@@ -140,43 +140,132 @@ struct MockMainWindowView : core::host::IWindow {
     int redoCalls = 0;
     void Redo() override { ++redoCalls; }
 
-    int startSearchCalls = 0;
-    ghostty_surface_t lastStartSearchSurface = nullptr;
-    std::wstring lastStartSearchNeedle;
-    void StartSearchForSurface(ghostty_surface_t surface,
-                               std::wstring needle) override {
-        ++startSearchCalls;
-        lastStartSearchSurface = surface;
-        lastStartSearchNeedle = std::move(needle);
+    // ----- surface directory (ISurfaceView) -----
+    // One mock pane view. FindSurfaceView records which surface was
+    // asked for and returns this view for any non-null surface unless
+    // a test sets `surfaceViewFor` to narrow it — that lets tests
+    // cover both "routes to the owning pane" and "unknown surface is
+    // dropped" without a second mock. Call counters and last-values
+    // live on the view; the aliases below keep the field names the
+    // existing tests use.
+    struct MockSurfaceView : core::host::ISurfaceView {
+        int setCursorShapeCalls = 0;
+        ghostty_action_mouse_shape_e lastCursorShape{};
+        void SetCursorShape(ghostty_action_mouse_shape_e shape) override {
+            ++setCursorShapeCalls; lastCursorShape = shape;
+        }
+        int setMouseVisibilityCalls = 0;
+        bool lastMouseVisible = true;
+        void SetMouseVisibility(bool visible) override {
+            ++setMouseVisibilityCalls; lastMouseVisible = visible;
+        }
+        int setHoveredLinkCalls = 0;
+        std::wstring lastHoveredLinkUrl;
+        void SetHoveredLink(std::wstring url) override {
+            ++setHoveredLinkCalls; lastHoveredLinkUrl = std::move(url);
+        }
+        int setSecureInputCalls = 0;
+        ghostty_action_secure_input_e lastSecureInputMode{};
+        void SetSecureInput(ghostty_action_secure_input_e mode) override {
+            ++setSecureInputCalls; lastSecureInputMode = mode;
+        }
+        int setReadonlyCalls = 0;
+        bool lastReadonly = false;
+        void SetReadonly(bool readonly) override {
+            ++setReadonlyCalls; lastReadonly = readonly;
+        }
+        int appendKeySequenceCalls = 0;
+        std::wstring lastKeySequenceLabel;
+        void AppendKeySequence(std::wstring label) override {
+            ++appendKeySequenceCalls; lastKeySequenceLabel = std::move(label);
+        }
+        int clearKeySequenceCalls = 0;
+        void ClearKeySequence() override { ++clearKeySequenceCalls; }
+        int pushKeyTableCalls = 0;
+        std::wstring lastKeyTableName;
+        void PushKeyTable(std::wstring name) override {
+            ++pushKeyTableCalls; lastKeyTableName = std::move(name);
+        }
+        int popKeyTableCalls = 0;
+        bool lastPopKeyTableAll = false;
+        void PopKeyTable(bool all) override {
+            ++popKeyTableCalls; lastPopKeyTableAll = all;
+        }
+        int setScrollbarCalls = 0;
+        ghostty_action_scrollbar_s lastScrollbar{};
+        void SetScrollbar(ghostty_action_scrollbar_s bar) override {
+            ++setScrollbarCalls; lastScrollbar = bar;
+        }
+        int startSearchCalls = 0;
+        std::wstring lastStartSearchNeedle;
+        void StartSearch(std::wstring needle) override {
+            ++startSearchCalls; lastStartSearchNeedle = std::move(needle);
+        }
+        int endSearchCalls = 0;
+        void EndSearch() override { ++endSearchCalls; }
+        int setSearchTotalCalls = 0;
+        ptrdiff_t lastSearchTotal = -99;
+        void SetSearchTotal(ptrdiff_t total) override {
+            ++setSearchTotalCalls; lastSearchTotal = total;
+        }
+        int setSearchSelectedCalls = 0;
+        ptrdiff_t lastSearchSelected = -99;
+        void SetSearchSelected(ptrdiff_t selected) override {
+            ++setSearchSelectedCalls; lastSearchSelected = selected;
+        }
+    };
+    MockSurfaceView surfaceView;
+    // When non-null, only this surface resolves to `surfaceView`;
+    // any other surface is "not in this window" (nullptr).
+    ghostty_surface_t surfaceViewFor = nullptr;
+    int findSurfaceViewCalls = 0;
+    ghostty_surface_t lastFindSurfaceViewSurface = nullptr;
+    core::host::ISurfaceView* FindSurfaceView(ghostty_surface_t surface) override {
+        ++findSurfaceViewCalls;
+        lastFindSurfaceViewSurface = surface;
+        if (!surface) return nullptr;
+        if (surfaceViewFor && surface != surfaceViewFor) return nullptr;
+        return &surfaceView;
     }
-    int endSearchCalls = 0;
-    ghostty_surface_t lastEndSearchSurface = nullptr;
-    void EndSearchForSurface(ghostty_surface_t surface) override {
-        ++endSearchCalls;
-        lastEndSearchSurface = surface;
-    }
-    int setSearchTotalCalls = 0;
-    ptrdiff_t lastSearchTotal = -99;
-    void SetSearchTotalForSurface(ghostty_surface_t, ptrdiff_t total) override {
-        ++setSearchTotalCalls;
-        lastSearchTotal = total;
-    }
-    int setSearchSelectedCalls = 0;
-    ptrdiff_t lastSearchSelected = -99;
-    void SetSearchSelectedForSurface(ghostty_surface_t, ptrdiff_t selected) override {
-        ++setSearchSelectedCalls;
-        lastSearchSelected = selected;
-    }
-
-    int setScrollbarCalls = 0;
-    ghostty_surface_t lastScrollbarSurface = nullptr;
-    ghostty_action_scrollbar_s lastScrollbar{};
-    void SetScrollbarForSurface(ghostty_surface_t surface,
-                                ghostty_action_scrollbar_s bar) override {
-        ++setScrollbarCalls;
-        lastScrollbarSurface = surface;
-        lastScrollbar = bar;
-    }
+    // Field aliases so the existing tests keep reading naturally.
+    int& setCursorShapeCalls = surfaceView.setCursorShapeCalls;
+    ghostty_action_mouse_shape_e& lastCursorShape = surfaceView.lastCursorShape;
+    int& setMouseVisibilityCalls = surfaceView.setMouseVisibilityCalls;
+    bool& lastMouseVisible = surfaceView.lastMouseVisible;
+    int& setHoveredLinkCalls = surfaceView.setHoveredLinkCalls;
+    std::wstring& lastHoveredLinkUrl = surfaceView.lastHoveredLinkUrl;
+    int& setSecureInputCalls = surfaceView.setSecureInputCalls;
+    ghostty_action_secure_input_e& lastSecureInputMode = surfaceView.lastSecureInputMode;
+    int& setReadonlyCalls = surfaceView.setReadonlyCalls;
+    bool& lastReadonly = surfaceView.lastReadonly;
+    int& appendKeySequenceCalls = surfaceView.appendKeySequenceCalls;
+    std::wstring& lastKeySequenceLabel = surfaceView.lastKeySequenceLabel;
+    int& clearKeySequenceCalls = surfaceView.clearKeySequenceCalls;
+    int& pushKeyTableCalls = surfaceView.pushKeyTableCalls;
+    std::wstring& lastKeyTableName = surfaceView.lastKeyTableName;
+    int& popKeyTableCalls = surfaceView.popKeyTableCalls;
+    bool& lastPopKeyTableAll = surfaceView.lastPopKeyTableAll;
+    int& setScrollbarCalls = surfaceView.setScrollbarCalls;
+    ghostty_action_scrollbar_s& lastScrollbar = surfaceView.lastScrollbar;
+    int& startSearchCalls = surfaceView.startSearchCalls;
+    std::wstring& lastStartSearchNeedle = surfaceView.lastStartSearchNeedle;
+    int& endSearchCalls = surfaceView.endSearchCalls;
+    int& setSearchTotalCalls = surfaceView.setSearchTotalCalls;
+    ptrdiff_t& lastSearchTotal = surfaceView.lastSearchTotal;
+    int& setSearchSelectedCalls = surfaceView.setSearchSelectedCalls;
+    ptrdiff_t& lastSearchSelected = surfaceView.lastSearchSelected;
+    // The "which surface" the old relays recorded is now the
+    // directory's last lookup.
+    ghostty_surface_t& lastCursorShapeSurface = lastFindSurfaceViewSurface;
+    ghostty_surface_t& lastHoveredLinkSurface = lastFindSurfaceViewSurface;
+    ghostty_surface_t& lastSecureInputSurface = lastFindSurfaceViewSurface;
+    ghostty_surface_t& lastReadonlySurface = lastFindSurfaceViewSurface;
+    ghostty_surface_t& lastKeySequenceSurface = lastFindSurfaceViewSurface;
+    ghostty_surface_t& lastKeyTableSurface = lastFindSurfaceViewSurface;
+    ghostty_surface_t& lastMouseVisibilitySurface = lastFindSurfaceViewSurface;
+    ghostty_surface_t& lastScrollbarSurface = lastFindSurfaceViewSurface;
+    ghostty_surface_t& lastStartSearchSurface = lastFindSurfaceViewSurface;
+    ghostty_surface_t& lastEndSearchSurface = lastFindSurfaceViewSurface;
 
     int applyCellSizeCalls = 0;
     ghostty_surface_t lastCellSizeSurface = nullptr;
@@ -211,49 +300,11 @@ struct MockMainWindowView : core::host::IWindow {
         lastBgB = b;
     }
 
-    int setCursorShapeCalls = 0;
-    ghostty_surface_t lastCursorShapeSurface = nullptr;
-    ghostty_action_mouse_shape_e lastCursorShape{};
-    void SetCursorShapeForSurface(ghostty_surface_t s,
-                                  ghostty_action_mouse_shape_e shape) override {
-        ++setCursorShapeCalls;
-        lastCursorShapeSurface = s;
-        lastCursorShape = shape;
-    }
-
-    int setHoveredLinkCalls = 0;
-    ghostty_surface_t lastHoveredLinkSurface = nullptr;
-    std::wstring lastHoveredLinkUrl;
-    void SetHoveredLinkForSurface(ghostty_surface_t s, std::wstring url) override {
-        ++setHoveredLinkCalls;
-        lastHoveredLinkSurface = s;
-        lastHoveredLinkUrl = std::move(url);
-    }
-
-    int setSecureInputCalls = 0;
-    ghostty_surface_t lastSecureInputSurface = nullptr;
-    ghostty_action_secure_input_e lastSecureInputMode{};
-    void SetSecureInputForSurface(ghostty_surface_t s,
-                                  ghostty_action_secure_input_e mode) override {
-        ++setSecureInputCalls;
-        lastSecureInputSurface = s;
-        lastSecureInputMode = mode;
-    }
-
     int promptTitleCalls = 0;
     ghostty_surface_t lastPromptTitleSurface = nullptr;
     void PromptTitleForSurface(ghostty_surface_t s) override {
         ++promptTitleCalls;
         lastPromptTitleSurface = s;
-    }
-
-    int setReadonlyCalls = 0;
-    ghostty_surface_t lastReadonlySurface = nullptr;
-    bool lastReadonly = false;
-    void SetReadonlyForSurface(ghostty_surface_t s, bool readonly) override {
-        ++setReadonlyCalls;
-        lastReadonlySurface = s;
-        lastReadonly = readonly;
     }
 
     int notifyCommandFinishedCalls = 0;
@@ -275,47 +326,6 @@ struct MockMainWindowView : core::host::IWindow {
         ++setPwdCalls;
         lastPwdSurface = s;
         lastPwd = std::move(pwd);
-    }
-
-    int appendKeySequenceCalls = 0;
-    ghostty_surface_t lastKeySequenceSurface = nullptr;
-    std::wstring lastKeySequenceLabel;
-    void AppendKeySequenceForSurface(ghostty_surface_t s, std::wstring label) override {
-        ++appendKeySequenceCalls;
-        lastKeySequenceSurface = s;
-        lastKeySequenceLabel = std::move(label);
-    }
-
-    int clearKeySequenceCalls = 0;
-    void ClearKeySequenceForSurface(ghostty_surface_t s) override {
-        ++clearKeySequenceCalls;
-        lastKeySequenceSurface = s;
-    }
-
-    int pushKeyTableCalls = 0;
-    ghostty_surface_t lastKeyTableSurface = nullptr;
-    std::wstring lastKeyTableName;
-    void PushKeyTableForSurface(ghostty_surface_t s, std::wstring name) override {
-        ++pushKeyTableCalls;
-        lastKeyTableSurface = s;
-        lastKeyTableName = std::move(name);
-    }
-
-    int popKeyTableCalls = 0;
-    bool lastPopKeyTableAll = false;
-    void PopKeyTableForSurface(ghostty_surface_t s, bool all) override {
-        ++popKeyTableCalls;
-        lastKeyTableSurface = s;
-        lastPopKeyTableAll = all;
-    }
-
-    int setMouseVisibilityCalls = 0;
-    ghostty_surface_t lastMouseVisibilitySurface = nullptr;
-    bool lastMouseVisible = true;
-    void SetMouseVisibilityForSurface(ghostty_surface_t s, bool visible) override {
-        ++setMouseVisibilityCalls;
-        lastMouseVisibilitySurface = s;
-        lastMouseVisible = visible;
     }
 
     int replaceConfigCalls = 0;

--- a/Tests/test_ghostty_actions.cpp
+++ b/Tests/test_ghostty_actions.cpp
@@ -594,6 +594,47 @@ TEST(GhosttyActionsTest, SearchActionsNullSurfaceAreAckedNotDelivered) {
               view.setSearchTotalCalls + view.setSearchSelectedCalls, 0);
 }
 
+// ----- surface directory -----
+// Surface-targeted actions resolve their pane through
+// IWindow::FindSurfaceView inside the dispatched call. These pin
+// the two directory behaviours the old per-action relays had
+// implicitly: the lookup happens for the surface the action named,
+// and a surface the window doesn't own is dropped, not misrouted.
+
+TEST(GhosttyActionsTest, SurfaceActionsResolveThroughTheDirectory) {
+    MockMainWindowView view;
+    Actions actions(view);
+    auto surface = reinterpret_cast<ghostty_surface_t>(0xBEEF);
+    EXPECT_TRUE(actions.OnReadonly(surface, GHOSTTY_READONLY_ON));
+    EXPECT_EQ(view.findSurfaceViewCalls, 1);
+    EXPECT_EQ(view.lastFindSurfaceViewSurface, surface);
+    EXPECT_EQ(view.surfaceView.setReadonlyCalls, 1);
+    EXPECT_TRUE(view.surfaceView.lastReadonly);
+}
+
+TEST(GhosttyActionsTest, SurfaceActionsForUnknownSurfacesAreDropped) {
+    MockMainWindowView view;
+    Actions actions(view);
+    auto owned = reinterpret_cast<ghostty_surface_t>(0xBEEF);
+    auto foreign = reinterpret_cast<ghostty_surface_t>(0xCAFE);
+    // Only `owned` maps to a pane in this window.
+    view.surfaceViewFor = owned;
+
+    // Delivered and acked as handled (ghostty's contract), but the
+    // view never sees it — a torn-out or already-closed surface.
+    EXPECT_TRUE(actions.OnReadonly(foreign, GHOSTTY_READONLY_ON));
+    EXPECT_EQ(view.findSurfaceViewCalls, 1);
+    EXPECT_EQ(view.surfaceView.setReadonlyCalls, 0);
+
+    EXPECT_TRUE(actions.OnScrollbar(foreign, { 100, 90, 10 }));
+    EXPECT_EQ(view.surfaceView.setScrollbarCalls, 0);
+
+    // The owned surface still routes.
+    EXPECT_TRUE(actions.OnReadonly(owned, GHOSTTY_READONLY_OFF));
+    EXPECT_EQ(view.surfaceView.setReadonlyCalls, 1);
+    EXPECT_FALSE(view.surfaceView.lastReadonly);
+}
+
 TEST(GhosttyActionsTest, OnScrollbarNullSurfaceIsAckedNotDelivered) {
     MockMainWindowView view;
     Actions actions(view);


### PR DESCRIPTION
Refactor #1 of the MainWindow responsibility series. **Behavior is unchanged** — this restructures how surface-targeted actions reach their pane.

## Why

ghostty addresses most actions to a *surface*, but the host exposed only a per-*window* interface (`IWindow`). So every surface action went dispatcher → window → look the pane up → forward to the control: **fourteen identical five-line relays on MainWindow** whose only job was the lookup. The window was acting as a post office, and each new surface action meant an `IWindow` method + a MainWindow relay + a mock override that all said the same thing (the search bar alone added four).

<details><summary>日本語</summary>

ghostty の action の多くは *surface* 宛なのに、host は *window* 単位のインターフェース (`IWindow`) しか持っていなかった。そのため surface 宛 action はすべて dispatcher → window → pane を検索 → control に転送、という経路になり、MainWindow に**検索するだけの同型 relay が 14 個**並んでいた。窓が郵便局を兼ねている状態で、surface action を 1 つ足すたびに `IWindow` メソッド + MainWindow relay + mock override の 3 点セットが増えていた (検索バーだけで 4 つ)。

</details>

## What

- **`core::host::ISurfaceView`** (new, WinUI-agnostic): the view of one surface — cursor shape / visibility, hovered link, secure-input / readonly / key-state indicators, scrollbar, search bar. `TerminalControl` implements it; its existing methods become the overrides (hstring conveniences kept for in-App callers)
- **`IWindow`**: the fourteen `*ForSurface` relays are gone; one `FindSurfaceView(surface)` lookup replaces them. The window is now a **directory**, not a relay
- **`Actions::DispatchToSurface`**: hops to the UI thread, resolves the view through the directory, and calls it — lookup and use in the *same* dispatched lambda, which is what keeps the borrowed `ISurfaceView*` safe (the pane cannot be torn down in between)
- **MainWindow**: −171 lines (3030 → 2883); `FindSurfaceView` is the single remaining lookup
- **Mock**: `MockSurfaceView` + a mock directory (`surfaceViewFor` narrows ownership); reference aliases keep every existing test's field names, so the 40-odd existing action/dispatcher tests pass unmodified
- Two new tests pin the directory contract: actions resolve through `FindSurfaceView` for the named surface, and a surface the window doesn't own is **dropped, not misrouted** (the old relays' lookup-miss behavior, now explicit)

Kept on `IWindow` (8) because they need window judgement: split ops, tab title / copy / prompt, cell snap, command-finished policy, pwd tooltip.

<details><summary>日本語</summary>

- **`core::host::ISurfaceView`** (新設、WinUI 非依存): surface 1 個の view — カーソル形状/可視、リンク banner、secure-input / readonly / key-state バッジ、scrollbar、検索バー。`TerminalControl` が実装し、既存メソッドがそのまま override になる (App 内の呼び出し向けに hstring 版も残す)
- **`IWindow`**: `*ForSurface` relay 14 個を削除し、`FindSurfaceView(surface)` 1 個に。窓は relay ではなく**住所録**になる
- **`Actions::DispatchToSurface`**: UI スレッドへ hop → directory で view を解決 → 呼ぶ。lookup と使用が*同じ* dispatched lambda 内なので、借用した `ISurfaceView*` は安全 (間に pane が破棄されない)
- **MainWindow**: −171 行 (3030 → 2883)。残る lookup は `FindSurfaceView` だけ
- **Mock**: `MockSurfaceView` + mock directory (`surfaceViewFor` で所有を絞れる)。参照エイリアスで既存テストの field 名を維持し、40 本超の既存 action/dispatcher テストは無修正で通る
- directory の契約をテスト 2 本で固定: 指定 surface で `FindSurfaceView` を経由すること、窓が所有しない surface は**誤配せずドロップ**されること (旧 relay の lookup-miss 挙動を明示化)

`IWindow` に残した 8 個は窓の判断が要るもの: split 操作、タブタイトル/コピー/プロンプト、cell snap、command-finished ポリシー、pwd tooltip。

</details>

## Lifetime contracts touched

None of the 12 documented invariants are affected — this changes the *shape* of the relay, not any lifetime: L7 (dispatched work is gated by `m_alive`) still wraps `DispatchToSurface`; L4 (`m_activeSurface`) and L9 (weak_ref lambdas) are untouched. A closed/torn-out surface resolves to null and is dropped exactly as before.

## Verification (regression)

- [x] Tests.exe green (2 new + all existing)
- [x] Hover a link → banner; secure-input (Alt+Shift+I) and read-only (Alt+Shift+R) badges; key table (Ctrl+G > T) badge
- [x] mouse-hide-while-typing hides the cursor; moving shows it
- [x] Scrollbar drag and search bar (Ctrl+F) behave as in v0.8.0
- [x] Split: the action lands on the pane that owns the surface (e.g. read-only toggle in the right pane marks the right pane only)
- [x] Tear out a tab, then use the search bar in both windows → each routes to its own pane

<details><summary>日本語</summary>

- [x] Tests.exe green (新規 2 + 既存すべて)
- [x] リンクにホバー → banner。secure-input (Alt+Shift+I) / read-only (Alt+Shift+R) バッジ、key table (Ctrl+G > T) バッジ
- [x] mouse-hide-while-typing でカーソルが隠れ、動かすと戻る
- [x] scrollbar ドラッグと検索バー (Ctrl+F) が v0.8.0 と同じ挙動
- [x] split: action が surface を所有する pane に届く (右 pane で read-only を切り替えると右だけにバッジ)
- [x] タブを tear-out して両ウインドウで検索バー → それぞれ自分の pane に届く

</details>
