### PR TITLE
Move the split actions onto the split panel, with their rules in Core

### DIFF
--- a/App/Tabs/Panes/Tree.h
+++ b/App/Tabs/Panes/Tree.h
@@ -5,6 +5,7 @@
 #include <functional>
 #include <memory>
 #include <utility>
+#include <vector>
 
 namespace winrt::GhosttyWin32::implementation {
 
@@ -59,6 +60,28 @@ public:
     // tree, pane not present) share one nullable return.
     Branch* TryFindBranch(Pane const& pane) noexcept {
         return HasRoot() ? m_root->FindBranchOfPane(pane) : nullptr;
+    }
+
+    // Every pane in depth-first order — the order GOTO_SPLIT
+    // PREVIOUS / NEXT cycles through.
+    std::vector<Pane*> Panes() {
+        std::vector<Pane*> out;
+        ForEachPane([&out](Pane& p) { out.push_back(&p); });
+        return out;
+    }
+
+    // The nearest Split above `pane` that divides along `axis` — the
+    // one RESIZE_SPLIT moves for an arrow across that axis. Null when
+    // no ancestor does (a lone pane, or only splits the other way).
+    Branch* NearestSplitAbove(Pane const& pane, Split::Direction axis) noexcept {
+        Branch* node = TryFindBranch(pane);
+        while (node && node->parent) {
+            node = node->parent;
+            if (auto* split = node->TryGet<Split>(); split && split->direction == axis) {
+                return node;
+            }
+        }
+        return nullptr;
     }
 
     // Preserves `target`'s identity by rewiring its wrapping Branch's

--- a/App/Tabs/SplitPanel.cpp
+++ b/App/Tabs/SplitPanel.cpp
@@ -1,5 +1,6 @@
 #include "pch.h"
 #include "Tabs/SplitPanel.h"
+#include <algorithm>
 #if __has_include("SplitPanel.g.cpp")
 #include "SplitPanel.g.cpp"
 #endif
@@ -85,6 +86,89 @@ void SplitPanel::EqualizeAll() {
     }
     InvalidateMeasure();
     InvalidateArrange();
+}
+
+namespace {
+
+namespace splits = core::ghostty::actions::splits;
+
+Split::Direction ToTree(splits::Axis axis) noexcept {
+    return axis == splits::Axis::Horizontal
+        ? Split::Direction::Horizontal
+        : Split::Direction::Vertical;
+}
+
+splits::Rect ToSplits(winrt::Windows::Foundation::Rect const& r) noexcept {
+    return { r.X, r.Y, r.Width, r.Height };
+}
+
+}  // namespace
+
+Pane* SplitPanel::SplitPane(Pane const& source,
+                            splits::Placement placement,
+                            std::unique_ptr<Branch> fresh) {
+    if (!fresh) return nullptr;
+    // The pane inside `fresh` keeps its address when the branch is
+    // moved into the subtree (unique_ptr hands over the same object),
+    // so this stays valid past ReplacePane.
+    Pane* created = fresh->TryGet<Pane>();
+    // Copy out before ReplacePane destroys the Branch wrapping
+    // `source`: the new wrapper needs its own reference to the
+    // control and the same PaneId so close_surface_cb still routes.
+    auto sourceWrapper = MakePaneBranch(source.control, source.id);
+    auto subtree = placement.newFirst
+        ? MakeSplitBranch(ToTree(placement.axis), 0.5, std::move(fresh), std::move(sourceWrapper))
+        : MakeSplitBranch(ToTree(placement.axis), 0.5, std::move(sourceWrapper), std::move(fresh));
+    if (!ReplacePane(source, std::move(subtree))) return nullptr;
+    return created;
+}
+
+Pane* SplitPanel::PaneToward(Pane const& from, ghostty_action_goto_split_e direction) {
+    auto panes = m_tree.Panes();
+    if (panes.size() <= 1) return nullptr;   // nothing to navigate to
+    auto it = std::find(panes.begin(), panes.end(), &from);
+    if (it == panes.end()) return nullptr;
+    const size_t index = static_cast<size_t>(std::distance(panes.begin(), it));
+
+    if (direction == GHOSTTY_GOTO_SPLIT_PREVIOUS || direction == GHOSTTY_GOTO_SPLIT_NEXT) {
+        return panes[splits::CyclePane(index, panes.size(), direction)];
+    }
+    // The spatial rule works on the arranged rects, which live on the
+    // wrapping Branch rather than the Pane.
+    std::vector<splits::Rect> rects;
+    rects.reserve(panes.size());
+    for (auto* pane : panes) {
+        auto* branch = m_tree.TryFindBranch(*pane);
+        rects.push_back(branch ? ToSplits(branch->arrangedRect) : splits::Rect{});
+    }
+    auto target = splits::AdjacentPane(rects, index, direction);
+    return target ? panes[*target] : nullptr;
+}
+
+bool SplitPanel::ResizeSplit(Pane const& pane, ghostty_action_resize_split_s resize) {
+    const auto axis = splits::ResizeAxis(resize.direction);
+    Branch* node = m_tree.NearestSplitAbove(pane, ToTree(axis));
+    if (!node) return false;
+    auto* split = node->TryGet<Split>();
+    if (!split) return false;
+    const auto rect = node->arrangedRect;
+    const float extent = (axis == splits::Axis::Horizontal) ? rect.Width : rect.Height;
+    split->ratio = splits::ResizedRatio(split->ratio, resize, extent,
+                                        static_cast<float>(kSplitterThickness));
+    InvalidateMeasure();
+    InvalidateArrange();
+    return true;
+}
+
+bool SplitPanel::ToggleZoom(Pane const& pane) {
+    if (m_tree.Zoomed()) {
+        SetZoomed(nullptr);
+        return false;
+    }
+    auto* root = m_tree.Root();
+    if (root && root->TryGet<Pane>() == &pane) return false;   // lone pane
+    SetZoomed(&pane);
+    return true;
 }
 
 void SplitPanel::SyncChildrenFromTree() {

--- a/App/Tabs/SplitPanel.h
+++ b/App/Tabs/SplitPanel.h
@@ -1,7 +1,9 @@
 #pragma once
 
 #include "SplitPanel.g.h"
+#include "Ghostty/Actions/Splits.h"
 #include "Tabs/Panes/Tree.h"
+#include "ghostty.h"
 #include <memory>
 #include <vector>
 
@@ -67,6 +69,38 @@ struct SplitPanel : SplitPanelT<SplitPanel> {
     // its area evenly. Matches EQUALIZE_SPLITS; no-op on a single-pane
     // tree.
     void EqualizeAll();
+
+    // ----- the split actions, over this panel's tree -----
+    // Each takes the pane the action was fired on, applies the rule
+    // from core::ghostty::actions::splits to the tree and its arranged
+    // rects, and reports what changed. Focus and active-pane bookkeeping
+    // are the caller's (MainWindow's) — they belong to the tab, not the
+    // layout.
+
+    // NEW_SPLIT: wrap `source` and `fresh` in a split placed per
+    // `placement`, keeping `source`'s control and PaneId. Returns the
+    // pane inside `fresh` (now in the tree), or null when `source` is
+    // not in this tree — `fresh` is then destroyed unused, so a caller
+    // that attached a surface to it must detach that first.
+    Pane* SplitPane(Pane const& source,
+                    core::ghostty::actions::splits::Placement placement,
+                    std::unique_ptr<Branch> fresh);
+
+    // GOTO_SPLIT: the pane focus should move to from `from` — the
+    // spatial neighbour for LEFT / RIGHT / UP / DOWN, the depth-first
+    // neighbour for PREVIOUS / NEXT — or null when there is none.
+    Pane* PaneToward(Pane const& from, ghostty_action_goto_split_e direction);
+
+    // RESIZE_SPLIT: move the boundary of the nearest split above
+    // `pane` on the arrow's axis. Returns false when no such split
+    // exists (a lone pane, or only splits the other way).
+    bool ResizeSplit(Pane const& pane, ghostty_action_resize_split_s resize);
+
+    // TOGGLE_SPLIT_ZOOM: a second press anywhere collapses an active
+    // zoom (as Windows Terminal / iTerm do); a lone pane has nothing
+    // to expand against; otherwise `pane` fills the panel. Returns
+    // whether `pane` is zoomed afterwards.
+    bool ToggleZoom(Pane const& pane);
 
     // Zoom one pane to fill the entire SplitPanel — every other pane
     // and every splitter is hidden via Visibility=Collapsed. Pass

--- a/App/Windows/MainWindow.xaml.cpp
+++ b/App/Windows/MainWindow.xaml.cpp
@@ -2,6 +2,7 @@
 #include "Windows/MainWindow.xaml.h"
 #include "App.xaml.h"
 #include "Ghostty/CallbackDispatcher.h"
+#include "Ghostty/Actions/Splits.h"
 #include "Ghostty/Config.h"
 #include "Windows/TearOut.h"
 #include "Windows/TransparentBackdrop.h"
@@ -39,6 +40,7 @@
 using namespace winrt;
 using namespace Microsoft::UI::Xaml;
 namespace muxc = Microsoft::UI::Xaml::Controls;
+namespace splits = core::ghostty::actions::splits;
 
 namespace winrt::GhosttyWin32::implementation
 {
@@ -2184,94 +2186,6 @@ namespace winrt::GhosttyWin32::implementation
         }
     }
 
-    namespace {
-        void CollectPanes(Branch& branch, std::vector<Pane*>& out) {
-            branch.ForEachPane([&out](Pane& p) { out.push_back(&p); });
-        }
-
-        // arrangedRect lives on Branch, not Pane — layout callers
-        // resolve the pane back to its wrapping Branch through this.
-        Branch* BranchOfPane(implementation::SplitPanel* panelImpl,
-                             Pane const* pane)
-        {
-            if (!panelImpl || !pane) return nullptr;
-            auto* root = panelImpl->Tree().Root();
-            return root ? root->FindBranchOfPane(*pane) : nullptr;
-        }
-
-        // Score = primary distance + 2 * perpendicular. The 2x
-        // penalty keeps focus moves predictable when an off-axis
-        // pane is technically closer in straight-line distance than
-        // the aligned neighbour. Returns nullptr when no pane sits
-        // on the requested side.
-        Pane* FindAdjacentPane(implementation::SplitPanel* panelImpl,
-                               Pane* active,
-                               std::vector<Pane*> const& panes,
-                               ghostty_action_goto_split_e dir)
-        {
-            if (!active || !panelImpl) return nullptr;
-            auto* activeBranch = BranchOfPane(panelImpl, active);
-            if (!activeBranch) return nullptr;
-            auto a = activeBranch->arrangedRect;
-            float ax2 = a.X + a.Width;
-            float ay2 = a.Y + a.Height;
-            float aCenterX = a.X + a.Width  * 0.5f;
-            float aCenterY = a.Y + a.Height * 0.5f;
-
-            Pane* best = nullptr;
-            double bestScore = std::numeric_limits<double>::max();
-            for (auto* candidate : panes) {
-                if (candidate == active) continue;
-                auto* candBranch = BranchOfPane(panelImpl, candidate);
-                if (!candBranch) continue;
-                auto c = candBranch->arrangedRect;
-                float cx2 = c.X + c.Width;
-                float cy2 = c.Y + c.Height;
-                float cCenterX = c.X + c.Width  * 0.5f;
-                float cCenterY = c.Y + c.Height * 0.5f;
-
-                double primary = 0.0, perpendicular = 0.0;
-                bool valid = false;
-                switch (dir) {
-                case GHOSTTY_GOTO_SPLIT_LEFT:
-                    // 1px slack absorbs float rounding on the boundary.
-                    if (cx2 > a.X + 1.0f) break;
-                    primary = a.X - cx2;
-                    perpendicular = std::abs(cCenterY - aCenterY);
-                    valid = true;
-                    break;
-                case GHOSTTY_GOTO_SPLIT_RIGHT:
-                    if (c.X < ax2 - 1.0f) break;
-                    primary = c.X - ax2;
-                    perpendicular = std::abs(cCenterY - aCenterY);
-                    valid = true;
-                    break;
-                case GHOSTTY_GOTO_SPLIT_UP:
-                    if (cy2 > a.Y + 1.0f) break;
-                    primary = a.Y - cy2;
-                    perpendicular = std::abs(cCenterX - aCenterX);
-                    valid = true;
-                    break;
-                case GHOSTTY_GOTO_SPLIT_DOWN:
-                    if (c.Y < ay2 - 1.0f) break;
-                    primary = c.Y - ay2;
-                    perpendicular = std::abs(cCenterX - aCenterX);
-                    valid = true;
-                    break;
-                default:
-                    return nullptr;  // PREVIOUS / NEXT handled elsewhere
-                }
-                if (!valid) continue;
-                double score = primary + 2.0 * perpendicular;
-                if (score < bestScore) {
-                    bestScore = score;
-                    best = candidate;
-                }
-            }
-            return best;
-        }
-    }
-
     void MainWindow::BroadcastOcclusion(bool visible)
     {
         for (auto& tab : m_tabs) {
@@ -2297,37 +2211,19 @@ namespace winrt::GhosttyWin32::implementation
         Pane* sourcePane = lookup.pane;
         auto* panelImpl = winrt::get_self<implementation::SplitPanel>(sourceTab->Panel());
         if (!panelImpl) return;
-
-        // Copy out before ReplacePane destroys the original Branch —
-        // the wrapper below needs its own reference to the underlying
-        // TerminalControl and id.
-        auto sourceControl = sourcePane->control;
-        PaneId sourcePaneId = sourcePane->id;
-
-        // RIGHT/DOWN put the new pane after the source on the layout
-        // axis; LEFT/UP put it before.
-        Split::Direction splitDir;
-        bool newFirst;
-        switch (direction) {
-            case GHOSTTY_SPLIT_DIRECTION_RIGHT: splitDir = Split::Direction::Horizontal; newFirst = false; break;
-            case GHOSTTY_SPLIT_DIRECTION_LEFT:  splitDir = Split::Direction::Horizontal; newFirst = true;  break;
-            case GHOSTTY_SPLIT_DIRECTION_DOWN:  splitDir = Split::Direction::Vertical;   newFirst = false; break;
-            case GHOSTTY_SPLIT_DIRECTION_UP:    splitDir = Split::Direction::Vertical;   newFirst = true;  break;
-            default: return;
-        }
+        auto placement = splits::PlaceSplit(direction);
+        if (!placement) return;
 
         // Size hint for the new ghostty surface: the source pane's
         // current SwapChainPanel size halved on the split axis,
         // expressed in PHYSICAL pixels (see display::MeasuredPhysical
         // for why the conversion matters).
-        uint32_t srcW = 0, srcH = 0;
+        splits::Size hint{};
         if (auto* srcTc = sourcePane->Impl()) {
             auto sz = display::MeasuredPhysical(srcTc->InnerPanel());
-            srcW = sz.width;
-            srcH = sz.height;
+            hint = { sz.width, sz.height };
         }
-        uint32_t newW = (splitDir == Split::Direction::Horizontal) ? srcW / 2 : srcW;
-        uint32_t newH = (splitDir == Split::Direction::Vertical)   ? srcH / 2 : srcH;
+        hint = splits::HalfAlong(hint, placement->axis);
 
         // Wrap MakePane in an SEH guard for the same reason CreateTab
         // does — ghostty_surface_new calls into dx_create_texture
@@ -2343,7 +2239,7 @@ namespace winrt::GhosttyWin32::implementation
             uint32_t initialHeight;
             std::unique_ptr<Branch> result;
         };
-        SplitCtx ctx{ m_tabFactory.get(), newW, newH, nullptr };
+        SplitCtx ctx{ m_tabFactory.get(), hint.width, hint.height, nullptr };
         int ok = RunSEHGuarded([](void* arg) noexcept {
             auto* c = static_cast<SplitCtx*>(arg);
             c->result = c->factory->MakePane(c->initialWidth, c->initialHeight);
@@ -2364,22 +2260,16 @@ namespace winrt::GhosttyWin32::implementation
             if (m_hwnd) PostMessageW(m_hwnd, WM_CLOSE, 0, 0);
             return;
         }
-        auto newBranch = std::move(ctx.result);
-        if (!newBranch) return;
-        // Cache before newBranch is moved into the subtree — get_if
-        // on the variant is only valid while the branch is around.
-        Pane* newPanePtr = newBranch->TryGet<Pane>();
+        auto fresh = std::move(ctx.result);
+        if (!fresh) return;
+        // Keep a handle to the new control: if the tree mutation fails
+        // the branch is destroyed and the attached surface must be
+        // detached rather than leaked.
         winrt::GhosttyWin32::TerminalControl newControl{ nullptr };
-        if (newPanePtr) newControl = newPanePtr->control;
+        if (auto* p = fresh->TryGet<Pane>()) newControl = p->control;
 
-        auto sourceWrapper = MakePaneBranch(sourceControl, sourcePaneId);
-        auto subtree = newFirst
-            ? MakeSplitBranch(splitDir, 0.5, std::move(newBranch), std::move(sourceWrapper))
-            : MakeSplitBranch(splitDir, 0.5, std::move(sourceWrapper), std::move(newBranch));
-
-        if (!panelImpl->ReplacePane(*sourcePane, std::move(subtree))) {
-            // Tree mutation failed after the new surface was already
-            // attached — detach so it doesn't leak.
+        Pane* created = panelImpl->SplitPane(*sourcePane, *placement, std::move(fresh));
+        if (!created) {
             if (newControl) {
                 if (auto* tc = winrt::get_self<implementation::TerminalControl>(newControl)) {
                     tc->Detach();
@@ -2391,7 +2281,7 @@ namespace winrt::GhosttyWin32::implementation
         // Focus shifts to the freshly-created pane: matches the
         // expectation set by every other terminal (a `:vsplit` lands
         // the cursor in the new pane).
-        sourceTab->SetActivePane(newPanePtr);
+        sourceTab->SetActivePane(created);
         if (newControl) {
             newControl.Focus(Microsoft::UI::Xaml::FocusState::Programmatic);
         }
@@ -2417,19 +2307,7 @@ namespace winrt::GhosttyWin32::implementation
         auto* panelImpl = winrt::get_self<implementation::SplitPanel>(tab->Panel());
         if (!panelImpl) return;
 
-        // Already zoomed → unzoom regardless of which pane fired the
-        // action. Matches how Windows Terminal / iTerm exit zoom mode:
-        // a second press anywhere collapses it back.
-        if (panelImpl->Zoomed()) {
-            panelImpl->SetZoomed(nullptr);
-            return;
-        }
-        // Single-pane tab has nothing to expand against; visual state
-        // would be identical to the normal layout.
-        auto* root = panelImpl->Tree().Root();
-        if (root && root->TryGet<Pane>() == pane) return;
-
-        panelImpl->SetZoomed(pane);
+        if (!panelImpl->ToggleZoom(*pane)) return;
         tab->SetActivePane(pane);
         // Re-focus so the zoomed pane keeps input even when zoom was
         // toggled from a non-active pane via a remapped binding.
@@ -2445,33 +2323,11 @@ namespace winrt::GhosttyWin32::implementation
         auto lookup = m_tabs.FindPaneBySurface(surface);
         if (!lookup.pane) return;
         auto* tab = lookup.tab;
-        Pane* active = lookup.pane;
         auto* panelImpl = winrt::get_self<implementation::SplitPanel>(tab->Panel());
         if (!panelImpl) return;
 
-        std::vector<Pane*> panes;
-        if (auto* root = panelImpl->Tree().Root()) CollectPanes(*root, panes);
-        if (panes.size() <= 1) return;  // nothing to navigate to
-
-        Pane* target = nullptr;
-        if (direction == GHOSTTY_GOTO_SPLIT_PREVIOUS
-            || direction == GHOSTTY_GOTO_SPLIT_NEXT) {
-            // Cycle through DFS order. wrap-around so the last pane's
-            // NEXT lands on the first and vice versa.
-            auto it = std::find(panes.begin(), panes.end(), active);
-            if (it == panes.end()) return;
-            size_t idx = static_cast<size_t>(std::distance(panes.begin(), it));
-            size_t newIdx;
-            if (direction == GHOSTTY_GOTO_SPLIT_NEXT) {
-                newIdx = (idx + 1) % panes.size();
-            } else {
-                newIdx = (idx == 0) ? panes.size() - 1 : idx - 1;
-            }
-            target = panes[newIdx];
-        } else {
-            target = FindAdjacentPane(panelImpl, active, panes, direction);
-        }
-        if (!target || target == active) return;
+        Pane* target = panelImpl->PaneToward(*lookup.pane, direction);
+        if (!target || target == lookup.pane) return;
 
         tab->SetActivePane(target);
         if (target->control) {
@@ -2485,52 +2341,9 @@ namespace winrt::GhosttyWin32::implementation
         if (!surface) return;
         auto lookup = m_tabs.FindPaneBySurface(surface);
         if (!lookup.pane) return;
-        auto* tab = lookup.tab;
-        Pane* pane = lookup.pane;
-        auto* panelImpl = winrt::get_self<implementation::SplitPanel>(tab->Panel());
+        auto* panelImpl = winrt::get_self<implementation::SplitPanel>(lookup.tab->Panel());
         if (!panelImpl) return;
-
-        // The split axis we're resizing matches the direction axis:
-        // LEFT/RIGHT → Horizontal split, UP/DOWN → Vertical split.
-        Split::Direction needDir =
-            (resize.direction == GHOSTTY_RESIZE_SPLIT_LEFT
-             || resize.direction == GHOSTTY_RESIZE_SPLIT_RIGHT)
-            ? Split::Direction::Horizontal
-            : Split::Direction::Vertical;
-
-        // Walk to the nearest ancestor Split whose axis matches.
-        Branch* node = BranchOfPane(panelImpl, pane);
-        while (node && node->parent) {
-            Branch* parent = node->parent;
-            auto* parentSplit = parent ? parent->TryGet<Split>() : nullptr;
-            if (parentSplit && parentSplit->direction == needDir) {
-                node = parent;
-                break;
-            }
-            node = parent;
-        }
-        if (!node) return;
-        auto* targetSplit = node->TryGet<Split>();
-        if (!targetSplit || targetSplit->direction != needDir) return;
-
-        auto rect = node->arrangedRect;
-        float extent = (needDir == Split::Direction::Horizontal) ? rect.Width : rect.Height;
-        float useable = std::max(1.0f,
-            extent - static_cast<float>(implementation::SplitPanel::kSplitterThickness));
-        double deltaRatio = static_cast<double>(resize.amount) / useable;
-
-        // Arrow direction == direction the boundary moves, regardless
-        // of which side of the split the active pane is on.
-        //   * RIGHT / DOWN move the boundary toward +axis → ratio
-        //     grows (first child gets larger).
-        //   * LEFT / UP move the boundary toward -axis → ratio shrinks.
-        bool increase = (resize.direction == GHOSTTY_RESIZE_SPLIT_RIGHT
-                      || resize.direction == GHOSTTY_RESIZE_SPLIT_DOWN);
-
-        targetSplit->ratio = ClampSplitRatio(
-            targetSplit->ratio + (increase ? deltaRatio : -deltaRatio));
-        panelImpl->InvalidateMeasure();
-        panelImpl->InvalidateArrange();
+        panelImpl->ResizeSplit(*lookup.pane, resize);
     }
 
     TerminalControl* MainWindow::ControlByPaneId(PaneId id) noexcept
@@ -2693,7 +2506,7 @@ namespace winrt::GhosttyWin32::implementation
             auto* panelForPark =
                 winrt::get_self<implementation::SplitPanel>(tab->Panel());
             Branch* wrappingForPark =
-                panelForPark ? BranchOfPane(panelForPark, pane) : nullptr;
+                panelForPark ? panelForPark->Tree().TryFindBranch(*pane) : nullptr;
             bool onlyPane = wrappingForPark && !wrappingForPark->parent;
             auto* tcForPark = pane->Impl();
             bool processAlive =
@@ -2726,7 +2539,7 @@ namespace winrt::GhosttyWin32::implementation
         // immediate Split ancestor.
         Pane* siblingPane = nullptr;
         bool closingActive = (tab->ActivePane() == pane);
-        if (auto* wrapping = BranchOfPane(panelImpl, pane)) {
+        if (auto* wrapping = panelImpl ? panelImpl->Tree().TryFindBranch(*pane) : nullptr) {
             if (auto* parent = wrapping->parent) {
                 if (auto* parentSplit = parent->TryGet<Split>()) {
                     Branch* siblingBranch =

--- a/Core/Core.vcxproj
+++ b/Core/Core.vcxproj
@@ -85,6 +85,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="Ghostty\Actions\Actions.h" />
+    <ClInclude Include="Ghostty\Actions\Splits.h" />
     <ClInclude Include="Ghostty\Actions\Tags\Fullscreen.h" />
     <ClInclude Include="Ghostty\Actions\Tags\BackgroundOpacity.h" />
     <ClInclude Include="Ghostty\Actions\Tags\CellSize.h" />

--- a/Core/Core.vcxproj.filters
+++ b/Core/Core.vcxproj.filters
@@ -27,6 +27,9 @@
     <ClInclude Include="Ghostty\Actions\Actions.h">
       <Filter>Ghostty\Actions</Filter>
     </ClInclude>
+    <ClInclude Include="Ghostty\Actions\Splits.h">
+      <Filter>Ghostty\Actions</Filter>
+    </ClInclude>
     <ClInclude Include="Ghostty\Actions\Tags\BackgroundOpacity.h">
       <Filter>Ghostty\Actions\Tags</Filter>
     </ClInclude>

--- a/Core/Ghostty/Actions/Splits.h
+++ b/Core/Ghostty/Actions/Splits.h
@@ -1,0 +1,178 @@
+#pragma once
+
+#include "ghostty.h"
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <limits>
+#include <optional>
+#include <span>
+
+namespace core::ghostty::actions::splits {
+
+// The decisions behind the split actions (NEW_SPLIT, GOTO_SPLIT,
+// RESIZE_SPLIT), over nothing but rectangles, indices and ratios. The
+// pane tree (App/Tabs/Panes) knows which pane is which and where it
+// was arranged; it hands those facts in here and applies the answer.
+// Nothing here sees a Pane, a Branch or a window, so every rule is
+// unit-testable on its own.
+
+// A pane's arranged rectangle, in whatever unit the layout used.
+struct Rect {
+    float x;
+    float y;
+    float width;
+    float height;
+
+    float right()   const noexcept { return x + width; }
+    float bottom()  const noexcept { return y + height; }
+    float centerX() const noexcept { return x + width * 0.5f; }
+    float centerY() const noexcept { return y + height * 0.5f; }
+};
+
+// Which way a split divides its area. Mirrors the tree's
+// Split::Direction without depending on it.
+enum class Axis {
+    Horizontal,   // children side by side
+    Vertical,     // children stacked
+};
+
+// GOTO_SPLIT LEFT / RIGHT / UP / DOWN: the pane to move focus to, as
+// an index into `panes`, or nullopt when no pane sits on that side.
+//
+// A candidate qualifies when its whole extent lies on the requested
+// side of the active pane (with 1px of slack to absorb float rounding
+// on a shared boundary). Among those, the score is
+//   primary distance + 2 × perpendicular offset of the centres
+// and the lowest wins: the 2× penalty keeps focus moves predictable
+// when an off-axis pane is technically closer in straight-line
+// distance than the aligned neighbour.
+//
+// PREVIOUS / NEXT are not spatial; see CyclePane.
+inline std::optional<size_t> AdjacentPane(
+    std::span<Rect const> panes,
+    size_t activeIndex,
+    ghostty_action_goto_split_e direction) noexcept
+{
+    if (activeIndex >= panes.size()) return std::nullopt;
+    const Rect a = panes[activeIndex];
+
+    std::optional<size_t> best;
+    double bestScore = std::numeric_limits<double>::max();
+    for (size_t i = 0; i < panes.size(); ++i) {
+        if (i == activeIndex) continue;
+        const Rect c = panes[i];
+
+        double primary = 0.0, perpendicular = 0.0;
+        switch (direction) {
+        case GHOSTTY_GOTO_SPLIT_LEFT:
+            if (c.right() > a.x + 1.0f) continue;
+            primary = a.x - c.right();
+            perpendicular = std::abs(c.centerY() - a.centerY());
+            break;
+        case GHOSTTY_GOTO_SPLIT_RIGHT:
+            if (c.x < a.right() - 1.0f) continue;
+            primary = c.x - a.right();
+            perpendicular = std::abs(c.centerY() - a.centerY());
+            break;
+        case GHOSTTY_GOTO_SPLIT_UP:
+            if (c.bottom() > a.y + 1.0f) continue;
+            primary = a.y - c.bottom();
+            perpendicular = std::abs(c.centerX() - a.centerX());
+            break;
+        case GHOSTTY_GOTO_SPLIT_DOWN:
+            if (c.y < a.bottom() - 1.0f) continue;
+            primary = c.y - a.bottom();
+            perpendicular = std::abs(c.centerX() - a.centerX());
+            break;
+        default:
+            return std::nullopt;
+        }
+        const double score = primary + 2.0 * perpendicular;
+        if (score < bestScore) {
+            bestScore = score;
+            best = i;
+        }
+    }
+    return best;
+}
+
+// GOTO_SPLIT PREVIOUS / NEXT: the neighbour in depth-first order,
+// wrapping around at either end. Any other direction, or an index
+// out of range, returns the index unchanged.
+inline size_t CyclePane(size_t index, size_t count,
+                        ghostty_action_goto_split_e direction) noexcept
+{
+    if (count == 0 || index >= count) return index;
+    switch (direction) {
+    case GHOSTTY_GOTO_SPLIT_NEXT:     return (index + 1) % count;
+    case GHOSTTY_GOTO_SPLIT_PREVIOUS: return index == 0 ? count - 1 : index - 1;
+    default:                          return index;
+    }
+}
+
+// NEW_SPLIT: which axis the new split divides along, and whether the
+// new pane goes before the existing one. RIGHT / DOWN put it after
+// the source on the layout axis; LEFT / UP put it before.
+struct Placement {
+    Axis axis;
+    bool newFirst;
+};
+
+inline std::optional<Placement> PlaceSplit(
+    ghostty_action_split_direction_e direction) noexcept
+{
+    switch (direction) {
+    case GHOSTTY_SPLIT_DIRECTION_RIGHT: return Placement{ Axis::Horizontal, false };
+    case GHOSTTY_SPLIT_DIRECTION_LEFT:  return Placement{ Axis::Horizontal, true };
+    case GHOSTTY_SPLIT_DIRECTION_DOWN:  return Placement{ Axis::Vertical,   false };
+    case GHOSTTY_SPLIT_DIRECTION_UP:    return Placement{ Axis::Vertical,   true };
+    default:                            return std::nullopt;
+    }
+}
+
+// The size hint for the pane a split creates: the source's size
+// halved along the split axis.
+struct Size {
+    uint32_t width;
+    uint32_t height;
+};
+
+inline Size HalfAlong(Size source, Axis axis) noexcept
+{
+    return axis == Axis::Horizontal
+        ? Size{ source.width / 2, source.height }
+        : Size{ source.width,     source.height / 2 };
+}
+
+// RESIZE_SPLIT: the split axis the arrow refers to. LEFT / RIGHT move
+// a vertical boundary, so the split being resized is a horizontal
+// one; UP / DOWN the other way round.
+inline Axis ResizeAxis(ghostty_action_resize_split_direction_e direction) noexcept
+{
+    return (direction == GHOSTTY_RESIZE_SPLIT_LEFT
+            || direction == GHOSTTY_RESIZE_SPLIT_RIGHT)
+        ? Axis::Horizontal
+        : Axis::Vertical;
+}
+
+// The split's new ratio after moving its boundary by `amount` pixels
+// in the arrow's direction. `extent` is the split's arranged length
+// along its axis, `splitterThickness` what the divider takes of it.
+// The arrow is the direction the boundary moves regardless of which
+// side of the split the active pane is on: RIGHT / DOWN move it
+// toward +axis, so the first child grows; LEFT / UP shrink it. The
+// result is clamped to [0.05, 0.95] so neither child can vanish.
+inline double ResizedRatio(double ratio,
+                           ghostty_action_resize_split_s resize,
+                           float extent,
+                           float splitterThickness) noexcept
+{
+    const float usable = std::max(1.0f, extent - splitterThickness);
+    const double delta = static_cast<double>(resize.amount) / usable;
+    const bool increase = (resize.direction == GHOSTTY_RESIZE_SPLIT_RIGHT
+                        || resize.direction == GHOSTTY_RESIZE_SPLIT_DOWN);
+    return std::clamp(ratio + (increase ? delta : -delta), 0.05, 0.95);
+}
+
+}  // namespace core::ghostty::actions::splits

--- a/Tests/Tests.vcxproj
+++ b/Tests/Tests.vcxproj
@@ -173,6 +173,7 @@
     <ClCompile Include="test_key_event_translator.cpp" />
     <ClCompile Include="test_window_decorations.cpp" />
     <ClCompile Include="test_background_opacity.cpp" />
+    <ClCompile Include="test_splits.cpp" />
     <ClCompile Include="test_tab_drag.cpp" />
     <ClCompile Include="test_pressed_tab.cpp" />
     <ClCompile Include="test_trigger_label.cpp" />

--- a/Tests/test_splits.cpp
+++ b/Tests/test_splits.cpp
@@ -1,0 +1,154 @@
+#include "pch.h"
+#include "../Core/Ghostty/Actions/Splits.h"
+#include <vector>
+
+using namespace core::ghostty::actions::splits;
+
+namespace core::ghostty::actions::splits {
+// gtest prints a scoped enum only through a PrintTo overload found
+// by ADL; without one, a failing EXPECT_EQ on Axis cannot be
+// reported.
+inline void PrintTo(Axis axis, std::ostream* os) {
+    *os << (axis == Axis::Horizontal ? "Horizontal" : "Vertical");
+}
+}  // namespace core::ghostty::actions::splits
+
+namespace {
+
+// A 2×2 grid of 100×100 panes:
+//   0 | 1
+//   --+--
+//   2 | 3
+std::vector<Rect> Grid2x2() {
+    return {
+        { 0,   0,   100, 100 },
+        { 100, 0,   100, 100 },
+        { 0,   100, 100, 100 },
+        { 100, 100, 100, 100 },
+    };
+}
+
+ghostty_action_resize_split_s Resize(ghostty_action_resize_split_direction_e dir, uint16_t amount) {
+    ghostty_action_resize_split_s r{};
+    r.direction = dir;
+    r.amount = amount;
+    return r;
+}
+
+}  // namespace
+
+// ----- GOTO_SPLIT, spatial -----
+
+TEST(SplitsTest, AdjacentPaneFindsTheAlignedNeighbour) {
+    auto panes = Grid2x2();
+    EXPECT_EQ(AdjacentPane(panes, 0, GHOSTTY_GOTO_SPLIT_RIGHT), 1u);
+    EXPECT_EQ(AdjacentPane(panes, 0, GHOSTTY_GOTO_SPLIT_DOWN),  2u);
+    EXPECT_EQ(AdjacentPane(panes, 3, GHOSTTY_GOTO_SPLIT_LEFT),  2u);
+    EXPECT_EQ(AdjacentPane(panes, 3, GHOSTTY_GOTO_SPLIT_UP),    1u);
+}
+
+TEST(SplitsTest, AdjacentPaneIsNoneAtTheEdge) {
+    auto panes = Grid2x2();
+    EXPECT_FALSE(AdjacentPane(panes, 0, GHOSTTY_GOTO_SPLIT_LEFT).has_value());
+    EXPECT_FALSE(AdjacentPane(panes, 0, GHOSTTY_GOTO_SPLIT_UP).has_value());
+    EXPECT_FALSE(AdjacentPane(panes, 3, GHOSTTY_GOTO_SPLIT_RIGHT).has_value());
+}
+
+TEST(SplitsTest, AdjacentPanePrefersAlignedOverNearerDiagonal) {
+    // Active on the left; to its right a tall pane whose centre is
+    // far off-axis but which touches, and a narrow pane further away
+    // that is aligned. The 2× perpendicular penalty makes the aligned
+    // one win even though the tall one is closer in straight-line
+    // distance.
+    std::vector<Rect> panes = {
+        { 0,   0,   100, 100 },   // active
+        { 100, 0,   100, 400 },   // touching, centre 150px below
+        { 220, 0,   100, 100 },   // 120px away, aligned
+    };
+    // scores: [1] 0 + 2*150 = 300, [2] 120 + 0 = 120
+    EXPECT_EQ(AdjacentPane(panes, 0, GHOSTTY_GOTO_SPLIT_RIGHT), 2u);
+}
+
+TEST(SplitsTest, AdjacentPaneAbsorbsBoundaryRounding) {
+    // A neighbour whose edge overlaps the boundary by half a pixel
+    // (float layout) still counts as "on that side".
+    std::vector<Rect> panes = {
+        { 0,     0, 100,   100 },
+        { 99.5f, 0, 100.5f, 100 },
+    };
+    EXPECT_EQ(AdjacentPane(panes, 0, GHOSTTY_GOTO_SPLIT_RIGHT), 1u);
+    // More than a pixel of overlap is a pane beside us, not beyond.
+    panes[1].x = 98.0f;
+    EXPECT_FALSE(AdjacentPane(panes, 0, GHOSTTY_GOTO_SPLIT_RIGHT).has_value());
+}
+
+TEST(SplitsTest, AdjacentPaneRejectsBadInput) {
+    auto panes = Grid2x2();
+    EXPECT_FALSE(AdjacentPane(panes, 4, GHOSTTY_GOTO_SPLIT_RIGHT).has_value());
+    EXPECT_FALSE(AdjacentPane(panes, 0, GHOSTTY_GOTO_SPLIT_NEXT).has_value());
+}
+
+// ----- GOTO_SPLIT, cyclic -----
+
+TEST(SplitsTest, CyclePaneWrapsBothWays) {
+    EXPECT_EQ(CyclePane(0, 3, GHOSTTY_GOTO_SPLIT_NEXT), 1u);
+    EXPECT_EQ(CyclePane(2, 3, GHOSTTY_GOTO_SPLIT_NEXT), 0u);
+    EXPECT_EQ(CyclePane(0, 3, GHOSTTY_GOTO_SPLIT_PREVIOUS), 2u);
+    EXPECT_EQ(CyclePane(1, 3, GHOSTTY_GOTO_SPLIT_PREVIOUS), 0u);
+}
+
+TEST(SplitsTest, CyclePaneLeavesOtherDirectionsAlone) {
+    EXPECT_EQ(CyclePane(1, 3, GHOSTTY_GOTO_SPLIT_LEFT), 1u);
+    EXPECT_EQ(CyclePane(5, 3, GHOSTTY_GOTO_SPLIT_NEXT), 5u);   // out of range
+    EXPECT_EQ(CyclePane(0, 0, GHOSTTY_GOTO_SPLIT_NEXT), 0u);
+}
+
+// ----- NEW_SPLIT -----
+
+TEST(SplitsTest, PlaceSplitMapsDirectionToAxisAndOrder) {
+    auto r = PlaceSplit(GHOSTTY_SPLIT_DIRECTION_RIGHT);
+    ASSERT_TRUE(r); EXPECT_EQ(r->axis, Axis::Horizontal); EXPECT_FALSE(r->newFirst);
+    auto l = PlaceSplit(GHOSTTY_SPLIT_DIRECTION_LEFT);
+    ASSERT_TRUE(l); EXPECT_EQ(l->axis, Axis::Horizontal); EXPECT_TRUE(l->newFirst);
+    auto d = PlaceSplit(GHOSTTY_SPLIT_DIRECTION_DOWN);
+    ASSERT_TRUE(d); EXPECT_EQ(d->axis, Axis::Vertical); EXPECT_FALSE(d->newFirst);
+    auto u = PlaceSplit(GHOSTTY_SPLIT_DIRECTION_UP);
+    ASSERT_TRUE(u); EXPECT_EQ(u->axis, Axis::Vertical); EXPECT_TRUE(u->newFirst);
+}
+
+TEST(SplitsTest, HalfAlongHalvesOnlyTheSplitAxis) {
+    auto h = HalfAlong({ 800, 600 }, Axis::Horizontal);
+    EXPECT_EQ(h.width, 400u); EXPECT_EQ(h.height, 600u);
+    auto v = HalfAlong({ 800, 600 }, Axis::Vertical);
+    EXPECT_EQ(v.width, 800u); EXPECT_EQ(v.height, 300u);
+}
+
+// ----- RESIZE_SPLIT -----
+
+TEST(SplitsTest, ResizeAxisIsTheOneTheArrowCrosses) {
+    EXPECT_EQ(ResizeAxis(GHOSTTY_RESIZE_SPLIT_LEFT),  Axis::Horizontal);
+    EXPECT_EQ(ResizeAxis(GHOSTTY_RESIZE_SPLIT_RIGHT), Axis::Horizontal);
+    EXPECT_EQ(ResizeAxis(GHOSTTY_RESIZE_SPLIT_UP),    Axis::Vertical);
+    EXPECT_EQ(ResizeAxis(GHOSTTY_RESIZE_SPLIT_DOWN),  Axis::Vertical);
+}
+
+TEST(SplitsTest, ResizedRatioMovesTheBoundaryTheArrowsWay) {
+    // 1000px wide split, 0px divider: 100px is a tenth.
+    EXPECT_DOUBLE_EQ(ResizedRatio(0.5, Resize(GHOSTTY_RESIZE_SPLIT_RIGHT, 100), 1000, 0), 0.6);
+    EXPECT_DOUBLE_EQ(ResizedRatio(0.5, Resize(GHOSTTY_RESIZE_SPLIT_LEFT,  100), 1000, 0), 0.4);
+    EXPECT_DOUBLE_EQ(ResizedRatio(0.5, Resize(GHOSTTY_RESIZE_SPLIT_DOWN,  100), 1000, 0), 0.6);
+    EXPECT_DOUBLE_EQ(ResizedRatio(0.5, Resize(GHOSTTY_RESIZE_SPLIT_UP,    100), 1000, 0), 0.4);
+}
+
+TEST(SplitsTest, ResizedRatioAccountsForTheDivider) {
+    // The divider is not pane space: 100px of a 1001px split with a
+    // 1px divider is a tenth of the usable 1000.
+    EXPECT_DOUBLE_EQ(ResizedRatio(0.5, Resize(GHOSTTY_RESIZE_SPLIT_RIGHT, 100), 1001, 1), 0.6);
+}
+
+TEST(SplitsTest, ResizedRatioNeverLetsAChildVanish) {
+    EXPECT_DOUBLE_EQ(ResizedRatio(0.9, Resize(GHOSTTY_RESIZE_SPLIT_RIGHT, 500), 1000, 0), 0.95);
+    EXPECT_DOUBLE_EQ(ResizedRatio(0.1, Resize(GHOSTTY_RESIZE_SPLIT_LEFT,  500), 1000, 0), 0.05);
+    // A degenerate extent does not divide by zero.
+    EXPECT_DOUBLE_EQ(ResizedRatio(0.5, Resize(GHOSTTY_RESIZE_SPLIT_RIGHT, 1), 0, 1), 0.95);
+}


### PR DESCRIPTION
## Why

`MainWindow` handled the five split actions (`NEW_SPLIT`, `GOTO_SPLIT`, `RESIZE_SPLIT`, `EQUALIZE_SPLITS`, `TOGGLE_SPLIT_ZOOM`) by finding the pane and then doing everything itself: walking the tree, scoring neighbours by rectangle, searching for the ancestor split on the right axis, computing the ratio delta, invalidating layout — 130 lines of that in an anonymous namespace plus the method bodies, next to the focus calls that apply the result. The window is the wrong place for it twice over: the panel owns the tree and the arranged rects those rules read, and the rules themselves (which pane is "to the right", where NEXT wraps, how far an arrow moves a boundary) could only be checked with a window on screen.

<details>
<summary>日本語</summary>

`MainWindow` は split 系 action 5 つ (`NEW_SPLIT` / `GOTO_SPLIT` / `RESIZE_SPLIT` / `EQUALIZE_SPLITS` / `TOGGLE_SPLIT_ZOOM`) を、pane を探した後は全部自分でやっていた。tree の走査、rect による隣 pane のスコアリング、正しい軸の祖先 split の探索、ratio 差分の計算、layout の invalidate — 匿名 namespace の 130 行 + 各メソッド本体が、結果を当てる focus 呼び出しの隣に並んでいた。窓は二重に置き場として間違っている: tree と arranged rect を持っているのは panel だし、判断そのもの (どの pane が「右」か、NEXT はどこで wrap するか、矢印で境界がどれだけ動くか) は画面に窓を出さないと確かめられなかった。
</details>

## What

**`Core/Ghostty/Actions/Splits.h`** (commit 1) — the decisions, over rectangles, indices and ratios only
- `AdjacentPane(rects, activeIndex, direction)` — the spatial rule for LEFT / RIGHT / UP / DOWN: whole extent on that side (1px slack for float layout), score = primary distance + 2 × perpendicular offset, lowest wins
- `CyclePane(index, count, direction)` — PREVIOUS / NEXT with wrap
- `PlaceSplit(direction)` → `{ axis, newFirst }`, `HalfAlong(size, axis)` — where a new split goes and the size hint for its surface
- `ResizeAxis(direction)`, `ResizedRatio(ratio, resize, extent, splitterThickness)` — which split an arrow moves and by how much, clamped to [0.05, 0.95]
- `test_splits.cpp` ×13: aligned-over-nearer-diagonal, edge → none, boundary slack, wrap both ways, direction → placement, halving, arrow → axis and sign, divider accounted for, clamp and zero-extent

**`App/Tabs`: the panel carries the actions out on its own tree** (commit 2)
- `Tree::Panes()` (depth-first list) and `Tree::NearestSplitAbove(pane, axis)` — the two walks the rules need
- `SplitPanel::SplitPane(source, placement, fresh)` / `PaneToward(from, direction)` / `ResizeSplit(pane, resize)` / `ToggleZoom(pane)` — each applies a rule from `Splits.h` to the tree and its arranged rects and reports what changed
- `MainWindow`: each handler is now lookup → panel → focus / active-pane bookkeeping. The SEH-guarded surface creation, the physical-pixel size hint and the detach-on-failure stay there; the anonymous namespace (`CollectPanes`, `BranchOfPane`, `FindAdjacentPane`) is gone. The two close-path uses of `BranchOfPane` read `Tree().TryFindBranch` directly
- `MainWindow.xaml.cpp` −209 lines. No behaviour change

<details>
<summary>日本語</summary>

**`Core/Ghostty/Actions/Splits.h`** (commit 1) — rect / index / ratio だけで判断
- `AdjacentPane(rects, activeIndex, direction)` — LEFT / RIGHT / UP / DOWN の空間ルール: 全体がその側にある (float layout 用に 1px の slack)、score = 主軸距離 + 2 × 垂直方向の中心ずれ、最小が勝つ
- `CyclePane(index, count, direction)` — PREVIOUS / NEXT の wrap
- `PlaceSplit(direction)` → `{ axis, newFirst }`、`HalfAlong(size, axis)` — 新しい split の置き場と surface の size hint
- `ResizeAxis(direction)`、`ResizedRatio(ratio, resize, extent, splitterThickness)` — 矢印がどの split をどれだけ動かすか、[0.05, 0.95] に clamp
- `test_splits.cpp` ×13: 斜めの近い pane より真横、端では none、境界の slack、両向きの wrap、方向 → 配置、半分にする、矢印 → 軸と符号、divider の考慮、clamp と extent 0

**`App/Tabs`: panel が自分の tree に対して action を実行** (commit 2)
- `Tree::Panes()` (DFS の一覧) と `Tree::NearestSplitAbove(pane, axis)` — ルールが必要とする走査 2 つ
- `SplitPanel::SplitPane(source, placement, fresh)` / `PaneToward(from, direction)` / `ResizeSplit(pane, resize)` / `ToggleZoom(pane)` — それぞれ `Splits.h` のルールを tree と arranged rect に当てて、何が変わったかを返す
- `MainWindow`: 各 handler は lookup → panel → focus / active-pane の記録、だけに。SEH guard 付きの surface 生成、物理 px の size hint、失敗時の detach は残す。匿名 namespace (`CollectPanes` / `BranchOfPane` / `FindAdjacentPane`) は消えた。close 経路の `BranchOfPane` 2 箇所は `Tree().TryFindBranch` を直接読む
- `MainWindow.xaml.cpp` −209 行。挙動変更なし
</details>

## Verification

- [x] Build Debug + Release; Tests green (`SplitsTest` ×13 added)
- [x] `new_split:right` / `left` / `down` / `up` from a pane → the new pane appears on that side, gets focus, and is half the source's size on the split axis
- [x] `goto_split:left/right/up/down` in a 2×2 grid → moves to the aligned neighbour; at an edge nothing happens; with one tall pane beside two stacked ones, LEFT from the top one lands on the tall pane
- [x] `goto_split:previous` / `next` → cycles in creation (depth-first) order and wraps at both ends
- [x] `resize_split:right,50` etc. → the boundary moves the arrow's way whichever side the active pane is on; a pane with no split on that axis does nothing; repeated presses stop at the 5% / 95% limits
- [x] `equalize_splits` → all ratios back to 0.5
- [x] `toggle_split_zoom` → the pane fills the tab; a second press anywhere unzooms; on a lone pane nothing happens
- [x] Close a pane in a split (ctrl+shift+w) → the sibling takes over and focus lands on it (the close path's `TryFindBranch` swap)

<details>
<summary>日本語</summary>

- [x] Debug + Release ビルド、Tests green (`SplitsTest` ×13 追加)
- [x] pane から `new_split:right` / `left` / `down` / `up` → その側に新しい pane が出て focus が移り、split 軸方向のサイズが元の半分
- [x] 2×2 で `goto_split:left/right/up/down` → 真横 / 真上下の pane へ。端では何も起きない。縦長 1 pane の横に 2 段の場合、上の段から LEFT で縦長に着く
- [x] `goto_split:previous` / `next` → 作成順 (DFS) に巡回、両端で wrap
- [x] `resize_split:right,50` 等 → active pane がどちら側でも境界が矢印の向きに動く。その軸の split が無い pane では何も起きない。連打は 5% / 95% で止まる
- [x] `equalize_splits` → 全部 0.5 に戻る
- [x] `toggle_split_zoom` → pane が tab 全体に。もう一度どこで押しても解除。1 pane では何も起きない
- [x] split 内の pane を閉じる (ctrl+shift+w) → 兄弟が引き継いで focus がそこに (close 経路の `TryFindBranch` 差し替え)
</details>
