### PR TITLE
Keep manual verification scripts in scripts/verify

### DIFF
--- a/scripts/verify/README.md
+++ b/scripts/verify/README.md
@@ -1,0 +1,9 @@
+# Verification scripts
+
+One file per manual check that needs more than a keybind. Each script's header says what it verifies, which config it needs, and what to expect — run it inside a GhosttyWin32 pane unless it says otherwise.
+
+| Script | Verifies |
+|---|---|
+| `command-finished.ps1` | `notify-on-command-finish` (COMMAND_FINISHED) without shell integration, via hand-emitted OSC 133 marks |
+
+When a pull request's verification steps need a script, add it here and link it from the PR instead of pasting the one-liner into the body.

--- a/scripts/verify/command-finished.ps1
+++ b/scripts/verify/command-finished.ps1
@@ -1,0 +1,50 @@
+<#
+.SYNOPSIS
+    Fire a COMMAND_FINISHED notification by hand (OSC 133 prompt marks).
+
+.DESCRIPTION
+    Command tracking in libghostty needs the shell-integration marks
+    OSC 133;C (command start) and OSC 133;D;<exit> (command end). Shell
+    integration is not active in this port (no resources dir), so a
+    plain `sleep 6` never notifies — emit the marks yourself instead.
+
+    Run inside a GhosttyWin32 pane. The notification fires only when
+    the pane is NOT focused at the moment the "command" ends, so start
+    it, then click another pane or alt-tab away before it finishes.
+
+    Config (ghostty config, then reload with ctrl+shift+,):
+
+        notify-on-command-finish = unfocused      # or: always
+        notify-on-command-finish-action = bell,notify
+        # notify-on-command-finish-after = 5s     # default; the script waits longer
+
+.PARAMETER Seconds
+    How long the fake command "runs". Must exceed notify-on-command-finish-after.
+
+.PARAMETER ExitCode
+    Exit code reported in the D mark. 0 -> "Command Succeeded", non-zero -> "Command Failed".
+
+.EXAMPLE
+    .\scripts\verify\command-finished.ps1
+    # then alt-tab away within 6 seconds -> bell + toast "Command Failed / Finished in 6s (exit 2)"
+
+.EXAMPLE
+    .\scripts\verify\command-finished.ps1 -ExitCode 0
+    # -> "Command Succeeded"
+
+.NOTES
+    Expected results:
+      - focused the whole time  : nothing (with `unfocused`)
+      - other pane / other app  : bell + toast
+      - toast click             : the originating tab / pane is selected
+    Duration shorter than the threshold: nothing.
+#>
+param(
+    [int] $Seconds = 6,
+    [int] $ExitCode = 2
+)
+
+$esc = [char]27
+Write-Host -NoNewline ($esc + ']133;C' + $esc + '\')
+Start-Sleep -Seconds $Seconds
+Write-Host -NoNewline ($esc + ']133;D;' + $ExitCode + $esc + '\')


### PR DESCRIPTION
Verification steps that need more than a keybind were living only in PR bodies. Re-verifying a feature meant digging the one-liner out of an old PR, and during the #175 checks the COMMAND_FINISHED one was misremembered (`sleep 6` alone never notifies here — shell integration is off, so the OSC 133 marks have to be emitted by hand).

`scripts/verify/` holds them now, one file per check, with the config and the expected results in the script header. `README.md` is the index. First entry: `command-finished.ps1`. Future PRs link a script from here instead of pasting one-liners into the body.

<details>
<summary>日本語</summary>

キーバインドだけで済まない検証手順が PR 本文にしか残っておらず、再検証のたびに古い PR を掘り返していた。#175 の検証では COMMAND_FINISHED の手順を思い違いしたまま出した (shell integration が無効なこの環境では `sleep 6` だけでは発火せず、OSC 133 マークを手で撃つ必要がある)。

`scripts/verify/` に 1 検証 1 ファイルで置き、config と期待結果はスクリプト先頭に書く。`README.md` が索引。初回は `command-finished.ps1`。以後の PR は本文にワンライナーを貼らず、ここのスクリプトを参照する。

</details>

## Verification

- [ ] Run `.\scripts\verify\command-finished.ps1` inside a pane with `notify-on-command-finish = unfocused` and alt-tab away within 6 s → bell + toast "Command Failed / Finished in 6s (exit 2)"
- [ ] `-ExitCode 0` → "Command Succeeded"

<details>
<summary>日本語</summary>

- [ ] `notify-on-command-finish = unfocused` で pane 内から `.\scripts\verify\command-finished.ps1` を実行、6 秒以内に alt-tab → bell + toast "Command Failed / Finished in 6s (exit 2)"
- [ ] `-ExitCode 0` → "Command Succeeded"

</details>