### PR TITLE
Name keyboard ownership once on the pane

### DIFF
--- a/App/App.vcxproj
+++ b/App/App.vcxproj
@@ -198,6 +198,7 @@
     <ClInclude Include="Terminal\Overlays\ScrollbackOverlay.xaml.h">
       <DependentUpon>Terminal\Overlays\ScrollbackOverlay.xaml</DependentUpon>
     </ClInclude>
+    <ClInclude Include="Terminal\Overlays\IKeyboardOverlay.h" />
     <ClInclude Include="Terminal\Overlays\SearchOverlay.xaml.h">
       <DependentUpon>Terminal\Overlays\SearchOverlay.xaml</DependentUpon>
     </ClInclude>

--- a/App/App.vcxproj.filters
+++ b/App/App.vcxproj.filters
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <ApplicationDefinition Include="App.xaml" />
@@ -117,6 +117,9 @@
       <Filter>Terminal\Overlays</Filter>
     </ClInclude>
     <ClInclude Include="Terminal\Overlays\ScrollbackOverlay.xaml.h">
+      <Filter>Terminal\Overlays</Filter>
+    </ClInclude>
+    <ClInclude Include="Terminal\Overlays\IKeyboardOverlay.h">
       <Filter>Terminal\Overlays</Filter>
     </ClInclude>
     <ClInclude Include="Terminal\Overlays\SearchOverlay.xaml.h">

--- a/App/Terminal/Overlays/IKeyboardOverlay.h
+++ b/App/Terminal/Overlays/IKeyboardOverlay.h
@@ -1,0 +1,20 @@
+#pragma once
+
+namespace winrt::GhosttyWin32::implementation
+{
+    // An overlay that can take the keyboard away from the terminal.
+    // TerminalControl keeps the list of these; SurfaceHost's input
+    // gate is answered from it (the terminal owns input only while no
+    // overlay holds the keyboard). Implementing this is the whole
+    // contract — every guard (keys, IME engagement, IME commits) is
+    // derived from the answer, so a new overlay never writes one.
+    struct IKeyboardOverlay
+    {
+        virtual ~IKeyboardOverlay() = default;
+
+        // True while this overlay's input element has keyboard focus.
+        // Focus, not "open": an open overlay whose box the user has
+        // clicked away from must hand the keyboard back (#171 review).
+        virtual bool HoldsKeyboardFocus() = 0;
+    };
+}

--- a/App/Terminal/Overlays/SearchOverlay.xaml.cpp
+++ b/App/Terminal/Overlays/SearchOverlay.xaml.cpp
@@ -70,7 +70,7 @@ namespace winrt::GhosttyWin32::implementation
         // Belt and braces for KeyUp: the release of a key typed in
         // the box must not bubble into the terminal's KeyUp.
         input.KeyUp([weakSelf](auto&&, muxi::KeyRoutedEventArgs const& args) {
-            if (auto self = weakSelf.get(); self && self->BoxHasFocus())
+            if (auto self = weakSelf.get(); self && self->HoldsKeyboardFocus())
                 args.Handled(true);
         });
 
@@ -112,7 +112,7 @@ namespace winrt::GhosttyWin32::implementation
         return wasOpen;
     }
 
-    bool SearchOverlay::BoxHasFocus()
+    bool SearchOverlay::HoldsKeyboardFocus()
     {
         if (!m_open) return false;
         auto input = Input();

--- a/App/Terminal/Overlays/SearchOverlay.xaml.h
+++ b/App/Terminal/Overlays/SearchOverlay.xaml.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "SearchOverlay.g.h"
+#include "Terminal/Overlays/IKeyboardOverlay.h"
 #include <cstddef>
 #include <functional>
 
@@ -15,7 +16,7 @@ namespace winrt::GhosttyWin32::implementation
     // Debounce mirrors the macOS SurfaceView: needles under 3 chars
     // wait 300ms (cheap keystrokes, expensive short-needle scans);
     // 3+ chars and empty go immediately.
-    struct SearchOverlay : SearchOverlayT<SearchOverlay>
+    struct SearchOverlay : SearchOverlayT<SearchOverlay>, IKeyboardOverlay
     {
         SearchOverlay();
 
@@ -36,11 +37,9 @@ namespace winrt::GhosttyWin32::implementation
 
         bool IsOpen() const noexcept { return m_open; }
 
-        // Whether the input box currently holds keyboard focus (false
-        // while closed). This — not "open" — is what gates terminal
-        // input: the bar can stay open while the user clicks back
-        // into the terminal to keep typing (#171 review).
-        bool BoxHasFocus();
+        // IKeyboardOverlay: whether the input box currently holds
+        // keyboard focus (false while closed).
+        bool HoldsKeyboardFocus() override;
 
         // If open, put keyboard focus on the box and return true.
         bool FocusInput();

--- a/App/Terminal/SurfaceHost.cpp
+++ b/App/Terminal/SurfaceHost.cpp
@@ -173,16 +173,16 @@ namespace winrt::GhosttyWin32::implementation
 
     // ----- focus / IME -----
 
+    void SurfaceHost::SyncImeEngagement(bool focused)
+    {
+        if (!m_editContext) return;
+        if (focused && TerminalOwnsInput()) m_editContext.NotifyFocusEnter();
+        else                                m_editContext.NotifyFocusLeave();
+    }
+
     void SurfaceHost::OnFocusGained()
     {
-        // Engaging the CoreTextEditContext while a sibling overlay
-        // owns text input would route that overlay's text through the
-        // terminal's IME path and into the pty (#171 review: search
-        // box input reached the shell) — the composite's gate says
-        // whether the terminal owns input right now.
-        if (m_editContext && TerminalOwnsInput()) {
-            m_editContext.NotifyFocusEnter();
-        }
+        SyncImeEngagement(true);
         // Surface-level focus event for the window. Mirrors the
         // upstream getActiveSurface pattern (#62): the window uses
         // this to retarget the tab's active pane without the host
@@ -199,19 +199,18 @@ namespace winrt::GhosttyWin32::implementation
 
     void SurfaceHost::OnFocusLost()
     {
-        if (m_editContext) m_editContext.NotifyFocusLeave();
+        SyncImeEngagement(false);
         m_surface.SetFocus(false);
     }
 
     void SurfaceHost::NotifyImeFocusEnter()
     {
-        // Same gate as OnFocusGained.
-        if (m_editContext && TerminalOwnsInput()) m_editContext.NotifyFocusEnter();
+        SyncImeEngagement(true);
     }
 
     void SurfaceHost::NotifyImeFocusLeave()
     {
-        if (m_editContext) m_editContext.NotifyFocusLeave();
+        SyncImeEngagement(false);
     }
 
     void SurfaceHost::EnsureImeContext()
@@ -288,7 +287,7 @@ namespace winrt::GhosttyWin32::implementation
                 auto utf8 = interop::Encoding::toUtf8(self->m_ime.text());
                 // A composition committed while a sibling overlay owns
                 // text input must not land in the pty (see
-                // OnFocusGained).
+                // SyncImeEngagement).
                 if (!utf8.empty() && self->TerminalOwnsInput()) {
                     self->m_surface.Text(utf8.c_str(), utf8.size());
                 }

--- a/App/Terminal/SurfaceHost.h
+++ b/App/Terminal/SurfaceHost.h
@@ -162,15 +162,16 @@ namespace winrt::GhosttyWin32::implementation
         // Idempotent.
         void EnsureImeContext();
 
-        // XAML GotFocus / LostFocus on the composite. GotFocus engages
-        // the EditContext (if the terminal owns input), notifies the
-        // window, and tells ghostty this surface is focused so the
-        // losing pane's renderer drops to the slow cadence.
+        // XAML GotFocus / LostFocus on the composite. GotFocus syncs
+        // the EditContext, notifies the window, and tells ghostty this
+        // surface is focused so the losing pane's renderer drops to
+        // the slow cadence.
         void OnFocusGained();
         void OnFocusLost();
 
         // Window-activation boundary: XAML's focus events do not fire
-        // on alt-tab, so the window pings the active control.
+        // on alt-tab, so the window pings the active control. Both
+        // only sync the EditContext.
         void NotifyImeFocusEnter();
         void NotifyImeFocusLeave();
 
@@ -209,6 +210,14 @@ namespace winrt::GhosttyWin32::implementation
         bool TerminalOwnsInput() const {
             return !m_terminalOwnsInput || m_terminalOwnsInput();
         }
+        // The one place the CoreTextEditContext is engaged or
+        // released. `focused` is whether the composite has keyboard
+        // focus at all; the context is engaged only when it does AND
+        // the terminal owns input (a sibling overlay holding the
+        // keyboard must not route its text through the terminal's
+        // IME path — #171). Every focus transition funnels here, so
+        // a new overlay never needs its own IME guard.
+        void SyncImeEngagement(bool focused);
         void CopySelectionToClipboard();
         void Tick();
 

--- a/App/Terminal/TerminalControl.xaml.cpp
+++ b/App/Terminal/TerminalControl.xaml.cpp
@@ -28,13 +28,13 @@ namespace winrt::GhosttyWin32::implementation
         auto weakSelf = get_weak();
 
         // The host asks this before letting keystrokes, IME engagement
-        // or IME commits through to the pty. The search box is a
-        // child of this control, so its input bubbles up here too;
-        // while it holds focus it owns the keyboard (#171 review:
-        // typing in the box also typed into the shell).
+        // or IME commits through to the pty. Overlay input bubbles up
+        // through this control too; while an overlay holds focus it
+        // owns the keyboard (#171 review: typing in the search box
+        // also typed into the shell).
         m_host->SetInputGate([weakSelf]() {
             auto self = weakSelf.get();
-            return self && !self->SearchBoxHasFocus();
+            return self && self->TerminalOwnsInput();
         });
 
         // Set up IME + self-focus on Loaded. Three reasons this all
@@ -345,10 +345,10 @@ namespace winrt::GhosttyWin32::implementation
         if (auto* se = SearchImpl()) se->SetSelected(selected);
     }
 
-    bool TerminalControl::SearchBoxHasFocus()
+    Microsoft::UI::Xaml::UIElement TerminalControl::FocusedOverlay()
     {
-        auto* se = SearchImpl();
-        return se && se->BoxHasFocus();
+        if (auto* se = SearchImpl(); se && se->BoxHasFocus()) return Search();
+        return nullptr;
     }
 
     bool TerminalControl::FocusSearchIfOpen()

--- a/App/Terminal/TerminalControl.xaml.cpp
+++ b/App/Terminal/TerminalControl.xaml.cpp
@@ -2,6 +2,7 @@
 #include "Terminal/TerminalControl.xaml.h"
 #include "resource.h"
 #include "Interop/Encoding.h"
+#include <algorithm>
 #if __has_include("TerminalControl.g.cpp")
 #include "TerminalControl.g.cpp"
 #endif
@@ -14,6 +15,9 @@ namespace winrt::GhosttyWin32::implementation
     {
         InitializeComponent();
         m_host = std::make_shared<SurfaceHost>(Panel());
+        // The overlays that can take the keyboard. Only ever appended
+        // to; the host's gate below is the only reader.
+        if (auto* se = SearchImpl()) m_keyboardOverlays.push_back(se);
 
         // Every handler below captures a weak_ref instead of `this`.
         // XAML can route a final pointer event during window/control
@@ -345,10 +349,10 @@ namespace winrt::GhosttyWin32::implementation
         if (auto* se = SearchImpl()) se->SetSelected(selected);
     }
 
-    Microsoft::UI::Xaml::UIElement TerminalControl::FocusedOverlay()
+    bool TerminalControl::TerminalOwnsInput() const
     {
-        if (auto* se = SearchImpl(); se && se->BoxHasFocus()) return Search();
-        return nullptr;
+        return std::none_of(m_keyboardOverlays.begin(), m_keyboardOverlays.end(),
+                            [](IKeyboardOverlay* o) { return o->HoldsKeyboardFocus(); });
     }
 
     bool TerminalControl::FocusSearchIfOpen()

--- a/App/Terminal/TerminalControl.xaml.h
+++ b/App/Terminal/TerminalControl.xaml.h
@@ -28,9 +28,11 @@ namespace winrt::GhosttyWin32::implementation
     //
     // What stays on the composite is exactly what needs both sides:
     //   * XAML focus. Focus() on pointer press, GotFocus / LostFocus
-    //     forwarded to the host, and the "does the terminal own text
-    //     input" gate the host consults — the search box is a sibling
-    //     the host cannot see.
+    //     forwarded to the host, and keyboard ownership: which child
+    //     has the keyboard right now. FocusedOverlay() is the single
+    //     enumeration of overlays that can take focus, and the host's
+    //     input gate is answered from it — the host itself cannot see
+    //     its siblings.
     //   * ProtectedCursor — one writer composing ghostty's shape and
     //     the hidden state. (Overlays that take input declare their
     //     own Arrow; the composite does not track hover.)
@@ -139,11 +141,6 @@ namespace winrt::GhosttyWin32::implementation
         // charge instead of dropping focus back on the terminal
         // behind it (alt-tab away and back while searching).
         bool FocusSearchIfOpen();
-        // Whether the search box currently holds keyboard focus. This
-        // — not "the bar is open" — is what gates terminal input
-        // (#171 review); SurfaceHost consults it through its input
-        // gate.
-        bool SearchBoxHasFocus();
 
         // Show/hide the opaque background underlay beneath the swap
         // chain (#69 — see the XAML comment on OpaqueUnderlay for
@@ -175,6 +172,17 @@ namespace winrt::GhosttyWin32::implementation
         PaneStatusOverlay* StatusImpl();
         ScrollbackOverlay* ScrollbackImpl();
         SearchOverlay* SearchImpl();
+
+        // Keyboard ownership. FocusedOverlay() returns the overlay
+        // that currently holds keyboard focus, or null when the
+        // terminal does — the one place focus-taking overlays are
+        // enumerated. Gating on focus rather than on "the bar is
+        // open" lets the user click back into the terminal and keep
+        // typing with the search bar up (#171 review). A future
+        // overlay that takes focus joins this function and inherits
+        // every guard the host derives from it.
+        Microsoft::UI::Xaml::UIElement FocusedOverlay();
+        bool TerminalOwnsInput() { return FocusedOverlay() == nullptr; }
 
         // Owns the surface; see SurfaceHost.h. Created in the ctor
         // against the inner panel, never null afterwards.

--- a/App/Terminal/TerminalControl.xaml.h
+++ b/App/Terminal/TerminalControl.xaml.h
@@ -5,11 +5,13 @@
 #include "Terminal/Overlays/PaneStatusOverlay.xaml.h"
 #include "Terminal/Overlays/ScrollbackOverlay.xaml.h"
 #include "Terminal/Overlays/SearchOverlay.xaml.h"
+#include "Terminal/Overlays/IKeyboardOverlay.h"
 #include "Ghostty/Surface.h"
 #include "Host/ISurfaceView.h"
 #include "ghostty.h"
 #include <functional>
 #include <memory>
+#include <vector>
 
 namespace winrt::GhosttyWin32::implementation
 {
@@ -28,11 +30,11 @@ namespace winrt::GhosttyWin32::implementation
     //
     // What stays on the composite is exactly what needs both sides:
     //   * XAML focus. Focus() on pointer press, GotFocus / LostFocus
-    //     forwarded to the host, and keyboard ownership: which child
-    //     has the keyboard right now. FocusedOverlay() is the single
-    //     enumeration of overlays that can take focus, and the host's
-    //     input gate is answered from it — the host itself cannot see
-    //     its siblings.
+    //     forwarded to the host, and keyboard ownership: the list of
+    //     overlays that can take the keyboard (m_keyboardOverlays)
+    //     and the predicate over it (TerminalOwnsInput) that answers
+    //     the host's input gate — the host itself cannot see its
+    //     siblings.
     //   * ProtectedCursor — one writer composing ghostty's shape and
     //     the hidden state. (Overlays that take input declare their
     //     own Arrow; the composite does not track hover.)
@@ -173,16 +175,15 @@ namespace winrt::GhosttyWin32::implementation
         ScrollbackOverlay* ScrollbackImpl();
         SearchOverlay* SearchImpl();
 
-        // Keyboard ownership. FocusedOverlay() returns the overlay
-        // that currently holds keyboard focus, or null when the
-        // terminal does — the one place focus-taking overlays are
-        // enumerated. Gating on focus rather than on "the bar is
-        // open" lets the user click back into the terminal and keep
-        // typing with the search bar up (#171 review). A future
-        // overlay that takes focus joins this function and inherits
-        // every guard the host derives from it.
-        Microsoft::UI::Xaml::UIElement FocusedOverlay();
-        bool TerminalOwnsInput() { return FocusedOverlay() == nullptr; }
+        // Keyboard ownership, split into the data and the judgement.
+        // m_keyboardOverlays is the one list of overlays that can
+        // take the keyboard (filled once in the ctor; a new overlay
+        // is one more entry). TerminalOwnsInput() is the predicate
+        // over it — true while none of them holds focus — and is
+        // what the host's input gate asks. Borrowed pointers into
+        // children this control owns, so they live as long as it.
+        std::vector<IKeyboardOverlay*> m_keyboardOverlays;
+        bool TerminalOwnsInput() const;
 
         // Owns the surface; see SurfaceHost.h. Created in the ctor
         // against the inner panel, never null afterwards.


### PR DESCRIPTION
Stage C of the pane refactor, the part #173 set out to do. Behaviour unchanged; #179 already collapsed the six focus guards into one predicate, this names the two remaining pieces so a future focus-taking overlay joins in one place.

## What changes

- **`IKeyboardOverlay`** — what an overlay implements to be able to take the keyboard (`HoldsKeyboardFocus()`); `SearchOverlay` is the first. **`TerminalControl::m_keyboardOverlays`** is the list of them, filled once in the ctor, and **`TerminalOwnsInput()`** is `none_of` over it — the data and the judgement kept apart. That predicate is what the host's input gate asks. `SearchBoxHasFocus()` is gone.
- **`SurfaceHost::SyncImeEngagement(bool focused)`** — the one place the `CoreTextEditContext` is engaged or released: engaged only when the composite has focus *and* the terminal owns input. `OnFocusGained` / `OnFocusLost` / `NotifyImeFocusEnter` / `NotifyImeFocusLeave` call it and nothing else about IME.

Where the guards live now:

```
composite  m_keyboardOverlays (list)  ──▶  TerminalOwnsInput() (none_of)  ──▶  host gate
                                                             ├─ OnKeyDown / OnKeyUp        (keys → pty)
                                                             ├─ CompositionCompleted        (IME commit → pty)
                                                             └─ SyncImeEngagement(focused)  (EditContext engage / release)
                                                                  ▲ OnFocusGained / OnFocusLost / NotifyImeFocusEnter / Leave
```

<details>
<summary>日本語</summary>

pane リファクタの C 段、#173 がやろうとしていた部分。挙動は不変。6 箇所に散っていたフォーカス判定は #179 で述語 1 個に畳んであるので、ここでは残り 2 つに名前を付けて、将来 focus を取る overlay が増えても 1 箇所に足すだけで済むようにする。

- **`IKeyboardOverlay`** — キーボードを取れる overlay が実装するもの (`HoldsKeyboardFocus()`)、`SearchOverlay` が最初の実装。**`TerminalControl::m_keyboardOverlays`** がその一覧 (ctor で 1 回だけ作る)、**`TerminalOwnsInput()`** はその `none_of` — データと判定を分けた。host の input gate が聞くのはこの述語。`SearchBoxHasFocus()` は削除。
- **`SurfaceHost::SyncImeEngagement(bool focused)`** — `CoreTextEditContext` の engage / release をする唯一の場所。composite がフォーカスを持ち *かつ* 端末が入力を所有している時だけ engage。`OnFocusGained` / `OnFocusLost` / `NotifyImeFocusEnter` / `NotifyImeFocusLeave` はこれを呼ぶだけで IME には触らない。

</details>

## Equivalence

The only behavioural difference is an extra, idempotent `NotifyFocusLeave` in two cases where the old code did nothing: GotFocus bubbling from the search box (the composite's own LostFocus had already released the context), and an activation re-arm while the box holds focus (the context was never engaged). Both leave the OS text-services state where it already was.

<details>
<summary>日本語</summary>

挙動の差は、旧コードが何もしなかった 2 ケースで冪等な `NotifyFocusLeave` が 1 回余分に出ることだけ: 検索箱からの GotFocus バブル (composite 自身の LostFocus で既に release 済み) と、箱がフォーカスを持ったままの活性化再 engage (元々 engage されていない)。どちらも OS 側の状態は変わらない。

</details>

## Verification

- [x] Build Debug + Release
- [x] `ctrl+f` → type → nothing reaches the shell; Enter / Shift+Enter / Esc work; click back into the terminal with the bar open → typing works
- [x] IME: 半角/全角 in the terminal composes and commits; switch to the search box mid-composition → the box gets the text, the shell does not; back to the terminal → IME works again
- [x] alt-tab away and back with the search box focused → box keeps focus, terminal IME stays off; same without the bar → terminal IME works

<details>
<summary>日本語</summary>

- [x] Debug + Release ビルド
- [x] `ctrl+f` → 入力 → シェルに行かない。Enter / Shift+Enter / Esc が効く。bar を開けたまま端末クリック → 入力できる
- [x] IME: 端末で 半角/全角 → 変換 → 確定。変換中に検索箱へ移る → 箱に入ってシェルには入らない。端末に戻る → IME が効く
- [x] 検索箱にフォーカスのまま alt-tab 往復 → 箱にフォーカス、端末 IME は off。bar 無しで同じ → 端末 IME が効く

</details>

