### PR TITLE
Close whole tabs through one teardown path

### DIFF
--- a/App/Tabs/ParkedTabs.h
+++ b/App/Tabs/ParkedTabs.h
@@ -135,6 +135,7 @@ public:
     }
 
     bool Empty() const noexcept { return m_entries.empty(); }
+    size_t Size() const noexcept { return m_entries.size(); }
 
     // ----- redo bookkeeping -----
     // Redo = "close that tab again": remember the items most

--- a/App/Windows/MainWindow.xaml.cpp
+++ b/App/Windows/MainWindow.xaml.cpp
@@ -1348,27 +1348,37 @@ namespace winrt::GhosttyWin32::implementation
     {
         auto* t = m_tabs.FindByItem(item);
         if (!t) return;
+        if (TryParkTab(*t)) return;
+        TearDownTab(*t);
+    }
+
+    bool MainWindow::TryParkTab(Tab& tab)
+    {
         // Undo support (#151): instead of tearing the tab down, park
         // it alive for undo-timeout. Only when another tab remains —
         // closing the last tab closes the window, and window-close
         // undo is out of scope for stage 1. undo-timeout = 0 opts
-        // out entirely and takes the immediate-teardown path below.
-        if (m_ghosttyApp && TabView().TabItems().Size() > 1) {
-            uint64_t timeoutMs =
-                ghostty::Config(m_ghosttyApp->ConfigHandle()).UndoTimeoutMs();
-            if (timeoutMs > 0) {
-                ParkTab(item, timeoutMs, /*fromRedo=*/false);
-                return;
-            }
-        }
+        // out entirely.
+        if (!m_ghosttyApp || TabView().TabItems().Size() <= 1) return false;
+        uint64_t timeoutMs =
+            ghostty::Config(m_ghosttyApp->ConfigHandle()).UndoTimeoutMs();
+        if (timeoutMs == 0) return false;
+        ParkTab(tab.Item(), timeoutMs, /*fromRedo=*/false);
+        return true;
+    }
+
+    void MainWindow::TearDownTab(Tab& tab)
+    {
+        auto item = tab.Item();
         // A stale press record must not keep the closed item alive.
         App::g_app->PressedTab().Forget(item);
         // Detach every pane before RemoveAt: SetSwapChainHandle(nullptr)
         // AVs at +0x1F8 inside microsoft.ui.xaml.dll if the panel has
         // already been unparented. Multi-pane tabs have multiple swap
         // chains and each one needs clearing before the panel comes
-        // out of the live visual tree.
-        t->DetachAll();
+        // out of the live visual tree. Idempotent against panes a
+        // caller already detached.
+        tab.DetachAll();
         auto tv = TabView();
         uint32_t idx = 0;
         if (tv.TabItems().IndexOf(item, idx)) {
@@ -1380,11 +1390,14 @@ namespace winrt::GhosttyWin32::implementation
             // tearing down the focused control synchronously here
             // leaves XAML's focus subsystem holding a stale pointer
             // that AVs at +0x1F8 once the window teardown starts.
+            // RequestClose (not Close) so the close gate's bypass is
+            // set and a WM_CLOSE re-emitted by the framework does not
+            // re-prompt.
             RequestClose();
         } else {
             // ~Tab doesn't know about AppContent — unparent here or
             // the panel leaks as an orphan child.
-            RemoveTabPanelFromAppContent(*t);
+            RemoveTabPanelFromAppContent(tab);
             m_tabs.Remove(item);
         }
     }
@@ -2698,15 +2711,7 @@ namespace winrt::GhosttyWin32::implementation
                                                 : nullptr),
                             onlyPane ? 1 : 0, processAlive ? 1 : 0,
                             TabView().TabItems().Size());
-            if (m_ghosttyApp && TabView().TabItems().Size() > 1 &&
-                onlyPane && processAlive) {
-                uint64_t timeoutMs =
-                    ghostty::Config(m_ghosttyApp->ConfigHandle()).UndoTimeoutMs();
-                if (timeoutMs > 0) {
-                    ParkTab(tab->Item(), timeoutMs, /*fromRedo=*/false);
-                    return;
-                }
-            }
+            if (onlyPane && processAlive && TryParkTab(*tab)) return;
         }
 
         // Detach first so the surface / DComp handle are released
@@ -2758,22 +2763,8 @@ namespace winrt::GhosttyWin32::implementation
         // RemovedRoot or NotFound — treat as full-tab close.
         // (NotFound shouldn't happen, but failing closed by closing
         // the tab is the safer recovery than leaving a half-detached
-        // pane around.) DetachAll is idempotent against the leaf we
-        // already detached above and sweeps any remaining ones.
-        tab->DetachAll();
-        auto item = tab->Item();
-        App::g_app->PressedTab().Forget(item);
-        auto tv = TabView();
-        uint32_t idx = 0;
-        if (tv.TabItems().IndexOf(item, idx)) {
-            tv.TabItems().RemoveAt(idx);
-        }
-        DwmFlush();
-        if (tv.TabItems().Size() == 0) {
-            Close();
-        } else {
-            m_tabs.Remove(item);
-        }
+        // pane around.)
+        TearDownTab(*tab);
     }
 
     // Caption button click handlers. We route through Win32 messages

--- a/App/Windows/MainWindow.xaml.cpp
+++ b/App/Windows/MainWindow.xaml.cpp
@@ -1399,22 +1399,29 @@ namespace winrt::GhosttyWin32::implementation
             // the panel leaks as an orphan child.
             RemoveTabPanelFromAppContent(tab);
             m_tabs.Remove(item);
-#if defined(_DEBUG)
-            // Leak check for the orphan-panel bug this path used to
-            // have: after a teardown the live SplitPanels under
-            // AppContent must equal the tabs still in m_tabs.
-            {
-                unsigned panels = 0;
-                for (auto const& child : AppContent().Children()) {
-                    if (child.try_as<winrt::GhosttyWin32::SplitPanel>()) ++panels;
-                }
-                wchar_t buf[96];
-                swprintf_s(buf, L"TearDownTab: tabs=%u panels=%u\n",
-                           static_cast<unsigned>(m_tabs.Size()), panels);
-                OutputDebugStringW(buf);
-            }
-#endif
+            AssertPanelInvariant();
         }
+    }
+
+    void MainWindow::AssertPanelInvariant() noexcept
+    {
+#if defined(_DEBUG)
+        unsigned panels = 0;
+        try {
+            for (auto const& child : AppContent().Children()) {
+                if (child.try_as<winrt::GhosttyWin32::SplitPanel>()) ++panels;
+            }
+        } catch (winrt::hresult_error const&) {
+            return;  // window already tearing down; nothing to check
+        }
+        const auto tabs = static_cast<unsigned>(m_tabs.Size());
+        const auto parked = static_cast<unsigned>(m_parkedTabs.Size());
+        wchar_t buf[96];
+        swprintf_s(buf, L"PanelInvariant: tabs=%u parked=%u panels=%u\n",
+                   tabs, parked, panels);
+        OutputDebugStringW(buf);
+        if (panels != tabs + parked && IsDebuggerPresent()) __debugbreak();
+#endif
     }
 
     void MainWindow::ParkTab(muxc::TabViewItem const& item,
@@ -1455,8 +1462,10 @@ namespace winrt::GhosttyWin32::implementation
                 if (auto self = weak.get()) {
                     expired->DetachAll();
                     self->RemoveTabPanelFromAppContent(*expired);
+                    self->AssertPanelInvariant();
                 }
             });
+        AssertPanelInvariant();
     }
 
     void MainWindow::Undo()
@@ -1479,6 +1488,7 @@ namespace winrt::GhosttyWin32::implementation
         // opacity toggle, recolour) — restate the window state over
         // the whole tab set, same as AdoptTornOutTab does.
         ApplyBackgroundOpacityAppearance();
+        AssertPanelInvariant();
     }
 
     void MainWindow::Redo()

--- a/App/Windows/MainWindow.xaml.cpp
+++ b/App/Windows/MainWindow.xaml.cpp
@@ -1399,11 +1399,11 @@ namespace winrt::GhosttyWin32::implementation
             // the panel leaks as an orphan child.
             RemoveTabPanelFromAppContent(tab);
             m_tabs.Remove(item);
-            AssertPanelInvariant();
+            DebugAssertPanelInvariant();
         }
     }
 
-    void MainWindow::AssertPanelInvariant() noexcept
+    void MainWindow::DebugAssertPanelInvariant() noexcept
     {
 #if defined(_DEBUG)
         unsigned panels = 0;
@@ -1462,10 +1462,10 @@ namespace winrt::GhosttyWin32::implementation
                 if (auto self = weak.get()) {
                     expired->DetachAll();
                     self->RemoveTabPanelFromAppContent(*expired);
-                    self->AssertPanelInvariant();
+                    self->DebugAssertPanelInvariant();
                 }
             });
-        AssertPanelInvariant();
+        DebugAssertPanelInvariant();
     }
 
     void MainWindow::Undo()
@@ -1488,7 +1488,7 @@ namespace winrt::GhosttyWin32::implementation
         // opacity toggle, recolour) — restate the window state over
         // the whole tab set, same as AdoptTornOutTab does.
         ApplyBackgroundOpacityAppearance();
-        AssertPanelInvariant();
+        DebugAssertPanelInvariant();
     }
 
     void MainWindow::Redo()

--- a/App/Windows/MainWindow.xaml.cpp
+++ b/App/Windows/MainWindow.xaml.cpp
@@ -1399,6 +1399,21 @@ namespace winrt::GhosttyWin32::implementation
             // the panel leaks as an orphan child.
             RemoveTabPanelFromAppContent(tab);
             m_tabs.Remove(item);
+#if defined(_DEBUG)
+            // Leak check for the orphan-panel bug this path used to
+            // have: after a teardown the live SplitPanels under
+            // AppContent must equal the tabs still in m_tabs.
+            {
+                unsigned panels = 0;
+                for (auto const& child : AppContent().Children()) {
+                    if (child.try_as<winrt::GhosttyWin32::SplitPanel>()) ++panels;
+                }
+                wchar_t buf[96];
+                swprintf_s(buf, L"TearDownTab: tabs=%u panels=%u\n",
+                           static_cast<unsigned>(m_tabs.Size()), panels);
+                OutputDebugStringW(buf);
+            }
+#endif
         }
     }
 

--- a/App/Windows/MainWindow.xaml.h
+++ b/App/Windows/MainWindow.xaml.h
@@ -387,6 +387,14 @@ namespace winrt::GhosttyWin32::implementation
         // RemoveAt → unparent the panel → destroy the Tab, or
         // RequestClose when it was the last tab.
         void TearDownTab(Tab& tab);
+        // Debug-only structural check, run after every operation
+        // that parents or unparents a tab's SplitPanel: the panels
+        // under AppContent must equal the tabs this window owns —
+        // listed in m_tabs plus parked for undo. A miss is an
+        // orphan (the pre-#184 shell-exit leak) or a double
+        // unparent; breaks into the debugger with the offending
+        // path on the stack. No-op in release builds.
+        void AssertPanelInvariant() noexcept;
         // Detach the item from the tab strip and move its Tab into
         // m_parkedTabs. fromRedo keeps the redo history intact (a
         // user-initiated close invalidates it).

--- a/App/Windows/MainWindow.xaml.h
+++ b/App/Windows/MainWindow.xaml.h
@@ -104,10 +104,9 @@ namespace winrt::GhosttyWin32::implementation
         // dispatcher reaches them through the interface.
         void CreateTab() override;
         void CloseTabBySurface(ghostty_surface_t surface) override;
-        // Shared tab-teardown primitive used by every close path (tab
-        // X, close_tab keybind, gate-approved close). Assumes the
-        // caller already ran confirmation; keeps the tricky detach /
-        // unparent / RemoveAt ordering in one place.
+        // Gate-approved close of a whole tab (tab X, close_tab
+        // keybind). Parks it for undo when allowed, otherwise tears
+        // it down now. Assumes the caller already ran confirmation.
         void CloseTabByItem(winrt::Microsoft::UI::Xaml::Controls::TabViewItem const& item);
         void GoToTab(int requested) override;
         void SetTabTitleForSurface(ghostty_surface_t surface,
@@ -377,6 +376,17 @@ namespace winrt::GhosttyWin32::implementation
         // add/remove, panel visibility, appearance restate, and the
         // expiry teardown callback).
         ParkedTabs m_parkedTabs;
+        // Undo support (#151): park `tab` instead of tearing it down
+        // when another tab remains and undo-timeout is non-zero.
+        // Returns whether it parked; callers add their own extra
+        // conditions before asking.
+        bool TryParkTab(Tab& tab);
+        // The one immediate tab teardown, shared by every close path
+        // once parking is ruled out. Keeps the ordering contract in a
+        // single place: DetachAll while the panel is still parented →
+        // RemoveAt → unparent the panel → destroy the Tab, or
+        // RequestClose when it was the last tab.
+        void TearDownTab(Tab& tab);
         // Detach the item from the tab strip and move its Tab into
         // m_parkedTabs. fromRedo keeps the redo history intact (a
         // user-initiated close invalidates it).

--- a/App/Windows/MainWindow.xaml.h
+++ b/App/Windows/MainWindow.xaml.h
@@ -394,7 +394,7 @@ namespace winrt::GhosttyWin32::implementation
         // orphan (the pre-#184 shell-exit leak) or a double
         // unparent; breaks into the debugger with the offending
         // path on the stack. No-op in release builds.
-        void AssertPanelInvariant() noexcept;
+        void DebugAssertPanelInvariant() noexcept;
         // Detach the item from the tab strip and move its Tab into
         // m_parkedTabs. fromRedo keeps the redo history intact (a
         // user-initiated close invalidates it).


### PR DESCRIPTION
Two close paths each carried their own copy of the whole-tab teardown, and the copies had drifted. This makes one path and fixes the two drifts, which were real bugs.

## The two paths

| entry | path | whole-tab teardown |
|---|---|---|
| tab X, `close_tab` | `CloseTabByItem` | Forget → DetachAll → RemoveAt → DwmFlush → last tab: `RequestClose()` / else: **unparent panel** + `m_tabs.Remove` |
| `close_surface` on an unsplit tab, and **every shell exit** (`close_surface_cb`) | `RemovePaneByIdApproved` tail | DetachAll → Forget → RemoveAt → DwmFlush → last tab: **`Close()`** / else: `m_tabs.Remove` |

<details>
<summary>日本語</summary>

whole-tab の teardown が 2 経路それぞれに複製されていて、中身がずれていた。1 本にして、ずれ 2 つ (どちらも実バグ) を直す。

| 入口 | 経路 | tab ごとの teardown |
|---|---|---|
| tab の X、`close_tab` | `CloseTabByItem` | Forget → DetachAll → RemoveAt → DwmFlush → 最後なら `RequestClose()` / でなければ **panel を unparent** + `m_tabs.Remove` |
| unsplit な tab での `close_surface`、そして **shell の exit 全部** (`close_surface_cb`) | `RemovePaneByIdApproved` の末尾 | DetachAll → Forget → RemoveAt → DwmFlush → 最後なら **`Close()`** / でなければ `m_tabs.Remove` |

</details>

## The two drifts

1. **Orphan `SplitPanel`.** The pane path never called `RemoveTabPanelFromAppContent`, so the tab's panel stayed a child of `AppContent` after the `Tab` was destroyed. `exit` in a shell while another tab is open is the common way to hit it — one leaked panel per such exit.
2. **Raw `Close()` on the last tab.** `RequestClose()` sets the close gate's bypass (so a `WM_CLOSE` the framework re-emits during `Close()` doesn't prompt again) and swallows the `hresult_error` `Window::Close` throws once teardown has begun. The pane path called `Close()` bare.

<details>
<summary>日本語</summary>

1. **`SplitPanel` の孤児化。** pane 経路は `RemoveTabPanelFromAppContent` を呼んでおらず、`Tab` 破棄後も panel が `AppContent` の子として残っていた。他 tab がある状態で shell を `exit` するのが一番普通の踏み方 — その exit ごとに panel が 1 個リーク。
2. **最後の tab で生 `Close()`。** `RequestClose()` は close gate の bypass を立て (`Close()` 中に framework が再発行する `WM_CLOSE` で再プロンプトしない)、teardown 開始後に `Window::Close` が投げる `hresult_error` を握る。pane 経路は素の `Close()` だった。

</details>

## Change

- `TearDownTab(Tab&)` — the one immediate teardown, with the ordering contract in one place (DetachAll while the panel is still parented → RemoveAt → unparent → destroy, or `RequestClose` for the last tab).
- `TryParkTab(Tab&)` — the one undo-park decision (another tab remains, undo-timeout > 0); the pane path adds its own `onlyPane && processAlive` in front.
- `CloseTabByItem` is `TryParkTab || TearDownTab`; `RemovePaneByIdApproved`'s whole-tab tail is `TearDownTab`. No class extraction — the two helpers are the whole coordinator for now.
- `DebugAssertPanelInvariant()` (debug builds only) — after every operation that parents or unparents a tab's `SplitPanel`, the panels under `AppContent` must equal `m_tabs.Size() + m_parkedTabs.Size()`; a miss breaks into the debugger. Turns the leak this PR fixes into something that cannot come back silently.

<details>
<summary>日本語</summary>

- `TearDownTab(Tab&)` — 唯一の即時 teardown。順序契約 (panel が parented なうちに DetachAll → RemoveAt → unparent → 破棄、最後の tab なら `RequestClose`) はここだけに置く。
- `TryParkTab(Tab&)` — 唯一の undo park 判定 (他 tab が残っている、undo-timeout > 0)。pane 経路は自分の条件 `onlyPane && processAlive` を前に付ける。
- `CloseTabByItem` は `TryParkTab || TearDownTab`、`RemovePaneByIdApproved` の tab ごと末尾は `TearDownTab`。class 抽出はしない — helper 2 つが今の coordinator の全部。
- `DebugAssertPanelInvariant()` (debug ビルド限定) — tab の `SplitPanel` を parent / unparent する操作のたびに、`AppContent` 配下の panel 数が `m_tabs.Size() + m_parkedTabs.Size()` と一致するか検査、ずれたらデバッガで止まる。この PR で直したリークが黙って再発しないようにする。

</details>

## Verification

Config already has `ctrl+shift+x = close_surface` and `ctrl+shift+z = undo`.

- [x] Build Debug + Release
- [x] Two tabs → `exit` in one → the other stays, no visual leftovers; repeat a few times (this is the orphan-panel path)
- [x] Two tabs → `ctrl+shift+x` on an unsplit tab → tab parks; `ctrl+shift+z` brings it back
- [x] Single tab → `exit` → the window closes cleanly (no confirmation dialog, no error)
- [x] Single tab → `ctrl+shift+x` → same
- [x] Split → `ctrl+shift+x` on one pane → sibling gets focus (pane path unchanged)
- [x] Tab X and `close_tab` still park / close as before

<details>
<summary>日本語</summary>

config には `ctrl+shift+x = close_surface` と `ctrl+shift+z = undo` が入っている。

- [x] Debug + Release ビルド
- [x] tab 2 つ → 片方で `exit` → もう片方が残り、見た目の残骸なし。何回か繰り返す (孤児 panel の経路)
- [x] tab 2 つ → unsplit な tab で `ctrl+shift+x` → park される。`ctrl+shift+z` で戻る
- [x] tab 1 つ → `exit` → 窓が素直に閉じる (確認ダイアログもエラーも出ない)
- [x] tab 1 つ → `ctrl+shift+x` → 同上
- [x] split → 片方の pane で `ctrl+shift+x` → 兄弟にフォーカス (pane 経路は不変)
- [x] tab の X と `close_tab` は今まで通り park / close

</details>

