### PR TITLE
Give TOGGLE_BACKGROUND_OPACITY its tag and let CellSize take its gate

### DIFF
--- a/App/App.vcxproj
+++ b/App/App.vcxproj
@@ -176,6 +176,7 @@
     <ClInclude Include="Terminal\SurfaceHost.h" />
     <ClInclude Include="Tabs\ParkedTabs.h" />
     <ClInclude Include="Windows\TransparentBackdrop.h" />
+    <ClInclude Include="Windows\TearOut.h" />
     <ClInclude Include="Windows\WindowCloseGate.h" />
     <ClInclude Include="Windows\WindowState.h" />
     <ClInclude Include="Tabs\Panes\Branch.h" />
@@ -232,6 +233,7 @@
     <ClCompile Include="Terminal\EditContext.cpp" />
     <ClCompile Include="Terminal\SurfaceHost.cpp" />
     <ClCompile Include="Windows\TransparentBackdrop.cpp" />
+    <ClCompile Include="Windows\TearOut.cpp" />
     <ClCompile Include="Windows\WindowCloseGate.cpp" />
     <ClCompile Include="Terminal\TerminalControl.xaml.cpp">
       <DependentUpon>Terminal\TerminalControl.xaml</DependentUpon>

--- a/App/App.vcxproj
+++ b/App/App.vcxproj
@@ -177,6 +177,7 @@
     <ClInclude Include="Tabs\ParkedTabs.h" />
     <ClInclude Include="Windows\TransparentBackdrop.h" />
     <ClInclude Include="Windows\WindowCloseGate.h" />
+    <ClInclude Include="Windows\WindowState.h" />
     <ClInclude Include="Tabs\Panes\Branch.h" />
     <ClInclude Include="Tabs\Panes\Pane.h" />
     <ClInclude Include="Tabs\Panes\PaneId.h" />

--- a/App/App.vcxproj.filters
+++ b/App/App.vcxproj.filters
@@ -98,6 +98,9 @@
     <ClInclude Include="Windows\MainWindows.h">
       <Filter>Windows</Filter>
     </ClInclude>
+    <ClInclude Include="Windows\TearOut.h">
+      <Filter>Windows</Filter>
+    </ClInclude>
     <ClInclude Include="Windows\WindowCloseGate.h">
       <Filter>Windows</Filter>
     </ClInclude>
@@ -146,6 +149,9 @@
       <Filter>Windows</Filter>
     </ClCompile>
     <ClCompile Include="Windows\MainWindows.cpp">
+      <Filter>Windows</Filter>
+    </ClCompile>
+    <ClCompile Include="Windows\TearOut.cpp">
       <Filter>Windows</Filter>
     </ClCompile>
     <ClCompile Include="Windows\WindowCloseGate.cpp">

--- a/App/App.vcxproj.filters
+++ b/App/App.vcxproj.filters
@@ -101,6 +101,9 @@
     <ClInclude Include="Windows\WindowCloseGate.h">
       <Filter>Windows</Filter>
     </ClInclude>
+    <ClInclude Include="Windows\WindowState.h">
+      <Filter>Windows</Filter>
+    </ClInclude>
     <ClInclude Include="Windows\TransparentBackdrop.h">
       <Filter>Windows</Filter>
     </ClInclude>

--- a/App/App.xaml.cpp
+++ b/App/App.xaml.cpp
@@ -313,7 +313,7 @@ namespace winrt::GhosttyWin32::implementation
         w.Activate();
     }
 
-    MainWindow* App::CreateTearOutWindow()
+    MainWindow* App::CreateTearOutWindow(WindowState const& inherited)
     {
         auto w = make<MainWindow>();
         auto* impl = winrt::get_self<MainWindow>(w);
@@ -321,6 +321,7 @@ namespace winrt::GhosttyWin32::implementation
         // one-shot init: this window adopts the dragged tab instead
         // of creating one.
         impl->SuppressInitialTab();
+        impl->InheritState(inherited);
         TrackWindow(w);
         // Deliberately no Activate(): the drop handler positions the
         // window at the drop point after adopting the tab and decides

--- a/App/App.xaml.h
+++ b/App/App.xaml.h
@@ -3,6 +3,7 @@
 #include "App.xaml.g.h"
 #include "Ghostty/App.h"
 #include "Windows/MainWindows.h"
+#include "Windows/WindowState.h"
 #include "Tabs/Panes/PaneIdAllocator.h"
 #include "Tabs/PressedTab.h"
 #include "Tabs/TabDrag.h"
@@ -111,12 +112,13 @@ namespace winrt::GhosttyWin32::implementation
         // a home when it arrives.
         void Quit();
 
-        // Spawn the window that will host a torn-out tab. Same
+        // Spawn the window that will host a torn-out tab, starting
+        // from `inherited` (the source window's State()). Same
         // tracking as CreateNewWindow, but with no initial tab (it
         // adopts the dropped one) and no Activate() — the drop
         // handler positions the window at the drop point after
         // adopting the tab and decides activation itself.
-        MainWindow* CreateTearOutWindow();
+        MainWindow* CreateTearOutWindow(WindowState const& inherited);
 
         // The live window whose tab strip owns `item`, or null.
         // Locates the source window of a dragged tab on the drop

--- a/App/Windows/MainWindow.xaml.cpp
+++ b/App/Windows/MainWindow.xaml.cpp
@@ -2055,6 +2055,10 @@ namespace winrt::GhosttyWin32::implementation
         UNDO_PARK_TRACE(L"CellSnap[%llu]: config replaced, enabled=%d\n",
                         GetTickCount64() % 100'000,
                         m_cellSize.Enabled() ? 1 : 0);
+        // background-opacity / background-blur likewise: a reload
+        // only brings CONFIG_CHANGE (COLOR_CHANGE is the OSC path),
+        // so nothing else re-reads them until the next toggle.
+        ApplyBackgroundOpacityAppearance();
     }
 
     void MainWindow::ReloadConfig(bool soft)

--- a/App/Windows/MainWindow.xaml.cpp
+++ b/App/Windows/MainWindow.xaml.cpp
@@ -1700,16 +1700,16 @@ namespace winrt::GhosttyWin32::implementation
 
     void MainWindow::ArmCellSnap(ghostty_action_cell_size_s cell)
     {
-        if (cell.width == 0 || cell.height == 0) return;
-        m_cellSize.Apply(m_hwnd, cell);
-        if (m_ghosttyApp) {
-            const bool enabled =
-                ghostty::Config(m_ghosttyApp->ConfigHandle()).WindowStepResize();
-            m_cellSize.SetEnabled(enabled);
-            UNDO_PARK_TRACE(L"CellSnap[%llu]: applied %ux%u enabled=%d\n",
-                            GetTickCount64() % 100'000, cell.width,
-                            cell.height, enabled ? 1 : 0);
-        }
+        m_cellSize.Apply(m_hwnd, cell, WindowStepResizeByConfig());
+        UNDO_PARK_TRACE(L"CellSnap[%llu]: applied %ux%u enabled=%d\n",
+                        GetTickCount64() % 100'000, cell.width,
+                        cell.height, m_cellSize.Enabled() ? 1 : 0);
+    }
+
+    bool MainWindow::WindowStepResizeByConfig() const
+    {
+        if (!m_ghosttyApp) return false;
+        return ghostty::Config(m_ghosttyApp->ConfigHandle()).WindowStepResize();
     }
 
     void MainWindow::ToggleFullscreen()
@@ -2051,11 +2051,10 @@ namespace winrt::GhosttyWin32::implementation
         // window-step-resize can be toggled by itself; CELL_SIZE
         // only re-fires on metric changes, so re-read the gate here
         // so a reload flips snapping immediately (#155).
-        const bool enabled =
-            ghostty::Config(m_ghosttyApp->ConfigHandle()).WindowStepResize();
-        m_cellSize.SetEnabled(enabled);
+        m_cellSize.SetEnabled(WindowStepResizeByConfig());
         UNDO_PARK_TRACE(L"CellSnap[%llu]: config replaced, enabled=%d\n",
-                        GetTickCount64() % 100'000, enabled ? 1 : 0);
+                        GetTickCount64() % 100'000,
+                        m_cellSize.Enabled() ? 1 : 0);
     }
 
     void MainWindow::ReloadConfig(bool soft)

--- a/App/Windows/MainWindow.xaml.cpp
+++ b/App/Windows/MainWindow.xaml.cpp
@@ -3,6 +3,7 @@
 #include "App.xaml.h"
 #include "Ghostty/CallbackDispatcher.h"
 #include "Ghostty/Config.h"
+#include "Windows/TearOut.h"
 #include "Windows/TransparentBackdrop.h"
 #include "Host/KeyModifiers.h"
 #include "Interop/Encoding.h"
@@ -431,38 +432,12 @@ namespace winrt::GhosttyWin32::implementation
                 auto item = App::g_app->TabDrag().TakeLastDraggedTab();
                 if (!item) return;
                 POINT cursor{};
-                bool haveCursor = GetCursorPos(&cursor) != 0;
-                // Offsets place the window so its tab strip lands near
-                // the pointer instead of the window's top-left corner.
-                int32_t dropX = static_cast<int32_t>(cursor.x) - 120;
-                int32_t dropY = static_cast<int32_t>(cursor.y) - 24;
-                // Dragging out the only tab must not leave an empty
-                // shell behind — just move this window to the drop
-                // point instead, browser-style.
-                if (self->m_tabs.Size() <= 1) {
-                    if (haveCursor) {
-                        self->AppWindow().Move({ dropX, dropY });
-                    }
-                    return;
-                }
-                auto* host = App::g_app->CreateTearOutWindow(self->State());
-                if (!host) return;
-                try {
-                    if (auto tab = self->ReleaseTornOutTab(item)) {
-                        host->AdoptTornOutTab(std::move(tab), -1);
-                        if (haveCursor) {
-                            host->AppWindow().Move({ dropX, dropY });
-                        }
-                        // The drag is over, so activation is safe —
-                        // hand the new window focus like a browser
-                        // does after a tab is torn off.
-                        host->Activate();
-                    } else {
-                        // Nothing moved; don't leak an empty host.
-                        host->RequestClose();
-                    }
-                } catch (winrt::hresult_error const&) {
-                }
+                std::optional<POINT> dropPoint;
+                if (GetCursorPos(&cursor)) dropPoint = cursor;
+                TearOut::ToNewWindow(*self, item, dropPoint,
+                    [](WindowState const& inherited) {
+                        return App::g_app->CreateTearOutWindow(inherited);
+                    });
             });
 
             // Don't call Window.SetTitleBar(AppTitleBar()) — that would

--- a/App/Windows/MainWindow.xaml.cpp
+++ b/App/Windows/MainWindow.xaml.cpp
@@ -445,11 +445,10 @@ namespace winrt::GhosttyWin32::implementation
                     }
                     return;
                 }
-                auto* host = App::g_app->CreateTearOutWindow();
+                auto* host = App::g_app->CreateTearOutWindow(self->State());
                 if (!host) return;
                 try {
                     if (auto tab = self->ReleaseTornOutTab(item)) {
-                        host->InheritWindowState(*self);
                         host->AdoptTornOutTab(std::move(tab), -1);
                         if (haveCursor) {
                             host->AppWindow().Move({ dropX, dropY });
@@ -1834,8 +1833,8 @@ namespace winrt::GhosttyWin32::implementation
         ghostty::Config cfg(m_ghosttyApp->ConfigHandle());
         // The tag holds the guards (config already opaque, or
         // fullscreen); a guarded toggle changes nothing to re-apply.
-        if (!m_backgroundOpacity.Toggle(cfg.BackgroundOpacity(),
-                                        m_fullscreen.Active())) {
+        if (!m_state.backgroundOpacity.Toggle(cfg.BackgroundOpacity(),
+                                              m_fullscreen.Active())) {
             return;
         }
         ApplyBackgroundOpacityAppearance();
@@ -1853,7 +1852,7 @@ namespace winrt::GhosttyWin32::implementation
             opacity = cfg.BackgroundOpacity();
             blur = cfg.BackgroundBlurEnabled();
         }
-        return m_backgroundOpacity.Effective(opacity, blur);
+        return m_state.backgroundOpacity.Effective(opacity, blur);
     }
 
     void MainWindow::ApplyBackgroundOpacityAppearance()

--- a/App/Windows/MainWindow.xaml.cpp
+++ b/App/Windows/MainWindow.xaml.cpp
@@ -1094,10 +1094,8 @@ namespace winrt::GhosttyWin32::implementation
             // background-opacity mode is window-scoped (#69), and a
             // pane born after a toggle must match its window.
             auto onLeafCreated = [this](implementation::TerminalControl& tc) {
-                ghostty::Config cfg(m_ghosttyApp->ConfigHandle());
-                const bool underlay =
-                    m_bgOpaque && cfg.BackgroundOpacity() < 1.0;
-                tc.SetOpaqueBackground(underlay, m_bgColor);
+                tc.SetOpaqueBackground(
+                    BackgroundOpacityAppearance().paneUnderlay, m_bgColor);
             };
             // Hand the factory the App wrapper, not a Config snapshot:
             // the config handle is freed and swapped on every config
@@ -1833,50 +1831,48 @@ namespace winrt::GhosttyWin32::implementation
     {
         if (!m_ghosttyApp) return;
         ghostty::Config cfg(m_ghosttyApp->ConfigHandle());
-        // macOS guards: nothing to toggle when no transparency is
-        // configured; never while fullscreen.
-        if (cfg.BackgroundOpacity() >= 1.0) return;
-        if (m_fullscreen.Active()) return;
-        m_bgOpaque = !m_bgOpaque;
+        // The tag holds the guards (config already opaque, or
+        // fullscreen); a guarded toggle changes nothing to re-apply.
+        if (!m_backgroundOpacity.Toggle(cfg.BackgroundOpacity(),
+                                        m_fullscreen.Active())) {
+            return;
+        }
         ApplyBackgroundOpacityAppearance();
+    }
+
+    ghostty::actions::tags::BackgroundOpacity::Appearance
+    MainWindow::BackgroundOpacityAppearance() const
+    {
+        // No ghostty yet = nothing configured = opaque, same as a
+        // config with background-opacity 1.0.
+        double opacity = 1.0;
+        bool blur = false;
+        if (m_ghosttyApp) {
+            ghostty::Config cfg(m_ghosttyApp->ConfigHandle());
+            opacity = cfg.BackgroundOpacity();
+            blur = cfg.BackgroundBlurEnabled();
+        }
+        return m_backgroundOpacity.Effective(opacity, blur);
     }
 
     void MainWindow::ApplyBackgroundOpacityAppearance()
     {
-        bool translucent = false;
-        if (m_ghosttyApp) {
-            ghostty::Config cfg(m_ghosttyApp->ConfigHandle());
-            translucent = cfg.BackgroundOpacity() < 1.0 && !m_bgOpaque;
-        }
-        // Backdrop selection mirrors Windows Terminal's two
-        // transparency modes and maps 1:1 onto ghostty config:
-        //   translucent + background-blur  -> DesktopAcrylic (blur
-        //     whatever is behind the window)
-        //   translucent, no blur           -> TransparentBackdrop
-        //     (crisp see-through — WT's "vintage opacity" look)
-        //   opaque                         -> Mica, as before
-        // Mica alone was tried first and reads as "slightly gray",
-        // not transparent — it only tints toward the wallpaper
-        // (observed during #69 verification).
-        bool blur = false;
-        if (translucent && m_ghosttyApp) {
-            blur = ghostty::Config(m_ghosttyApp->ConfigHandle())
-                       .BackgroundBlurEnabled();
-        }
+        // Every branch below is a decision the tag already made
+        // (see BackgroundOpacity.h for why each backdrop); this
+        // method only turns it into XAML / DWM calls.
+        using Backdrop = ghostty::actions::tags::BackgroundOpacity::Backdrop;
+        const auto look = BackgroundOpacityAppearance();
         try {
-            if (translucent) {
-                if (blur) {
-                    // Not the stock DesktopAcrylicBackdrop: its
-                    // material tint swallows the terminal's own
-                    // translucency. ClearAcrylic is pure blur, so
-                    // background-opacity and background-blur compose
-                    // (frosted glass).
+            switch (look.backdrop) {
+                case Backdrop::ClearAcrylic:
                     SystemBackdrop(winrt::GhosttyWin32::ClearAcrylicBackdrop());
-                } else {
+                    break;
+                case Backdrop::Transparent:
                     SystemBackdrop(winrt::GhosttyWin32::TransparentBackdrop());
-                }
-            } else {
-                SystemBackdrop(winrt::Microsoft::UI::Xaml::Media::MicaBackdrop());
+                    break;
+                case Backdrop::Mica:
+                    SystemBackdrop(winrt::Microsoft::UI::Xaml::Media::MicaBackdrop());
+                    break;
             }
         } catch (winrt::hresult_error const&) {
             // Backdrop swap can fail during teardown; visuals only.
@@ -1886,16 +1882,13 @@ namespace winrt::GhosttyWin32::implementation
         // see-through. Enabling "blur behind" with an empty region is
         // the long-standing switch that makes DWM honour the window's
         // per-pixel alpha (the blur itself has been a no-op since
-        // Win8; only the alpha semantics remain). Only needed for the
-        // crisp mode — Acrylic/Mica are DWM materials that composite
-        // on their own.
+        // Win8; only the alpha semantics remain).
         if (m_hwnd) {
-            const bool wantAlpha = translucent && !blur;
             DWM_BLURBEHIND bb{};
             bb.dwFlags = DWM_BB_ENABLE;
-            bb.fEnable = wantAlpha ? TRUE : FALSE;
+            bb.fEnable = look.dwmPerPixelAlpha ? TRUE : FALSE;
             HRGN rgn = nullptr;
-            if (wantAlpha) {
+            if (look.dwmPerPixelAlpha) {
                 rgn = CreateRectRgn(-1, -1, 0, 0);
                 bb.dwFlags |= DWM_BB_BLURREGION;
                 bb.hRgnBlur = rgn;
@@ -1903,24 +1896,17 @@ namespace winrt::GhosttyWin32::implementation
             DwmEnableBlurBehindWindow(m_hwnd, &bb);
             if (rgn) DeleteObject(rgn);
         }
-        // Root: in translucent mode the root stays unpainted so the
-        // window backdrop shows through behind the panes; otherwise
-        // paint it with the terminal background as before.
         if (auto content = Content()) {
             auto panel = content.as<winrt::Microsoft::UI::Xaml::Controls::Panel>();
-            if (translucent) {
-                panel.Background(nullptr);
-            } else {
+            if (look.paintRoot) {
                 panel.Background(
                     winrt::Microsoft::UI::Xaml::Media::SolidColorBrush(m_bgColor));
+            } else {
+                panel.Background(nullptr);
             }
         }
-        // Underlays only earn their pixel cost when they change the
-        // result: config transparency present AND the user toggled
-        // opaque. (With opacity 1.0 the swap chain is opaque anyway.)
-        const bool underlay = !translucent && m_bgOpaque;
         for (auto& tab : m_tabs) {
-            if (tab) tab->ApplyBackgroundOpacity(underlay, m_bgColor);
+            if (tab) tab->ApplyBackgroundOpacity(look.paneUnderlay, m_bgColor);
         }
     }
 

--- a/App/Windows/MainWindow.xaml.cpp
+++ b/App/Windows/MainWindow.xaml.cpp
@@ -449,6 +449,7 @@ namespace winrt::GhosttyWin32::implementation
                 if (!host) return;
                 try {
                     if (auto tab = self->ReleaseTornOutTab(item)) {
+                        host->InheritWindowState(*self);
                         host->AdoptTornOutTab(std::move(tab), -1);
                         if (haveCursor) {
                             host->AppWindow().Move({ dropX, dropY });

--- a/App/Windows/MainWindow.xaml.h
+++ b/App/Windows/MainWindow.xaml.h
@@ -290,6 +290,16 @@ namespace winrt::GhosttyWin32::implementation
         // App::CreateTearOutWindow through the existing friendship.
         void SuppressInitialTab() noexcept { m_suppressInitialTab = true; }
 
+        // Window-scoped state a torn-out tab should keep: the
+        // background-opacity mode of the window it came from
+        // (upstream macOS keeps it on the controller, which moves
+        // with the tab). Called by the drop-outside handler before
+        // AdoptTornOutTab, whose final re-apply then paints this
+        // window like the source.
+        void InheritWindowState(MainWindow const& source) noexcept {
+            m_backgroundOpacity = source.m_backgroundOpacity;
+        }
+
         // Take `item`'s Tab out of this window alive: strip entry
         // removed, panel unparented from AppContent, focused-surface
         // cache cleared if it pointed into the tab — but nothing

--- a/App/Windows/MainWindow.xaml.h
+++ b/App/Windows/MainWindow.xaml.h
@@ -157,10 +157,12 @@ namespace winrt::GhosttyWin32::implementation
         void ApplyCellSizeForSurface(ghostty_surface_t surface,
                                      ghostty_action_cell_size_s cell) override;
         // Shared tail of the surface report and the adopt-time
-        // re-arm: update the WM_SIZING snapping tag with the metrics
-        // and re-read the window-step-resize gate. No-op on {0,0}
-        // (nothing reported yet).
+        // re-arm: hand the WM_SIZING snapping tag the metrics and
+        // the current window-step-resize gate.
         void ArmCellSnap(ghostty_action_cell_size_s cell);
+        // `window-step-resize` as the config says right now; false
+        // before ghostty is up. The one place it is read.
+        bool WindowStepResizeByConfig() const;
 
         // Terminal-driven appearance / lifecycle overrides. Bodies
         // are in MainWindow.xaml.cpp; the logic moved verbatim

--- a/App/Windows/MainWindow.xaml.h
+++ b/App/Windows/MainWindow.xaml.h
@@ -214,6 +214,12 @@ namespace winrt::GhosttyWin32::implementation
         // this window's guts, granted access by name rather than by
         // widening the public surface.
         friend struct App;
+        // TearOut runs the tab-moves-to-a-new-window sequence, which
+        // is the window's own protocol (State / TabCount /
+        // ReleaseTornOutTab / AdoptTornOutTab) pulled out of the
+        // constructor so it can be read in one place. Same footing
+        // as App: named access, not a public surface.
+        friend class TearOut;
 
 
         void InitGhostty();
@@ -298,6 +304,9 @@ namespace winrt::GhosttyWin32::implementation
         // AdoptTornOutTab's final re-apply then paints this window
         // like the source.
         void InheritState(WindowState const& state) noexcept { m_state = state; }
+
+        // How many tabs the strip holds (parked ones excluded).
+        size_t TabCount() const noexcept { return m_tabs.Size(); }
 
         // Take `item`'s Tab out of this window alive: strip entry
         // removed, panel unparented from AppContent, focused-surface

--- a/App/Windows/MainWindow.xaml.h
+++ b/App/Windows/MainWindow.xaml.h
@@ -2,7 +2,6 @@
 
 #include "MainWindow.g.h"
 #include "ghostty.h"
-#include "Ghostty/Actions/Tags/BackgroundOpacity.h"
 #include "Ghostty/Actions/Tags/CellSize.h"
 #include "Ghostty/Actions/Tags/Fullscreen.h"
 #include "Ghostty/Actions/Tags/SizeLimit.h"
@@ -18,6 +17,7 @@
 #include "Tabs/TabFactory.h"
 #include "Tabs/Tabs.h"
 #include "Windows/WindowCloseGate.h"
+#include "Windows/WindowState.h"
 
 namespace winrt::GhosttyWin32::implementation
 {
@@ -290,15 +290,14 @@ namespace winrt::GhosttyWin32::implementation
         // App::CreateTearOutWindow through the existing friendship.
         void SuppressInitialTab() noexcept { m_suppressInitialTab = true; }
 
-        // Window-scoped state a torn-out tab should keep: the
-        // background-opacity mode of the window it came from
-        // (upstream macOS keeps it on the controller, which moves
-        // with the tab). Called by the drop-outside handler before
-        // AdoptTornOutTab, whose final re-apply then paints this
-        // window like the source.
-        void InheritWindowState(MainWindow const& source) noexcept {
-            m_backgroundOpacity = source.m_backgroundOpacity;
-        }
+        // The window-scoped state this window was born with and
+        // has toggled since — what a torn-out tab takes along.
+        WindowState const& State() const noexcept { return m_state; }
+        // Start from another window's state. Called by
+        // App::CreateTearOutWindow before the tab is adopted;
+        // AdoptTornOutTab's final re-apply then paints this window
+        // like the source.
+        void InheritState(WindowState const& state) noexcept { m_state = state; }
 
         // Take `item`'s Tab out of this window alive: strip entry
         // removed, panel unparented from AppContent, focused-surface
@@ -386,8 +385,10 @@ namespace winrt::GhosttyWin32::implementation
         ghostty::actions::tags::SizeLimit          m_sizeLimit;
         ghostty::actions::tags::CellSize           m_cellSize;
         ghostty::actions::tags::Fullscreen         m_fullscreen;
-        ghostty::actions::tags::BackgroundOpacity  m_backgroundOpacity;
         ghostty::actions::tags::WindowDecorations  m_windowDecorations;
+        // The tags that travel with a torn-out tab, as one value —
+        // see WindowState.h for which and why.
+        WindowState m_state;
         Tabs m_tabs;
         // Undo support for tab closes (#151): parked-tab stack,
         // expiry timers, redo bookkeeping — see Tabs/ParkedTabs.h.

--- a/App/Windows/MainWindow.xaml.h
+++ b/App/Windows/MainWindow.xaml.h
@@ -2,6 +2,7 @@
 
 #include "MainWindow.g.h"
 #include "ghostty.h"
+#include "Ghostty/Actions/Tags/BackgroundOpacity.h"
 #include "Ghostty/Actions/Tags/CellSize.h"
 #include "Ghostty/Actions/Tags/Fullscreen.h"
 #include "Ghostty/Actions/Tags/SizeLimit.h"
@@ -123,12 +124,17 @@ namespace winrt::GhosttyWin32::implementation
         void ToggleWindowDecorations() override;
         void SetFloatOnTop(ghostty_action_float_window_e mode) override;
         void ToggleBackgroundOpacity() override;
-        // Push the current background-opacity mode (m_bgOpaque +
-        // config) to the XAML root and every pane. Called from the
-        // toggle, from pane-creation funnels (CreateTab / split /
-        // adopt) so new panes match the window state, and from
+        // Carry out what the BackgroundOpacity tag decides for the
+        // current config: window backdrop, DWM alpha, root brush,
+        // per-pane underlays. Called from the toggle, from
+        // pane-creation funnels (CreateTab / split / adopt) so new
+        // panes match the window state, and from
         // ApplyBackgroundColor when the terminal recolours.
         void ApplyBackgroundOpacityAppearance();
+        // The tag's verdict for the current config; the one place
+        // the config is read for this purpose.
+        ghostty::actions::tags::BackgroundOpacity::Appearance
+        BackgroundOpacityAppearance() const;
         // Apply the current decoration state (config + any override
         // installed by ToggleWindowDecorations) to the XAML caption
         // buttons / drag region. Called once at startup so the config
@@ -368,6 +374,7 @@ namespace winrt::GhosttyWin32::implementation
         ghostty::actions::tags::SizeLimit          m_sizeLimit;
         ghostty::actions::tags::CellSize           m_cellSize;
         ghostty::actions::tags::Fullscreen         m_fullscreen;
+        ghostty::actions::tags::BackgroundOpacity  m_backgroundOpacity;
         ghostty::actions::tags::WindowDecorations  m_windowDecorations;
         Tabs m_tabs;
         // Undo support for tab closes (#151): parked-tab stack,
@@ -414,12 +421,6 @@ namespace winrt::GhosttyWin32::implementation
         // one is up throws. Set when the dialog opens, cleared in its
         // Completed handler.
         bool m_renamePromptOpen = false;
-        // TOGGLE_BACKGROUND_OPACITY state (#69). false = the config's
-        // background-opacity applies (translucent when < 1.0, which
-        // is also the launch state, matching macOS); true = the user
-        // toggled to fully opaque. Meaningless while the config
-        // opacity is 1.0 — the toggle no-ops there.
-        bool m_bgOpaque = false;
         // Terminal background colour as last applied (config value at
         // init, updated by COLOR_CHANGE via ApplyBackgroundColor).
         // Feeds the opaque underlays and the root brush.

--- a/App/Windows/TearOut.cpp
+++ b/App/Windows/TearOut.cpp
@@ -1,0 +1,79 @@
+#include "pch.h"
+#include "Windows/TearOut.h"
+#include "Windows/MainWindow.xaml.h"
+#include <winrt/Windows.Graphics.h>
+
+namespace winrt::GhosttyWin32::implementation {
+
+namespace {
+
+// Every way ToNewWindow can return null is silent by design (the
+// drag simply ends), which makes a tear-out that "did nothing" hard
+// to tell apart from one that never ran. Debug builds say which it
+// was.
+#if defined(_DEBUG)
+void Trace(wchar_t const* what) noexcept
+{
+    OutputDebugStringW(L"TearOut: ");
+    OutputDebugStringW(what);
+    OutputDebugStringW(L"\n");
+}
+#else
+void Trace(wchar_t const*) noexcept {}
+#endif
+
+// Offsets place the window so its tab strip lands near the pointer
+// instead of the window's top-left corner.
+winrt::Windows::Graphics::PointInt32 HostPositionFor(POINT dropPoint) noexcept
+{
+    return { static_cast<int32_t>(dropPoint.x) - 120,
+             static_cast<int32_t>(dropPoint.y) - 24 };
+}
+
+}  // namespace
+
+MainWindow* TearOut::ToNewWindow(
+    MainWindow& source,
+    winrt::Microsoft::UI::Xaml::Controls::TabViewItem const& item,
+    std::optional<POINT> dropPoint,
+    SpawnHost const& spawnHost)
+{
+    // Dragging out the only tab must not leave an empty shell behind
+    // — just move this window to the drop point instead.
+    if (source.TabCount() <= 1) {
+        Trace(L"only tab in its window; moved the window instead of spawning");
+        if (dropPoint) source.AppWindow().Move(HostPositionFor(*dropPoint));
+        return nullptr;
+    }
+    if (!spawnHost) {
+        Trace(L"no spawnHost supplied; nothing to tear into");
+        return nullptr;
+    }
+    auto* host = spawnHost(source.State());
+    if (!host) {
+        Trace(L"spawnHost returned null; tab stays where it is");
+        return nullptr;
+    }
+    try {
+        auto tab = source.ReleaseTornOutTab(item);
+        if (!tab) {
+            // Nothing moved; don't leak an empty host.
+            Trace(L"source does not own the dragged item; closing the empty host");
+            host->RequestClose();
+            return nullptr;
+        }
+        host->AdoptTornOutTab(std::move(tab), -1);
+        if (dropPoint) host->AppWindow().Move(HostPositionFor(*dropPoint));
+        // The drag is over, so activation is safe — hand the new
+        // window focus like a browser does after a tab is torn off.
+        host->Activate();
+        return host;
+    } catch (winrt::hresult_error const&) {
+        // A failed move must not take either window down; whichever
+        // side holds the unique_ptr owns the tab.
+        Trace(L"adopt threw; whichever side holds the tab keeps it");
+        return nullptr;
+    }
+}
+
+}  // namespace winrt::GhosttyWin32::implementation

--- a/App/Windows/TearOut.h
+++ b/App/Windows/TearOut.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include "Windows/WindowState.h"
+#include <winrt/Microsoft.UI.Xaml.Controls.h>
+#include <windows.h>
+#include <functional>
+#include <optional>
+
+namespace winrt::GhosttyWin32::implementation {
+
+struct MainWindow;
+
+// A tab leaving its window for a new one, browser-style. The one
+// place that knows the steps and their order: spawn the host with
+// the source window's WindowState, move the tab across, place the
+// host at the drop point, hand it focus — and what happens when a
+// step can't (the only tab moves its window instead; a host that
+// received nothing is closed, not leaked).
+//
+// It creates no window itself and reaches for no global: the one
+// thing it needs from outside — a host window born with the given
+// WindowState — is handed in as `spawnHost` (App, which owns the
+// window list, provides it).
+class TearOut {
+public:
+    using SpawnHost = std::function<MainWindow*(WindowState const& inherited)>;
+
+    // Move `item`'s tab out of `source` into a fresh window from
+    // `spawnHost`. `dropPoint` is the pointer position in screen
+    // coordinates, if known; the host is placed so its tab strip
+    // lands near it. Returns the new host, or null when nothing
+    // moved.
+    static MainWindow* ToNewWindow(
+        MainWindow& source,
+        winrt::Microsoft::UI::Xaml::Controls::TabViewItem const& item,
+        std::optional<POINT> dropPoint,
+        SpawnHost const& spawnHost);
+};
+
+}  // namespace winrt::GhosttyWin32::implementation

--- a/App/Windows/WindowState.h
+++ b/App/Windows/WindowState.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include "Ghostty/Actions/Tags/BackgroundOpacity.h"
+#include <type_traits>
+
+namespace winrt::GhosttyWin32::implementation {
+
+// The window-scoped action state a window is born with. A window
+// created from scratch starts at the defaults; a window created to
+// host a torn-out tab starts with a copy of the source window's
+// (upstream macOS keeps this state on the controller, which moves
+// with the tab).
+//
+// One field per tag that travels. Adding a tag here is the whole
+// change: MainWindow holds its copy as this one value and hands it
+// over as a unit, and App::CreateTearOutWindow requires one, so no
+// spawn path can forget it.
+//
+// Only values belong here — state that means the same thing in
+// another window. Tags that hold a window's own resources (an HWND,
+// a WM_SIZING subclass, a saved placement) are non-copyable, so
+// putting one here fails to compile; the assert below says why.
+//
+// Tags deliberately not here:
+//   Fullscreen        a new window is never born fullscreen (and it
+//                     holds the pre-fullscreen placement)
+//   SizeLimit         re-reported by the surfaces once they present
+//   CellSize          re-queried at adopt time (#155)
+//   WindowDecorations per window today; one line here if it should
+//                     travel
+struct WindowState {
+    core::ghostty::actions::tags::BackgroundOpacity backgroundOpacity;
+};
+
+static_assert(std::is_copy_assignable_v<WindowState>,
+              "WindowState travels between windows by copy: only tags "
+              "that are plain values (no HWND / subclass / placement) "
+              "can go in it");
+
+}  // namespace winrt::GhosttyWin32::implementation

--- a/Core/Core.vcxproj
+++ b/Core/Core.vcxproj
@@ -86,6 +86,7 @@
   <ItemGroup>
     <ClInclude Include="Ghostty\Actions\Actions.h" />
     <ClInclude Include="Ghostty\Actions\Tags\Fullscreen.h" />
+    <ClInclude Include="Ghostty\Actions\Tags\BackgroundOpacity.h" />
     <ClInclude Include="Ghostty\Actions\Tags\CellSize.h" />
     <ClInclude Include="Ghostty\Actions\Tags\SizeLimit.h" />
     <ClInclude Include="Ghostty\Actions\Tags\TriggerLabel.h" />

--- a/Core/Core.vcxproj.filters
+++ b/Core/Core.vcxproj.filters
@@ -27,6 +27,9 @@
     <ClInclude Include="Ghostty\Actions\Actions.h">
       <Filter>Ghostty\Actions</Filter>
     </ClInclude>
+    <ClInclude Include="Ghostty\Actions\Tags\BackgroundOpacity.h">
+      <Filter>Ghostty\Actions\Tags</Filter>
+    </ClInclude>
     <ClInclude Include="Ghostty\Actions\Tags\Fullscreen.h">
       <Filter>Ghostty\Actions\Tags</Filter>
     </ClInclude>

--- a/Core/Ghostty/Actions/Tags/BackgroundOpacity.h
+++ b/Core/Ghostty/Actions/Tags/BackgroundOpacity.h
@@ -59,9 +59,9 @@ public:
         bool operator==(const Appearance&) const noexcept = default;
     };
 
+    // A plain value: copying one window's mode into another (a
+    // tear-out host taking its source's) is ordinary assignment.
     BackgroundOpacity() = default;
-    BackgroundOpacity(const BackgroundOpacity&) = delete;
-    BackgroundOpacity& operator=(const BackgroundOpacity&) = delete;
 
     // Apply the user's TOGGLE keypress. `configOpacity` is the current
     // `background-opacity` (Config::BackgroundOpacity()), `fullscreen`

--- a/Core/Ghostty/Actions/Tags/BackgroundOpacity.h
+++ b/Core/Ghostty/Actions/Tags/BackgroundOpacity.h
@@ -1,0 +1,102 @@
+#pragma once
+
+namespace core::ghostty::actions::tags {
+
+// TOGGLE_BACKGROUND_OPACITY action state (#69). Per-window flip
+// between "as configured" (translucent when `background-opacity`
+// < 1.0, which is also the launch state) and "fully opaque", with
+// the same two guards as upstream macOS
+// (BaseTerminalController.toggleBackgroundOpacity):
+//
+//   * nothing to toggle when the config is already opaque
+//   * never while fullscreen (transparency doesn't apply there)
+//
+// The Windows-specific part is how the mode becomes pixels. The
+// window backdrop mirrors Windows Terminal's two transparency modes
+// and maps 1:1 onto ghostty config:
+//
+//   translucent + background-blur  -> ClearAcrylic (pure blur of
+//     whatever is behind the window; the stock DesktopAcrylic tint
+//     would swallow the terminal's own translucency)
+//   translucent, no blur           -> Transparent (crisp see-through,
+//     WT's "vintage opacity" look). DWM composites a window as opaque
+//     by default, so this one also needs per-pixel alpha switched on
+//     (DwmEnableBlurBehindWindow with an empty region)
+//   opaque                         -> Mica, as before. Mica alone was
+//     tried first and reads as "slightly gray", not transparent — it
+//     only tints toward the wallpaper
+//
+// Pure value object: `Toggle` applies the keypress, `Effective`
+// turns the current config + override into an Appearance the view
+// side (MainWindow) just applies. No Win32 / XAML in here so the
+// guards and the backdrop decision are unit-testable.
+class BackgroundOpacity {
+public:
+    enum class Backdrop {
+        Transparent,   // crisp see-through
+        ClearAcrylic,  // blurred see-through
+        Mica,          // opaque
+    };
+
+    // What the window should look like right now. Every field is a
+    // decision already made; the view only carries it out.
+    struct Appearance {
+        Backdrop backdrop;
+        // Ask DWM to honour the window's per-pixel alpha. Only the
+        // crisp mode needs it — Acrylic / Mica are DWM materials that
+        // composite on their own.
+        bool dwmPerPixelAlpha;
+        // Paint the XAML root with the terminal background. In the
+        // translucent modes the root stays unpainted so the backdrop
+        // shows through behind the panes.
+        bool paintRoot;
+        // Show each pane's opaque underlay. Only earns its pixel cost
+        // when it changes the result: config transparency present AND
+        // the user toggled opaque (with opacity 1.0 the swap chain is
+        // opaque anyway).
+        bool paneUnderlay;
+
+        bool operator==(const Appearance&) const noexcept = default;
+    };
+
+    BackgroundOpacity() = default;
+    BackgroundOpacity(const BackgroundOpacity&) = delete;
+    BackgroundOpacity& operator=(const BackgroundOpacity&) = delete;
+
+    // Apply the user's TOGGLE keypress. `configOpacity` is the current
+    // `background-opacity` (Config::BackgroundOpacity()), `fullscreen`
+    // whether borderless fullscreen is active. Returns whether the
+    // mode flipped — false means a guard fired and there is nothing
+    // to re-apply.
+    bool Toggle(double configOpacity, bool fullscreen) noexcept {
+        if (configOpacity >= 1.0) return false;
+        if (fullscreen) return false;
+        m_opaque = !m_opaque;
+        return true;
+    }
+
+    // Whether the user has toggled to fully opaque. Meaningless while
+    // the config opacity is 1.0 — `Effective` ignores it there.
+    bool Opaque() const noexcept { return m_opaque; }
+
+    // The look for the current config and override. `configBlur` is
+    // Config::BackgroundBlurEnabled().
+    Appearance Effective(double configOpacity, bool configBlur) const noexcept {
+        const bool transparentConfig = configOpacity < 1.0;
+        const bool translucent = transparentConfig && !m_opaque;
+        const bool blur = translucent && configBlur;
+        return Appearance{
+            .backdrop = !translucent ? Backdrop::Mica
+                      : blur         ? Backdrop::ClearAcrylic
+                                     : Backdrop::Transparent,
+            .dwmPerPixelAlpha = translucent && !blur,
+            .paintRoot = !translucent,
+            .paneUnderlay = transparentConfig && m_opaque,
+        };
+    }
+
+private:
+    bool m_opaque = false;
+};
+
+}  // namespace core::ghostty::actions::tags

--- a/Core/Ghostty/Actions/Tags/CellSize.cpp
+++ b/Core/Ghostty/Actions/Tags/CellSize.cpp
@@ -30,9 +30,12 @@ LONG SnapEdge(LONG anchor, LONG moving, LONG step, int direction) noexcept
 
 }  // namespace
 
-void CellSize::Apply(HWND hwnd, ghostty_action_cell_size_s cell) noexcept
+void CellSize::Apply(HWND hwnd, ghostty_action_cell_size_s cell,
+                     bool stepResize) noexcept
 {
+    if (cell.width == 0 || cell.height == 0) return;
     m_value = cell;
+    m_enabled = stepResize;
     Attach(hwnd);
 }
 

--- a/Core/Ghostty/Actions/Tags/CellSize.h
+++ b/Core/Ghostty/Actions/Tags/CellSize.h
@@ -31,12 +31,15 @@ public:
     CellSize(const CellSize&) = delete;
     CellSize& operator=(const CellSize&) = delete;
 
-    // Update the active cell metrics and install the subclass on
-    // first use. Zero in either dimension disables snapping on
-    // that axis (defensive — the renderer always reports both).
-    // A null hwnd still records the metrics; call Attach once the
-    // HWND exists to complete the install.
-    void Apply(HWND hwnd, ghostty_action_cell_size_s cell) noexcept;
+    // Take a CELL_SIZE report: record the metrics, set the gate
+    // from `window-step-resize` (Config::WindowStepResize(),
+    // upstream default: false) and install the subclass on first
+    // use. A report with a zero dimension is ignored — nothing has
+    // been measured yet, and the previous metrics stay. A null
+    // hwnd still records the metrics; call Attach once the HWND
+    // exists to complete the install.
+    void Apply(HWND hwnd, ghostty_action_cell_size_s cell,
+               bool stepResize) noexcept;
 
     // Late subclass install for the adopt-before-activation order:
     // a fresh tear-out host adopts its tab (and arms the metrics)
@@ -46,10 +49,11 @@ public:
     // that never saw a CELL_SIZE keep paying no subclass cost).
     void Attach(HWND hwnd) noexcept;
 
-    // Gate from `window-step-resize` (upstream default: false).
-    // The metrics keep flowing regardless so a config toggle takes
-    // effect instantly without waiting for the next CELL_SIZE.
-    void SetEnabled(bool enabled) noexcept { m_enabled = enabled; }
+    // Re-read of the gate alone, for a config reload: CELL_SIZE
+    // only re-fires on metric changes, so a reload that flips
+    // `window-step-resize` by itself must reach the gate this way.
+    void SetEnabled(bool stepResize) noexcept { m_enabled = stepResize; }
+    bool Enabled() const noexcept { return m_enabled; }
 
 private:
     static LRESULT CALLBACK SubclassProc(

--- a/Tests/Tests.vcxproj
+++ b/Tests/Tests.vcxproj
@@ -170,6 +170,7 @@
     <ClCompile Include="test_fullscreen.cpp" />
     <ClCompile Include="test_key_event_translator.cpp" />
     <ClCompile Include="test_window_decorations.cpp" />
+    <ClCompile Include="test_background_opacity.cpp" />
     <ClCompile Include="test_tab_drag.cpp" />
     <ClCompile Include="test_pressed_tab.cpp" />
     <ClCompile Include="test_trigger_label.cpp" />

--- a/Tests/test_background_opacity.cpp
+++ b/Tests/test_background_opacity.cpp
@@ -1,0 +1,101 @@
+#include "pch.h"
+#include "../Core/Ghostty/Actions/Tags/BackgroundOpacity.h"
+
+using core::ghostty::actions::tags::BackgroundOpacity;
+using Backdrop = BackgroundOpacity::Backdrop;
+
+// ----- initial state -----
+
+TEST(BackgroundOpacityTest, LaunchesAsConfigured) {
+    BackgroundOpacity o;
+    EXPECT_FALSE(o.Opaque());
+}
+
+// ----- toggle guards: match upstream macOS toggleBackgroundOpacity -----
+
+TEST(BackgroundOpacityTest, ToggleIsNoOpWhenConfigIsOpaque) {
+    BackgroundOpacity o;
+    EXPECT_FALSE(o.Toggle(/*configOpacity=*/1.0, /*fullscreen=*/false));
+    EXPECT_FALSE(o.Opaque());
+}
+
+TEST(BackgroundOpacityTest, ToggleIsNoOpWhileFullscreen) {
+    BackgroundOpacity o;
+    EXPECT_FALSE(o.Toggle(/*configOpacity=*/0.8, /*fullscreen=*/true));
+    EXPECT_FALSE(o.Opaque());
+}
+
+TEST(BackgroundOpacityTest, ToggleFlipsAndFlipsBack) {
+    BackgroundOpacity o;
+    EXPECT_TRUE(o.Toggle(0.8, false));
+    EXPECT_TRUE(o.Opaque());
+    EXPECT_TRUE(o.Toggle(0.8, false));
+    EXPECT_FALSE(o.Opaque());
+}
+
+// ----- appearance: the three backdrops and what each one needs -----
+
+TEST(BackgroundOpacityTest, OpaqueConfigIsMicaWithPaintedRoot) {
+    BackgroundOpacity o;
+    auto a = o.Effective(/*configOpacity=*/1.0, /*configBlur=*/true);
+    EXPECT_EQ(a.backdrop, Backdrop::Mica);
+    EXPECT_FALSE(a.dwmPerPixelAlpha);
+    EXPECT_TRUE(a.paintRoot);
+    EXPECT_FALSE(a.paneUnderlay);
+}
+
+TEST(BackgroundOpacityTest, TranslucentWithoutBlurIsCrispAndNeedsDwmAlpha) {
+    BackgroundOpacity o;
+    auto a = o.Effective(0.8, /*configBlur=*/false);
+    EXPECT_EQ(a.backdrop, Backdrop::Transparent);
+    EXPECT_TRUE(a.dwmPerPixelAlpha);
+    EXPECT_FALSE(a.paintRoot);
+    EXPECT_FALSE(a.paneUnderlay);
+}
+
+TEST(BackgroundOpacityTest, TranslucentWithBlurIsClearAcrylic) {
+    BackgroundOpacity o;
+    auto a = o.Effective(0.8, /*configBlur=*/true);
+    EXPECT_EQ(a.backdrop, Backdrop::ClearAcrylic);
+    // Acrylic is a DWM material; it composites on its own.
+    EXPECT_FALSE(a.dwmPerPixelAlpha);
+    EXPECT_FALSE(a.paintRoot);
+    EXPECT_FALSE(a.paneUnderlay);
+}
+
+TEST(BackgroundOpacityTest, ToggledOpaqueIsMicaWithUnderlays) {
+    BackgroundOpacity o;
+    o.Toggle(0.8, false);
+    auto a = o.Effective(0.8, /*configBlur=*/true);
+    EXPECT_EQ(a.backdrop, Backdrop::Mica);
+    EXPECT_FALSE(a.dwmPerPixelAlpha);
+    EXPECT_TRUE(a.paintRoot);
+    // The one case the underlays earn their cost: the swap chain is
+    // translucent but the user wants it opaque.
+    EXPECT_TRUE(a.paneUnderlay);
+}
+
+// ----- config-change tolerance -----
+
+TEST(BackgroundOpacityTest, ReloadToOpaqueConfigDropsUnderlaysButKeepsOverride) {
+    // User toggled opaque, then a config reload sets
+    // background-opacity = 1.0. The swap chain is opaque on its own
+    // now, so no underlay; the override is kept for when the config
+    // goes translucent again (matches the previous MainWindow
+    // behaviour — nothing ever cleared the flag).
+    BackgroundOpacity o;
+    o.Toggle(0.8, false);
+    auto a = o.Effective(1.0, false);
+    EXPECT_EQ(a.backdrop, Backdrop::Mica);
+    EXPECT_FALSE(a.paneUnderlay);
+    EXPECT_TRUE(o.Opaque());
+
+    auto again = o.Effective(0.8, false);
+    EXPECT_TRUE(again.paneUnderlay);
+}
+
+TEST(BackgroundOpacityTest, ReloadFlippingBlurSwitchesBackdropInPlace) {
+    BackgroundOpacity o;
+    EXPECT_EQ(o.Effective(0.8, false).backdrop, Backdrop::Transparent);
+    EXPECT_EQ(o.Effective(0.8, true).backdrop, Backdrop::ClearAcrylic);
+}


### PR DESCRIPTION
## Why

Every window-scoped ghostty action (`TOGGLE_FULLSCREEN`, `TOGGLE_WINDOW_DECORATIONS`, `SIZE_LIMIT`, `CELL_SIZE`) has a tag in `Core/Ghostty/Actions/Tags/` — a value that holds the action's state and makes its decisions, with the window only carrying them out. `TOGGLE_BACKGROUND_OPACITY` was the exception: its state was a `bool` on `MainWindow`, and the decision (the macOS guards, the three-way backdrop choice, DWM per-pixel alpha, root brush, per-pane underlays) lived in an 80-line apply plus a second, slightly different underlay formula in the leaf-created hook. None of it could be tested without a window.

The `CELL_SIZE` tag had a smaller version of the same problem: the `window-step-resize` gate was read from config and pushed into it at two sites, and the "nothing measured yet" check on a zero cell sat in the window.

<details>
<summary>日本語</summary>

窓スコープの ghostty action (`TOGGLE_FULLSCREEN` / `TOGGLE_WINDOW_DECORATIONS` / `SIZE_LIMIT` / `CELL_SIZE`) には `Core/Ghostty/Actions/Tags/` に tag がある。action の状態を持って判断まで済ませる値で、窓はその結果を当てるだけ。`TOGGLE_BACKGROUND_OPACITY` だけ例外で、状態は `MainWindow` の `bool`、判断 (macOS の guard、backdrop 3 択、DWM の per-pixel alpha、root の塗り、pane の underlay) は 80 行の apply と、それとは少し違う式の leaf-created hook に散っていた。窓なしでは何もテストできない。

`CELL_SIZE` tag にも小さい同じ問題があった。`window-step-resize` の gate を config から読んで tag に押し込む処理が 2 箇所にあり、cell が 0 の「まだ測ってない」判定が窓側にあった。
</details>

## What

**`tags::BackgroundOpacity`** (header-only, pure)
- `Toggle(configOpacity, fullscreen)` — the two upstream guards (config already opaque / fullscreen), returns whether the mode flipped
- `Effective(configOpacity, configBlur)` → `Appearance { backdrop, dwmPerPixelAlpha, paintRoot, paneUnderlay }` — every field is a decision already made
- `MainWindow::ApplyBackgroundOpacityAppearance` is now a `switch` on `backdrop` plus three straight applications; the leaf-created hook uses the same verdict as the window-wide apply (previously it had its own formula — the two only differed after a config reload to opacity 1.0 with a stale toggle, where the swap chain is opaque anyway)
- `MainWindow::m_bgOpaque` is gone
- 10 unit tests: guards, the three backdrops and what each needs, config-reload behaviour

**`tags::CellSize`**
- `Apply(hwnd, cell, stepResize)` takes the gate with the metrics and ignores zero-dimension reports itself; `SetEnabled` stays for the config-reload path, `Enabled()` added for the trace
- `MainWindow::WindowStepResizeByConfig()` is the one place the config is read for it

**Config reload** (found while verifying)
- A reload only delivers `CONFIG_CHANGE` (`COLOR_CHANGE` is the OSC path), and `ReplaceConfig` never re-applied the appearance — so editing `background-opacity` / `background-blur` in the config file did nothing until the next toggle or a restart. `ReplaceConfig` now re-applies it, the same way it re-reads the cell-snap gate

**Tear-out** (found while verifying)
- A tab dragged out of a window toggled opaque landed in a window at the config default: the mode is window-scoped and the host started fresh (same shape as the cell-snap gap in #155). Upstream macOS keeps the mode on the controller, which moves with the tab. What travels is now named: **`App/Windows/WindowState.h`** is the list of tags a window is born with (one field per tag; `MainWindow` holds them as this one value, `App::CreateTearOutWindow(WindowState const&)` requires one, the copy is plain assignment). Only value tags can go in — the ones that own a window's resources (`Fullscreen`, `SizeLimit`, `CellSize`) are non-copyable, and a `static_assert` turns that into a readable error. Dropping into an existing window keeps that window's mode, as before

**`App/Windows/TearOut`**
- The tear-out sequence (only-tab rule, spawn with the source's `WindowState`, move, placement, activation, the two failure paths) was a forty-line lambda in the `MainWindow` constructor. `TearOut::ToNewWindow(source, item, dropPoint, spawnHost)` holds it; the drop handler takes the dragged item and the pointer position and calls it. `TearOut` reaches for no global — the one thing it needs from outside, a host window born with a given `WindowState`, comes in as `spawnHost` (the handler passes `App::CreateTearOutWindow`)

<details>
<summary>日本語</summary>

**`tags::BackgroundOpacity`** (header-only、純粋)
- `Toggle(configOpacity, fullscreen)` — 本家の guard 2 つ (config が既に不透明 / fullscreen 中)。反転したかを返す
- `Effective(configOpacity, configBlur)` → `Appearance { backdrop, dwmPerPixelAlpha, paintRoot, paneUnderlay }` — 全フィールドが判断済みの結果
- `MainWindow::ApplyBackgroundOpacityAppearance` は `backdrop` の `switch` + 3 つの当てるだけの処理になった。leaf-created hook も窓全体の apply と同じ verdict を使う (以前は別の式で、config reload で opacity 1.0 に戻った時に toggle が残っている場合だけ答えが違った。swap chain は不透明なので見た目は同じ)
- `MainWindow::m_bgOpaque` を削除
- 単体テスト 10 本: guard、backdrop 3 種とそれぞれに必要なもの、config reload の挙動

**`tags::CellSize`**
- `Apply(hwnd, cell, stepResize)` が metrics と一緒に gate を受け取り、0 の report は自分で無視する。`SetEnabled` は config reload 経路のために残し、trace 用に `Enabled()` を追加
- `MainWindow::WindowStepResizeByConfig()` が config を読む唯一の場所

**config reload** (検証中に判明)
- reload で来るのは `CONFIG_CHANGE` だけ (`COLOR_CHANGE` は OSC 経路) で、`ReplaceConfig` は見た目を再適用していなかった。config ファイルの `background-opacity` / `background-blur` を変えても次の toggle か再起動まで反映されない状態だった。cell-snap の gate を読み直すのと同じ場所で再適用するようにした

**tear-out** (検証中に判明)
- 不透明に倒した窓から tab をドラッグで外すと、新しい窓は config 通りに戻っていた。mode は窓スコープで、新しい host は初期値から始まるため (#155 の cell-snap と同じ形)。本家 macOS は mode を controller に持たせていて tab と一緒に動く。何が付いていくかを名前にした: **`App/Windows/WindowState.h`** が「窓が生まれる時に持たされる tag」のリスト (tag 1 つ = field 1 つ。`MainWindow` はこの 1 値として持ち、`App::CreateTearOutWindow(WindowState const&)` が引数として要求、コピーは普通の代入)。値の tag しか入れられない — 窓の資源を握る `Fullscreen` / `SizeLimit` / `CellSize` は非コピーで、`static_assert` がそれを読めるエラーにする。既存の窓へ drop した場合はその窓の mode のまま (従来通り)

**`App/Windows/TearOut`**
- tear-out の手順 (唯一の tab なら窓ごと移動、元窓の `WindowState` で spawn、移動、配置、activate、失敗 2 経路) は `MainWindow` ctor の 40 行ラムダだった。`TearOut::ToNewWindow(source, item, dropPoint, spawnHost)` に置き、drop handler はドラッグ中の item と pointer 位置を取って呼ぶだけ。`TearOut` は global に触らない — 外から要るのは「指定の `WindowState` で生まれる host 窓」だけで、それを `spawnHost` として受け取る (handler は `App::CreateTearOutWindow` を渡す)
</details>

## Verification

- [x] Build Debug + Release; Tests green (`test_background_opacity` ×10 added)
- [x] `background-opacity = 0.8`, no blur: launch → see-through window; `toggle_background_opacity` keybind → opaque (Mica + terminal-coloured root + pane underlays); toggle again → see-through
- [x] `background-opacity = 0.8`, `background-blur = true`: launch → frosted (ClearAcrylic); toggle → opaque; toggle back → frosted
- [x] `background-opacity = 1.0`: toggle does nothing
- [x] Fullscreen (`toggle_fullscreen`) with a translucent config: toggle does nothing; leave fullscreen → toggle works again
- [x] While toggled opaque: new tab and split match the window (no see-through pane)
- [x] Config reload that flips `background-blur` (or `background-opacity`) switches the backdrop in place, without a toggle or restart
- [x] Toggle opaque, drag a tab out → the new window is opaque too; drag it into another window → that window keeps its own mode
- [x] `window-step-resize = true`: interactive resize snaps to the cell grid; reload with `false` → free resize; reload with `true` → snaps again (gate path)

<details>
<summary>日本語</summary>

- [x] Debug + Release ビルド、Tests green (`test_background_opacity` ×10 追加)
- [x] `background-opacity = 0.8`、blur なし: 起動 → 透ける。`toggle_background_opacity` の keybind → 不透明 (Mica + 端末色の root + pane の underlay)。もう一度 → 透ける
- [x] `background-opacity = 0.8`、`background-blur = true`: 起動 → すりガラス (ClearAcrylic)。toggle → 不透明。戻す → すりガラス
- [x] `background-opacity = 1.0`: toggle しても何も起きない
- [x] 透過 config で fullscreen (`toggle_fullscreen`) 中: toggle しても何も起きない。fullscreen 解除 → toggle が効く
- [x] 不透明に倒した状態で新しい tab と split → 窓と同じ (透ける pane が出ない)
- [x] `background-blur` (か `background-opacity`) を変えて config reload → toggle も再起動もなしに backdrop がその場で切り替わる
- [x] 不透明に倒して tab をドラッグで外す → 新しい窓も不透明。別の窓へ drop → その窓の mode のまま
- [x] `window-step-resize = true`: ドラッグ resize が cell 単位で snap する。`false` に reload → 自由 resize。`true` に reload → また snap (gate 経路)
</details>
