### PR TITLE
Silence the two standing build warnings

### DIFF
--- a/App/Windows/MainWindow.xaml.cpp
+++ b/App/Windows/MainWindow.xaml.cpp
@@ -2401,8 +2401,8 @@ namespace winrt::GhosttyWin32::implementation
         // (ghostty_surface_size), no carried state needed.
         ghostty_action_cell_size_s adoptedCell{};
         if (auto* tc = tab->ActiveControl()) {
-            auto size = tc->Surface().Size();
-            adoptedCell = { size.cell_width_px, size.cell_height_px };
+            auto surfaceSize = tc->Surface().Size();
+            adoptedCell = { surfaceSize.cell_width_px, surfaceSize.cell_height_px };
         }
         m_tabs.Add(std::move(tab));
         tv.SelectedItem(selected);

--- a/Core/Ghostty/Surface.h
+++ b/Core/Ghostty/Surface.h
@@ -132,9 +132,13 @@ public:
     // not necessarily the shell (that's the ancestor). Used by the
     // tab-title poll to show the running command's name (`vim`,
     // `ssh host`) instead of just the shell name. Returns 0 when
-    // no surface, no PTY yet, or no foreground process.
+    // no surface, no PTY yet, or no foreground process. libghostty
+    // reports the pid as a uint64 for platform-agnosticism; a Windows
+    // pid is a DWORD, so the narrowing is deliberate and lossless.
     uint32_t ForegroundPid() const noexcept {
-        return m_handle ? ghostty_surface_foreground_pid(m_handle) : 0;
+        return m_handle
+            ? static_cast<uint32_t>(ghostty_surface_foreground_pid(m_handle))
+            : 0;
     }
 
     // Ghostty's per-surface prompt-on-quit signal. Reflects the


### PR DESCRIPTION
## Why

Every build has printed the same two warnings for a while — ×9 `C4244` from `Surface::ForegroundPid` (one per TU that includes the header) and one `C4456` in `AdoptTab`. A noisy baseline hides real warnings.

<details><summary>日本語</summary>

しばらく前から毎ビルド同じ warning が出ています — `Surface::ForegroundPid` 由来の `C4244` ×9 (header を include する TU ごとに 1 個) と `AdoptTab` の `C4456`。ベースラインがうるさいと本物の warning が埋もれます。

</details>

## What

- `Surface::ForegroundPid`: libghostty reports the foreground pid as `uint64_t` for platform-agnosticism, but a Windows pid is a DWORD — the narrowing is deliberate and lossless, so say it with a `static_cast<uint32_t>` and a comment.
- `MainWindow::AdoptTab`: the inner `size` (the surface's cell metrics) shadowed the outer `size` (the tab count). The inner one is the surface size — renamed to `surfaceSize`.

No behaviour change in either.

<details><summary>日本語</summary>

- `Surface::ForegroundPid`: libghostty はプラットフォーム非依存のため pid を `uint64_t` で返しますが、Windows の pid は DWORD — 縮小変換は意図的かつ無損失なので、`static_cast<uint32_t>` とコメントで明示。
- `MainWindow::AdoptTab`: 内側の `size` (surface のセル寸法) が外側の `size` (タブ数) を隠蔽していました。内側は surface のサイズなので `surfaceSize` に改名。

どちらも挙動変更なし。

</details>

## Verification

- [x] Rebuild Debug (or ASan): the `C4244` ×9 and the `C4456` are gone from the warning list; no new warnings

<details><summary>日本語</summary>

- [ ] Debug (か ASan) でリビルド: warning 一覧から `C4244` ×9 と `C4456` が消えていること、新規 warning が無いこと

</details>
