### PR TITLE
Keep local Release builds off the production package identity

### DIFF
--- a/.github/actions/build-signed-msix/action.yml
+++ b/.github/actions/build-signed-msix/action.yml
@@ -190,6 +190,11 @@ runs:
         $msbuildArgs = @(
           "Package/Package.wapproj",
           "/p:Configuration=Release",
+          # The production package identity (Package.appxmanifest).
+          # Local builds default to the ".Dev" identity so they
+          # coexist with an installed Ghostty; only a build that is
+          # going to be published carries the real one.
+          "/p:ProductionIdentity=true",
           "/p:Platform=x64",
           "/p:PlatformToolset=v145",
           "/p:GenerateAppxPackageOnBuild=true",

--- a/Package/Package.Debug.appxmanifest
+++ b/Package/Package.Debug.appxmanifest
@@ -1,19 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <!--
-  Debug-configuration manifest. Selected by Package.wapproj when
-  building the Debug|* configurations; Release builds (including
-  every CI channel — dev-build / RC / production) use the sibling
+  Local-build manifest. Selected by Package.wapproj for every build
+  that is not going to be published — any configuration, Release
+  included — while builds with ProductionIdentity=true (every CI
+  channel: dev-build / RC / production) use the sibling
   Package.appxmanifest instead.
 
-  The only substantive differences from the Release manifest are:
+  The only substantive differences from the production manifest are:
 
-  - Identity/@Name: appended ".Dev" so Windows treats an F5-registered
-    debug loose install as a completely different app from the
-    installed production MSIX. Without this split, installing the
-    production MSIX after an F5 (or vice versa) trips 0x80073cfb
-    ("current user already installed a packaged / unpackaged version
-    of this app") and requires manual uninstall each round.
+  - Identity/@Name: appended ".Dev" so Windows treats a locally
+    deployed build (F5 loose install, or a local Release deploy) as
+    a completely different app from the installed production MSIX.
+    Without this split, deploying a local build replaces the
+    installed one, and installing the production MSIX after an F5
+    (or vice versa) trips 0x80073cfb ("current user already
+    installed a packaged / unpackaged version of this app") and
+    requires manual uninstall each round.
   - DisplayName / VisualElements/@DisplayName: suffixed "(Dev)" so
     the debug entry is visually distinguishable in Start Menu, task
     switcher, and taskbar — you know at a glance which build you're

--- a/Package/Package.wapproj
+++ b/Package/Package.wapproj
@@ -51,36 +51,44 @@
     <EntryPointProjectUniqueName>..\App\App.vcxproj</EntryPointProjectUniqueName>
   </PropertyGroup>
   <!--
-    Manifest per configuration.
+    Which manifest, and so which package identity, this build gets.
 
-    Release|* → Package.appxmanifest (the production identity CI signs
-      and ships). Every CI channel — dev-build / RC / production —
-      builds Release, so this is what ends up in every MSIX we publish.
+    ProductionIdentity=true → Package.appxmanifest (the identity CI
+      signs and ships). Only a build that is going to be published
+      should carry it: every CI channel — dev-build / RC / production
+      — passes /p:ProductionIdentity=true through
+      .github/actions/build-signed-msix, and it also defaults on for
+      a Release build under CI=true (set by GitHub Actions) so a
+      workflow that forgets the property still ships the right thing.
 
-    Everything else (Debug, ASan) → Package.Debug.appxmanifest
-      (Identity Name ends in ".Dev", distinct DisplayName + toast
-      CLSID). Lets an F5-registered loose install coexist with an
-      installed production MSIX on the same machine instead of
-      tripping 0x80073cfb every round. Keyed on "not Release" rather
-      than listing dev configurations so a future local-only
-      configuration can't silently pick up the production identity.
+    Everything else → Package.Debug.appxmanifest (Identity Name ends
+      in ".Dev", distinct DisplayName + toast CLSID). That is every
+      local build, Release included: Windows keys installs on the
+      package family, so a local Release deploy carrying the
+      production identity replaces the Ghostty the developer has
+      installed (and an F5 after that trips 0x80073cfb). With the
+      ".Dev" identity the two coexist. A deliberate local production
+      package is still one property away:
+        msbuild Package\Package.wapproj /p:Configuration=Release /p:ProductionIdentity=true
 
     See the comment at the top of Package.Debug.appxmanifest for the
     fuller rationale and the two-file maintenance cost.
   -->
-  <ItemGroup Condition="'$(Configuration)'=='Release'">
+  <PropertyGroup>
+    <ProductionIdentity Condition="'$(ProductionIdentity)'=='' and '$(Configuration)'=='Release' and '$(CI)'=='true'">true</ProductionIdentity>
+    <ProductionIdentity Condition="'$(ProductionIdentity)'==''">false</ProductionIdentity>
+  </PropertyGroup>
+  <ItemGroup Condition="'$(ProductionIdentity)'=='true'">
     <AppxManifest Include="Package.appxmanifest">
       <SubType>Designer</SubType>
     </AppxManifest>
+    <None Include="Package.Debug.appxmanifest" />
   </ItemGroup>
-  <ItemGroup Condition="'$(Configuration)'!='Release'">
+  <ItemGroup Condition="'$(ProductionIdentity)'!='true'">
     <AppxManifest Include="Package.Debug.appxmanifest">
       <SubType>Designer</SubType>
     </AppxManifest>
     <None Include="Package.appxmanifest" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(Configuration)'=='Release'">
-    <None Include="Package.Debug.appxmanifest" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="Images\SplashScreen.scale-200.png" />


### PR DESCRIPTION
## Why

`Package.wapproj` picked the package identity by configuration: Release got the production `Package.appxmanifest`, everything else the `.Dev` one. That let Debug/ASan F5 installs coexist with an installed Ghostty, but a local **Release** deploy carried the production identity, and Windows keys installs on the package family — so running Release from Visual Studio replaced the Ghostty the developer had installed (and an F5 afterwards tripped 0x80073cfb). Release is also the only configuration whose warnings we care about, so this came up every time a change needed a Release check.

<details>
<summary>日本語</summary>

`Package.wapproj` は identity を構成で選んでいた。Release は本物の `Package.appxmanifest`、それ以外は `.Dev`。Debug/ASan の F5 はインストール済みの Ghostty と共存できたが、ローカルの **Release** deploy は本物の identity を持っていて、Windows は install を package family で識別するので、VS から Release を実行するとインストール済みの Ghostty が置き換わっていた (その後の F5 は 0x80073cfb)。warning を見たいのは Release だけなので、Release 確認のたびにこれが起きていた。
</details>

## What

- The manifest is now selected by a `ProductionIdentity` MSBuild property, not by configuration. `true` → `Package.appxmanifest`; anything else → `Package.Debug.appxmanifest` (`.Dev` identity). Every local build, Release included, is `.Dev` and coexists with the installed Ghostty
- `.github/actions/build-signed-msix` passes `/p:ProductionIdentity=true` explicitly — it is the one path all three CI channels (ci / dev-build / release) build through. As a second line, the property also defaults on for a Release build under `CI=true` (GitHub Actions sets it), so a future workflow that forgets it still ships the right identity
- A deliberate local production package is one property away: `msbuild Package\Package.wapproj /p:Configuration=Release /p:ProductionIdentity=true`
- Comments in the wapproj and at the top of `Package.Debug.appxmanifest` rewritten for the new rule

No change to what CI publishes: the same manifest, the same identity, now selected by an explicit property instead of an implicit "it's Release".

<details>
<summary>日本語</summary>

- manifest の選択を構成ではなく MSBuild property `ProductionIdentity` で行う。`true` → `Package.appxmanifest`、それ以外 → `Package.Debug.appxmanifest` (`.Dev` identity)。ローカルのビルドは Release も含めて全部 `.Dev` になり、インストール済みの Ghostty と共存する
- `.github/actions/build-signed-msix` が `/p:ProductionIdentity=true` を明示的に渡す。CI 3 経路 (ci / dev-build / release) は全部この action を通る。保険として、`CI=true` (GitHub Actions が立てる) 下の Release ではこの property が自動で on になるので、将来の workflow が渡し忘れても本物の identity で出る
- 意図的にローカルで本物の package を作るなら property 1 つ: `msbuild Package\Package.wapproj /p:Configuration=Release /p:ProductionIdentity=true`
- wapproj と `Package.Debug.appxmanifest` 冒頭のコメントを新しいルールに書き直した

CI が publish するものは変わらない。同じ manifest、同じ identity を、暗黙の「Release だから」ではなく明示的な property で選ぶようになっただけ。
</details>

## Verification

- [x] CI green on this PR — the ci workflow builds through the action, so a wrong property name would fail there
- [ ] With a production Ghostty installed: run **Release** from Visual Studio → a second "Ghostty (Dev)" appears; the installed Ghostty is untouched and still launches — deferred: the production install was replaced by the pre-fix Release run, so this is checked together with the item below once v0.9.0 is installed
- [x] Run Debug afterwards → replaces only the Dev entry (same `.Dev` identity), no 0x80073cfb
- [ ] After merge, the next dev-build asset installs as the production identity (updates the installed Ghostty, does not add a Dev entry) — deferred: will be checked with the v0.9.0 release

<details>
<summary>日本語</summary>

- [x] この PR で CI green — ci workflow は action 経由でビルドするので、property 名が間違っていればそこで落ちる
- [ ] 本物の Ghostty をインストールした状態で VS から **Release** を実行 → 2 つ目の「Ghostty (Dev)」が出る。インストール済みの Ghostty はそのままで起動できる — 保留: 修正前の Release 実行で production の install が消えているので、v0.9.0 を入れた後に下の項目と一緒に確認
- [x] 続けて Debug を実行 → Dev の方だけ置き換わる (同じ `.Dev` identity)、0x80073cfb なし
- [ ] merge 後、次の dev-build の asset が本物の identity で入る (インストール済みの Ghostty が更新され、Dev の entry は増えない) — 保留: v0.9.0 リリース時に確認
</details>
