### PR TITLE
Name the debug trace for what it is, not for its first user

### DIFF
--- a/App/Tabs/ParkedTabs.h
+++ b/App/Tabs/ParkedTabs.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "Tabs/Tab.h"
+#include "Win32/DebugTrace.h"
 #include <winrt/Microsoft.UI.Dispatching.h>
 #include <winrt/Microsoft.UI.Xaml.Controls.h>
 #include <algorithm>
@@ -9,23 +10,6 @@
 #include <memory>
 #include <optional>
 #include <vector>
-
-// Undo-park lifecycle tracing (#151). Debug / ASan builds only —
-// Release compiles the calls (and the format strings) out entirely.
-// Every call site passes at least the tick argument, so the plain
-// __VA_ARGS__ form works under the conformant preprocessor too.
-// Defined here because both this class and MainWindow's close-path
-// decision log speak the same trace vocabulary.
-#if defined(_DEBUG)
-#define UNDO_PARK_TRACE(fmt, ...)                                     \
-    do {                                                              \
-        wchar_t undoParkTraceBuf_[224];                               \
-        swprintf_s(undoParkTraceBuf_, fmt, __VA_ARGS__);              \
-        OutputDebugStringW(undoParkTraceBuf_);                        \
-    } while (0)
-#else
-#define UNDO_PARK_TRACE(fmt, ...) do { } while (0)
-#endif
 
 namespace winrt::GhosttyWin32::implementation {
 
@@ -81,7 +65,7 @@ public:
             }
         }
         if (!m_entries.empty()) {
-            UNDO_PARK_TRACE(L"UndoPark[%llu]: re-armed %zu parked timer(s)\n",
+            DEBUG_TRACE(L"UndoPark[%llu]: re-armed %zu parked timer(s)\n",
                             GetTickCount64() % 100'000, m_entries.size());
         }
 #endif
@@ -106,7 +90,7 @@ public:
         entry.timer = timer;
         m_entries.push_back(std::move(entry));
         timer.Start();
-        UNDO_PARK_TRACE(L"UndoPark[%llu]: parked tab=%p idx=%u timeout=%llums "
+        DEBUG_TRACE(L"UndoPark[%llu]: parked tab=%p idx=%u timeout=%llums "
                         L"(parked total: %zu)\n",
                         GetTickCount64() % 100'000, static_cast<void*>(key),
                         index, timeoutMs, m_entries.size());
@@ -121,14 +105,14 @@ public:
     std::optional<Restored> PopNewest()
     {
         if (m_entries.empty()) {
-            UNDO_PARK_TRACE(L"UndoPark[%llu]: undo requested, stack empty\n",
+            DEBUG_TRACE(L"UndoPark[%llu]: undo requested, stack empty\n",
                             GetTickCount64() % 100'000);
             return std::nullopt;
         }
         Entry entry = std::move(m_entries.back());
         m_entries.pop_back();
         if (entry.timer) entry.timer.Stop();
-        UNDO_PARK_TRACE(L"UndoPark[%llu]: undo tab=%p (parked left: %zu)\n",
+        DEBUG_TRACE(L"UndoPark[%llu]: undo tab=%p (parked left: %zu)\n",
                         GetTickCount64() % 100'000,
                         static_cast<void*>(entry.tab.get()), m_entries.size());
         return Restored{ std::move(entry.tab), entry.index };
@@ -193,7 +177,7 @@ private:
         auto tab = std::move(it->tab);
         auto onExpire = std::move(it->onExpire);
         m_entries.erase(it);
-        UNDO_PARK_TRACE(L"UndoPark[%llu]: expired tab=%p (parked left: %zu)\n",
+        DEBUG_TRACE(L"UndoPark[%llu]: expired tab=%p (parked left: %zu)\n",
                         GetTickCount64() % 100'000, static_cast<void*>(key),
                         m_entries.size());
         if (onExpire) onExpire(std::move(tab));

--- a/App/Windows/MainWindow.xaml.cpp
+++ b/App/Windows/MainWindow.xaml.cpp
@@ -9,6 +9,7 @@
 #include "Interop/Encoding.h"
 #include "Display/PhysicalPixels.h"
 #include "Win32/Clipboard.h"
+#include "Win32/DebugTrace.h"
 #include "Win32/SEHGuard.h"
 #if __has_include("MainWindow.g.cpp")
 #include "MainWindow.g.cpp"
@@ -38,7 +39,6 @@
 using namespace winrt;
 using namespace Microsoft::UI::Xaml;
 namespace muxc = Microsoft::UI::Xaml::Controls;
-// UNDO_PARK_TRACE comes from Tabs/ParkedTabs.h (via MainWindow.xaml.h).
 
 namespace winrt::GhosttyWin32::implementation
 {
@@ -1389,10 +1389,8 @@ namespace winrt::GhosttyWin32::implementation
         }
         const auto tabs = static_cast<unsigned>(m_tabs.Size());
         const auto parked = static_cast<unsigned>(m_parkedTabs.Size());
-        wchar_t buf[96];
-        swprintf_s(buf, L"PanelInvariant: tabs=%u parked=%u panels=%u\n",
-                   tabs, parked, panels);
-        OutputDebugStringW(buf);
+        DEBUG_TRACE(L"PanelInvariant: tabs=%u parked=%u panels=%u\n",
+                    tabs, parked, panels);
         if (panels != tabs + parked && IsDebuggerPresent()) __debugbreak();
 #endif
     }
@@ -1664,7 +1662,7 @@ namespace winrt::GhosttyWin32::implementation
         // one window share the font config, so whichever pane
         // reported last is the right step anyway.
         if (!m_tabs.FindBySurface(surface)) {
-            UNDO_PARK_TRACE(L"CellSnap[%llu]: CELL_SIZE %ux%u for surface=%p "
+            DEBUG_TRACE(L"CellSnap[%llu]: CELL_SIZE %ux%u for surface=%p "
                             L"not in this window, skipped\n",
                             GetTickCount64() % 100'000, cell.width,
                             cell.height, static_cast<void*>(surface));
@@ -1676,7 +1674,7 @@ namespace winrt::GhosttyWin32::implementation
     void MainWindow::ArmCellSnap(ghostty_action_cell_size_s cell)
     {
         m_cellSize.Apply(m_hwnd, cell, WindowStepResizeByConfig());
-        UNDO_PARK_TRACE(L"CellSnap[%llu]: applied %ux%u enabled=%d\n",
+        DEBUG_TRACE(L"CellSnap[%llu]: applied %ux%u enabled=%d\n",
                         GetTickCount64() % 100'000, cell.width,
                         cell.height, m_cellSize.Enabled() ? 1 : 0);
     }
@@ -2027,7 +2025,7 @@ namespace winrt::GhosttyWin32::implementation
         // only re-fires on metric changes, so re-read the gate here
         // so a reload flips snapping immediately (#155).
         m_cellSize.SetEnabled(WindowStepResizeByConfig());
-        UNDO_PARK_TRACE(L"CellSnap[%llu]: config replaced, enabled=%d\n",
+        DEBUG_TRACE(L"CellSnap[%llu]: config replaced, enabled=%d\n",
                         GetTickCount64() % 100'000,
                         m_cellSize.Enabled() ? 1 : 0);
         // background-opacity / background-blur likewise: a reload
@@ -2690,7 +2688,7 @@ namespace winrt::GhosttyWin32::implementation
             auto* tcForPark = pane->Impl();
             bool processAlive =
                 tcForPark && !tcForPark->Surface().ProcessExited();
-            UNDO_PARK_TRACE(L"UndoPark[%llu]: close-eval pane=%p wrapping=%p "
+            DEBUG_TRACE(L"UndoPark[%llu]: close-eval pane=%p wrapping=%p "
                             L"parent=%p onlyPane=%d alive=%d tabs=%u\n",
                             GetTickCount64() % 100'000,
                             static_cast<void*>(pane),

--- a/App/Windows/TearOut.cpp
+++ b/App/Windows/TearOut.cpp
@@ -1,26 +1,12 @@
 #include "pch.h"
 #include "Windows/TearOut.h"
 #include "Windows/MainWindow.xaml.h"
+#include "Win32/DebugTrace.h"
 #include <winrt/Windows.Graphics.h>
 
 namespace winrt::GhosttyWin32::implementation {
 
 namespace {
-
-// Every way ToNewWindow can return null is silent by design (the
-// drag simply ends), which makes a tear-out that "did nothing" hard
-// to tell apart from one that never ran. Debug builds say which it
-// was.
-#if defined(_DEBUG)
-void Trace(wchar_t const* what) noexcept
-{
-    OutputDebugStringW(L"TearOut: ");
-    OutputDebugStringW(what);
-    OutputDebugStringW(L"\n");
-}
-#else
-void Trace(wchar_t const*) noexcept {}
-#endif
 
 // Offsets place the window so its tab strip lands near the pointer
 // instead of the window's top-left corner.
@@ -40,25 +26,29 @@ MainWindow* TearOut::ToNewWindow(
 {
     // Dragging out the only tab must not leave an empty shell behind
     // — just move this window to the drop point instead.
+    // Every way out of here without a host is silent by design (the
+    // drag simply ends), which makes a tear-out that "did nothing"
+    // hard to tell apart from one that never ran; the traces say
+    // which it was.
     if (source.TabCount() <= 1) {
-        Trace(L"only tab in its window; moved the window instead of spawning");
+        DEBUG_TRACE(L"TearOut: only tab in its window; moved the window instead of spawning\n");
         if (dropPoint) source.AppWindow().Move(HostPositionFor(*dropPoint));
         return nullptr;
     }
     if (!spawnHost) {
-        Trace(L"no spawnHost supplied; nothing to tear into");
+        DEBUG_TRACE(L"TearOut: no spawnHost supplied; nothing to tear into\n");
         return nullptr;
     }
     auto* host = spawnHost(source.State());
     if (!host) {
-        Trace(L"spawnHost returned null; tab stays where it is");
+        DEBUG_TRACE(L"TearOut: spawnHost returned null; tab stays where it is\n");
         return nullptr;
     }
     try {
         auto tab = source.ReleaseTornOutTab(item);
         if (!tab) {
             // Nothing moved; don't leak an empty host.
-            Trace(L"source does not own the dragged item; closing the empty host");
+            DEBUG_TRACE(L"TearOut: source does not own the dragged item; closing the empty host\n");
             host->RequestClose();
             return nullptr;
         }
@@ -67,11 +57,13 @@ MainWindow* TearOut::ToNewWindow(
         // The drag is over, so activation is safe — hand the new
         // window focus like a browser does after a tab is torn off.
         host->Activate();
+        DEBUG_TRACE(L"TearOut: tab moved to a new window (source has %zu left)\n",
+                    source.TabCount());
         return host;
     } catch (winrt::hresult_error const&) {
         // A failed move must not take either window down; whichever
         // side holds the unique_ptr owns the tab.
-        Trace(L"adopt threw; whichever side holds the tab keeps it");
+        DEBUG_TRACE(L"TearOut: adopt threw; whichever side holds the tab keeps it\n");
         return nullptr;
     }
 }

--- a/Core/Core.vcxproj
+++ b/Core/Core.vcxproj
@@ -105,6 +105,7 @@
     <ClInclude Include="Input\KeyEventTranslator.h" />
     <ClInclude Include="Interop\Encoding.h" />
     <ClInclude Include="Win32\Clipboard.h" />
+    <ClInclude Include="Win32\DebugTrace.h" />
     <ClInclude Include="Win32\SEHGuard.h" />
   </ItemGroup>
   <ItemGroup>

--- a/Core/Core.vcxproj.filters
+++ b/Core/Core.vcxproj.filters
@@ -78,6 +78,9 @@
     <ClInclude Include="Win32\Clipboard.h">
       <Filter>Win32</Filter>
     </ClInclude>
+    <ClInclude Include="Win32\DebugTrace.h">
+      <Filter>Win32</Filter>
+    </ClInclude>
     <ClInclude Include="Win32\SEHGuard.h">
       <Filter>Win32</Filter>
     </ClInclude>

--- a/Core/Ghostty/Actions/Tags/CellSize.cpp
+++ b/Core/Ghostty/Actions/Tags/CellSize.cpp
@@ -1,4 +1,5 @@
 #include "CellSize.h"
+#include "Win32/DebugTrace.h"
 #include <cmath>
 #include <cwchar>
 #include <commctrl.h>
@@ -59,12 +60,10 @@ LRESULT CALLBACK CellSize::SubclassProc(
     // go quiet after a new tab even though the gate reads enabled.
     if (msg == WM_ENTERSIZEMOVE) {
         auto* self = reinterpret_cast<CellSize*>(ref);
-        wchar_t buf[128];
-        swprintf_s(buf, L"CellSnap: sizing loop enter, enabled=%d cell=%ux%u\n",
-                   self && self->m_enabled ? 1 : 0,
-                   self ? self->m_value.width : 0,
-                   self ? self->m_value.height : 0);
-        OutputDebugStringW(buf);
+        DEBUG_TRACE(L"CellSnap: sizing loop enter, enabled=%d cell=%ux%u\n",
+                    self && self->m_enabled ? 1 : 0,
+                    self ? self->m_value.width : 0,
+                    self ? self->m_value.height : 0);
     }
 #endif
     if (msg == WM_SIZING) {

--- a/Core/Win32/DebugTrace.h
+++ b/Core/Win32/DebugTrace.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <windows.h>
+#include <cstdio>
+
+// One line to the debugger's output window, Debug / ASan builds
+// only — Release compiles the call and its format string out
+// entirely, so a trace costs nothing to leave in.
+//
+//   DEBUG_TRACE(L"CellSnap[%llu]: applied %ux%u\n", tick, w, h);
+//   DEBUG_TRACE(L"TearOut: spawnHost returned null\n");
+//
+// The format string is the first variadic argument so a call with no
+// values is legal under both the traditional and the conformant
+// preprocessor. Each subsystem prefixes its own lines (UndoPark[..],
+// CellSnap[..], PanelInvariant, TearOut) so a filtered output window
+// reads as one story.
+#if defined(_DEBUG)
+#define DEBUG_TRACE(...)                                              \
+    do {                                                              \
+        wchar_t debugTraceBuf_[224];                                  \
+        swprintf_s(debugTraceBuf_, __VA_ARGS__);                      \
+        OutputDebugStringW(debugTraceBuf_);                           \
+    } while (0)
+#else
+#define DEBUG_TRACE(...) do { } while (0)
+#endif


### PR DESCRIPTION
## Why

`UNDO_PARK_TRACE` was defined in `Tabs/ParkedTabs.h` for the undo-park log (#151), then borrowed by the cell-snap lines (#155) and the panel-invariant check (#184). A third of its call sites had nothing to do with undo, so the name told a reader the wrong thing there. Meanwhile `CellSize.cpp`, `TearOut.cpp` and `DebugAssertPanelInvariant` each carried their own hand-rolled `swprintf_s` + `OutputDebugStringW` under `#if defined(_DEBUG)`.

<details>
<summary>日本語</summary>

`UNDO_PARK_TRACE` は `Tabs/ParkedTabs.h` に undo-park のログ (#151) 用として定義され、その後 cell-snap (#155) と panel-invariant (#184) の行に借用された。呼び出し箇所の 1/3 は undo と無関係で、名前が読む人に嘘をつく状態だった。加えて `CellSize.cpp` / `TearOut.cpp` / `DebugAssertPanelInvariant` はそれぞれ `#if defined(_DEBUG)` 下に手書きの `swprintf_s` + `OutputDebugStringW` を持っていた。
</details>

## What

- **`Core/Win32/DebugTrace.h`** — `DEBUG_TRACE(...)`: one line to the debugger output, Debug / ASan only, compiled out (format string included) in Release. The format string is the first variadic argument so a call with no values is legal under both preprocessors
- `UNDO_PARK_TRACE` is gone from `ParkedTabs.h`; its 10 call sites (UndoPark ×7, CellSnap ×3) are `DEBUG_TRACE` with the same text
- `DebugAssertPanelInvariant`, `CellSize::SubclassProc` and the `TearOut` outcome lines use the macro instead of their own buffers; `TearOut`'s local `Trace()` helper is removed, and a success line is added so the log tells the whole story, not just the failures
- Each subsystem keeps its own line prefix (`UndoPark[..]`, `CellSnap[..]`, `PanelInvariant`, `TearOut`), so a filtered output window still reads as one story

No behaviour change; existing output text is identical (one line added for a successful tear-out).

<details>
<summary>日本語</summary>

- **`Core/Win32/DebugTrace.h`** — `DEBUG_TRACE(...)`: デバッガ出力へ 1 行。Debug / ASan 限定で、Release では format 文字列ごとコンパイルアウト。format を最初の可変引数にしてあるので、値なしの呼び出しも従来 / conformant どちらのプリプロセッサでも通る
- `ParkedTabs.h` から `UNDO_PARK_TRACE` を削除。呼び出し 10 箇所 (UndoPark ×7、CellSnap ×3) は同じ文面のまま `DEBUG_TRACE` に
- `DebugAssertPanelInvariant` / `CellSize::SubclassProc` / `TearOut` の各経路も自前バッファをやめてマクロに。`TearOut` のローカル `Trace()` は削除、失敗だけでなく成功時にも 1 行出すようにして log が話として読めるように
- 各 subsystem の行 prefix (`UndoPark[..]` / `CellSnap[..]` / `PanelInvariant` / `TearOut`) はそのままなので、出力窓で filter しても今まで通り読める

挙動変更なし、既存の出力文面も同一 (tear-out 成功時の 1 行だけ追加)。
</details>

## Verification

- [x] Build Debug + Release (Release must not warn about unused trace arguments)
- [x] Debug: close a tab, undo, let one expire → `UndoPark[..]` lines in the VS output window as before
- [x] Debug: drag-resize with `window-step-resize = true` → `CellSnap: sizing loop enter …` line
- [x] Debug: tear a tab out → `TearOut: tab moved to a new window …`; then drag that window's only tab → `TearOut: only tab in its window …`
- [x] Debug: close a tab → `PanelInvariant: tabs=… parked=… panels=…` line

<details>
<summary>日本語</summary>

- [x] Debug + Release ビルド (Release で未使用引数の warning が出ないこと)
- [x] Debug: tab を閉じる、undo、期限切れ → VS 出力窓に従来通り `UndoPark[..]` の行
- [x] Debug: `window-step-resize = true` でドラッグ resize → `CellSnap: sizing loop enter …` の行
- [x] Debug: tab を外へドラッグ → `TearOut: tab moved to a new window …`。続けてその窓の唯一の tab をドラッグ → `TearOut: only tab in its window …`
- [x] Debug: tab を閉じる → `PanelInvariant: tabs=… parked=… panels=…` の行
</details>
