### PR TITLE
Derive the focused surface from Tab state instead of caching it

### DIFF
--- a/App/MainWindow.xaml.cpp
+++ b/App/MainWindow.xaml.cpp
@@ -976,9 +976,20 @@ namespace winrt::GhosttyWin32::implementation
         return static_cast<bool>(id) && m_tabs.FindByPaneId(id).tab != nullptr;
     }
 
+    bool MainWindow::IsActiveSurface(ghostty_surface_t surface) noexcept
+    {
+        if (!surface) return false;
+        try {
+            auto* tc = ActiveControl();
+            return tc && tc->Surface().Owns(surface);
+        } catch (winrt::hresult_error const&) {
+            // TabView() throws RO_E_CLOSED on a disposed window.
+            return false;
+        }
+    }
+
     void MainWindow::NotifySurfaceFocused(ghostty_surface_t surface) noexcept
     {
-        m_activeSurface = surface;
         // Route the focus event back into the owning Tab so it can
         // update its per-tab dim invariant. SetActivePane is idempotent
         // when `leaf` is already the tab's active leaf, so the deferred
@@ -1352,23 +1363,6 @@ namespace winrt::GhosttyWin32::implementation
         }
         // A stale press record must not keep the closed item alive.
         App::g_app->PressedTab().Forget(item);
-        // The focused-surface cache must not outlive the surfaces this
-        // close is about to free — same invariant CloseSurfaceByPaneId
-        // and ReleaseTornOutTab already hold. m_activeSurface can point
-        // at any pane in the tab, so walk them all rather than checking
-        // only the active control. The next GotFocus on the newly
-        // selected tab refills the slot.
-        if (m_activeSurface) {
-            if (auto* panelImpl =
-                    winrt::get_self<implementation::SplitPanel>(t->Panel())) {
-                if (panelImpl->Tree().FindPaneBy([this](Pane const& p) {
-                        auto const* tc = Tab::PaneToTerminalControl(p);
-                        return tc && tc->Surface().Owns(m_activeSurface);
-                    })) {
-                    m_activeSurface = nullptr;
-                }
-            }
-        }
         // Detach every pane before RemoveAt: SetSwapChainHandle(nullptr)
         // AVs at +0x1F8 inside microsoft.ui.xaml.dll if the panel has
         // already been unparented. Multi-pane tabs have multiple swap
@@ -1400,21 +1394,9 @@ namespace winrt::GhosttyWin32::implementation
     {
         auto* t = m_tabs.FindByItem(item);
         if (!t) return;
-        // Same bookkeeping as the immediate-teardown path: no stale
-        // press record, and the focused-surface cache must not point
-        // at a surface that is no longer reachable via the UI.
+        // Same bookkeeping as the immediate-teardown path: a stale
+        // press record must not keep the item alive.
         App::g_app->PressedTab().Forget(item);
-        if (m_activeSurface) {
-            if (auto* panelImpl =
-                    winrt::get_self<implementation::SplitPanel>(t->Panel())) {
-                if (panelImpl->Tree().FindPaneBy([this](Pane const& p) {
-                        auto const* tc = Tab::PaneToTerminalControl(p);
-                        return tc && tc->Surface().Owns(m_activeSurface);
-                    })) {
-                    m_activeSurface = nullptr;
-                }
-            }
-        }
         auto tv = TabView();
         uint32_t idx = 0;
         if (tv.TabItems().IndexOf(item, idx)) {
@@ -1941,7 +1923,7 @@ namespace winrt::GhosttyWin32::implementation
             // surface AND the window is in the foreground — a
             // command finishing in a visible, focused pane needs no
             // announcement.
-            const bool focused = surface == m_activeSurface &&
+            const bool focused = IsActiveSurface(surface) &&
                                  GetForegroundWindow() == m_hwnd;
             if (focused) return;
         }
@@ -2571,22 +2553,6 @@ namespace winrt::GhosttyWin32::implementation
         auto* t = m_tabs.FindByItem(item);
         if (!t) return nullptr;
 
-        // The focused-surface cache must not follow the tab out: the
-        // surfaces stay alive, but they stop being *this* window's
-        // surfaces. Walk the departing tab's leaves rather than just
-        // its active control — m_activeSurface can point at any pane.
-        if (m_activeSurface) {
-            if (auto* panelImpl =
-                    winrt::get_self<implementation::SplitPanel>(t->Panel())) {
-                if (panelImpl->Tree().FindPaneBy([this](Pane const& p) {
-                        auto const* tc = Tab::PaneToTerminalControl(p);
-                        return tc && tc->Surface().Owns(m_activeSurface);
-                    })) {
-                    m_activeSurface = nullptr;
-                }
-            }
-        }
-
         // Unparent the visual pieces but detach nothing: the swap
         // chains keep presenting while the tab is in flight.
         RemoveTabPanelFromAppContent(*t);
@@ -2764,12 +2730,6 @@ namespace winrt::GhosttyWin32::implementation
         // synchronously, before the Branch holding the TerminalControl
         // is destroyed.
         if (auto* tc = Tab::PaneToTerminalControl(*pane)) {
-            // Clear m_activeSurface if it pointed at the surface we're
-            // about to free — the focused-surface cache must never
-            // outlive the underlying ghostty_surface_t. The next
-            // TerminalControl::GotFocus on the retargeted sibling (or
-            // a new tab) will refill the slot.
-            if (tc->Surface().Owns(m_activeSurface)) m_activeSurface = nullptr;
             tc->Detach();
         }
 

--- a/App/MainWindow.xaml.h
+++ b/App/MainWindow.xaml.h
@@ -45,20 +45,22 @@ namespace winrt::GhosttyWin32::implementation
                           winrt::Microsoft::UI::Xaml::RoutedEventArgs const&);
 
         // Called by every TerminalControl when it receives keyboard
-        // focus (wired by TabFactory). Updates m_activeSurface so any
-        // future caller — APP-target action handlers, multi-window
-        // focus delivery, IPC / scripting bridges — can ask "which
-        // surface is the user looking at right now" without a
-        // separate tree walk. Public because TerminalControl needs to
-        // reach in via the host-supplied callback. UI thread only.
+        // focus (wired by TabFactory). Routes the event to the owning
+        // Tab so its active-pane state — and with it the per-tab
+        // dim overlay — follows keyboard focus. The window keeps no
+        // focused-surface cache of its own: "which surface is the
+        // user looking at" is answered by ActiveControl(), which reads
+        // the Tab state this call keeps current. Public because
+        // TerminalControl needs to reach in via the host-supplied
+        // callback. UI thread only.
         void NotifySurfaceFocused(ghostty_surface_t surface) noexcept;
 
-        // Last surface to receive keyboard focus inside this window.
-        // Null until the first focus delivery (typically the very
-        // first tab's TerminalControl GotFocus right after launch).
-        // Stays valid across alt-tab — we only clear it when the
-        // surface itself is torn down.
-        ghostty_surface_t GetActiveSurface() const noexcept { return m_activeSurface; }
+        // Whether `surface` is the one the user is looking at: the
+        // active pane of the active tab. Derived, never cached — a
+        // cache had to be invalidated on every close / tear-out /
+        // pane-close path, and each of those was a chance to let it
+        // outlive the surface (the old m_activeSurface contract).
+        bool IsActiveSurface(ghostty_surface_t surface) noexcept;
 
         // True when any leaf in this window's tab tree owns `surface`.
         // App::FindWindowForSurface iterates its window list and asks
@@ -389,10 +391,6 @@ namespace winrt::GhosttyWin32::implementation
         // to let the resulting WM_CLOSE (if any) through without
         // re-prompting. One-shot — the window is about to die.
         bool m_bypassCloseGate = false;
-        // Focus-tracked active surface. Set by NotifySurfaceFocused
-        // when a TerminalControl gains focus, cleared when the
-        // matching surface is torn down through CloseSurfaceByPaneId.
-        ghostty_surface_t m_activeSurface = nullptr;
         // Re-entrancy guard for the rename-title prompt: WinUI allows
         // one ContentDialog per XamlRoot, and a second ShowAsync while
         // one is up throws. Set when the dialog opens, cleared in its


### PR DESCRIPTION
Refactor #2 of the MainWindow series, stacked on #174. **Behavior is unchanged.**

## Why

The audit flagged `m_activeSurface` as a coupling hotspot (touched from 5 responsibility buckets) with **three identical eleven-line clearing walks**. Looking closer, the cache had **one reader** — the command-finished "is this pane focused" check — and a public `GetActiveSurface()` that **nothing calls**. Everything else (4 sites, ~40 lines) was maintenance to keep the copy from outliving its surface: the very invariant the comments kept restating at each site.

It duplicated `Tab::m_activePane`, which `NotifySurfaceFocused` already keeps current on the same focus events. A copy of state that is maintained elsewhere is only ever a liability.

<details><summary>日本語</summary>

監査で `m_activeSurface` は結合ホットスポット (5 バケットから参照) で、**同一 11 行のクリア走査が 3 箇所**にあった。よく見ると読み手は **1 箇所** (command-finished の「この pane はフォーカス中か」判定) だけで、public な `GetActiveSurface()` は**誰も呼んでいない**。残り 4 箇所 (約 40 行) は全部「コピーを surface より長生きさせない」ための保守コードで、各所のコメントが同じ不変条件を繰り返していた。

これは `Tab::m_activePane` の複製で、`NotifySurfaceFocused` が同じフォーカスイベントで既に同期している。他所で維持されている状態のコピーは負債にしかならない。

</details>

## What

- `m_activeSurface` and `GetActiveSurface()` removed; the four clearing sites (three tree walks + one scalar) removed with them
- **`IsActiveSurface(surface)`** answers the one question by asking `ActiveControl()` — i.e. the Tab state. Derived, never cached; the L4 invariant ("cache must not outlive the surface") **disappears with the copy** rather than being moved somewhere
- `NotifySurfaceFocused` keeps its dim-routing role (`Tab::SetActivePane`), minus the cache write
- Correctness of the derivation: `Tab::SetActivePane` is the sole writer of `m_activePane`; pane close calls `SetActivePane(nullptr)` **before** `Detach`, so the predicate can never read a dangling pane; a disposed window's `TabView()` throw is caught → false
- MainWindow −41 lines (2883 → 2844)

<details><summary>日本語</summary>

- `m_activeSurface` と `GetActiveSurface()` を削除。クリア 4 箇所 (走査 3 + スカラ 1) も一緒に消える
- **`IsActiveSurface(surface)`** が唯一の問いに `ActiveControl()` = Tab 状態で答える。派生値でありキャッシュしない。L4 不変条件 (「cache は surface より短命」) は別の場所に移るのではなく**コピーと共に消滅**
- `NotifySurfaceFocused` は dim 同期 (`Tab::SetActivePane`) の役目を維持、cache 書き込みだけ消える
- 派生の正しさ: `Tab::SetActivePane` が `m_activePane` の唯一の書き手。pane close は `Detach` の**前**に `SetActivePane(nullptr)` を呼ぶので dangling を読む隙がない。disposed window の `TabView()` 例外は catch して false
- MainWindow −41 行 (2883 → 2844)

</details>

## Verification (regression — the one behavior that reads this)

- [x] Tests.exe green
- [x] `notify-on-command-finish = unfocused` + `-action = notify`: run `sleep 6` in the **focused** pane, window in foreground → **no** toast
- [x] Same, then click another pane (split) before it finishes → toast (the pane is no longer active)
- [x] Same, then alt-tab to another app → toast (window not foreground)
- [x] Close a tab / park (undo) / tear out a tab / close a split pane — no crash, no stale-focus oddities (these were the four clearing sites)

<details><summary>日本語</summary>

- [x] Tests.exe green
- [x] `notify-on-command-finish = unfocused` + `-action = notify`: **フォーカス中の** pane で `sleep 6`、ウインドウ前面 → トースト**出ない**
- [x] 同じく、完了前に別 pane (split) をクリック → トースト出る (pane が active でなくなる)
- [x] 同じく、alt-tab で別アプリへ → トースト出る (ウインドウが前面でない)
- [x] タブ close / park (undo) / tear-out / split pane close — クラッシュやフォーカス異常なし (この 4 つが旧クリア箇所)

</details>
