### PR TITLE
Reconcile the split panel's children by diff so focus survives a split

### DIFF
--- a/App/Tabs/SplitPanel.cpp
+++ b/App/Tabs/SplitPanel.cpp
@@ -146,34 +146,73 @@ bool SplitPanel::ToggleZoom(Pane const& pane) {
 }
 
 void SplitPanel::SyncChildrenFromTree() {
-    Children().Clear();
-    m_splitters.clear();
     m_draggingBranch = nullptr;
     // Any tree shape change invalidates a stored zoom pointer.
     m_tree.ClearZoomed();
-    if (auto* root = m_tree.Root()) AppendBranchToChildren(*root);
-    // Re-evaluate Visibility after rebuilding Children (previous zoom
-    // could have left Visibility=Collapsed on now-unrelated elements).
+
+    // What Children() should become. Collected before m_splitters is
+    // replaced so surviving Splits can be looked up in the previous
+    // sync's entries and keep their Borders.
+    std::vector<winrt::Microsoft::UI::Xaml::UIElement> desired;
+    std::vector<SplitterEntry> splitters;
+    if (auto* root = m_tree.Root()) CollectChildrenOf(*root, desired, splitters);
+    m_splitters = std::move(splitters);
+
+    // Reconcile by diff (see the declaration for why): first drop
+    // what left the tree, then place what is new. No current
+    // mutation reorders survivors, so a staying element is never
+    // detached — the move branch below is a safety net only.
+    auto children = Children();
+    auto isDesired = [&desired](winrt::Microsoft::UI::Xaml::UIElement const& el) {
+        return std::find(desired.begin(), desired.end(), el) != desired.end();
+    };
+    for (int32_t i = static_cast<int32_t>(children.Size()) - 1; i >= 0; --i) {
+        if (!isDesired(children.GetAt(static_cast<uint32_t>(i)))) {
+            children.RemoveAt(static_cast<uint32_t>(i));
+        }
+    }
+    for (uint32_t i = 0; i < desired.size(); ++i) {
+        if (i < children.Size() && children.GetAt(i) == desired[i]) continue;
+
+        // An element may appear only once in Children(), so an
+        // out-of-order survivor is moved rather than re-inserted.
+        for (uint32_t j = i + 1; j < children.Size(); ++j) {
+            if (children.GetAt(j) == desired[i]) {
+                children.RemoveAt(j);
+                break;
+            }
+        }
+        children.InsertAt(i, desired[i]);
+    }
+
+    // Re-evaluate Visibility after the diff (a previous zoom could
+    // have left Visibility=Collapsed on now-unrelated elements).
     UpdateChildVisibility();
 }
 
-void SplitPanel::AppendBranchToChildren(Branch& branch) {
+void SplitPanel::CollectChildrenOf(
+    Branch& branch,
+    std::vector<winrt::Microsoft::UI::Xaml::UIElement>& desired,
+    std::vector<SplitterEntry>& splitters)
+{
     if (auto* pane = branch.TryGet<Pane>()) {
         if (auto element = ElementOf(*pane)) {
-            Children().Append(element);
+            desired.push_back(element);
         }
         return;
     }
     auto* split = branch.TryGet<Split>();
     if (!split) return;
+
     // Walk left → splitter → right. Placing the splitter between the
     // children in Children() means it paints on top of the junction so
     // the drag strip is always reachable for input.
-    if (split->left)  AppendBranchToChildren(*split->left);
-    auto splitter = MakeSplitter(&branch);
-    Children().Append(splitter);
-    m_splitters.push_back({ splitter, &branch });
-    if (split->right) AppendBranchToChildren(*split->right);
+    if (split->left)  CollectChildrenOf(*split->left, desired, splitters);
+    auto splitter = SplitterForBranch(&branch);
+    if (!splitter) splitter = MakeSplitter(&branch);
+    desired.push_back(splitter);
+    splitters.push_back({ splitter, &branch });
+    if (split->right) CollectChildrenOf(*split->right, desired, splitters);
 }
 
 Microsoft::UI::Xaml::Controls::Border SplitPanel::MakeSplitter(Branch* splitBranch) {

--- a/App/Tabs/SplitPanel.h
+++ b/App/Tabs/SplitPanel.h
@@ -137,19 +137,19 @@ private:
     // direction-based GOTO_SPLIT).
     void ArrangeBranch(Branch& branch, winrt::Windows::Foundation::Rect rect);
 
-    // Repopulates Children() and m_splitters to match the current tree.
-    // Called after every SetRoot / ReplacePane / RemovePane.
+    // Brings Children() and m_splitters in line with the current
+    // tree. Called after every SetRoot / ReplacePane / RemovePane.
+    // Reconciles by diff, not Clear + re-append: an element that
+    // merely stays must never leave the visual tree, or XAML fires
+    // its own asynchronous recovery focus which can land after the
+    // caller's programmatic Focus and steal it (issue #192).
     void SyncChildrenFromTree();
 
-    // Append a depth-first traversal of `branch` to Children(): every
-    // leaf's content, and one fresh Splitter Border per Split node
-    // (recorded in m_splitters so measure/arrange can find it).
-    void AppendBranchToChildren(Branch& branch);
-
     // Build a Border for the drag-handle of a Split branch and wire
-    // its pointer events. Borders are recreated on every
-    // SyncChildrenFromTree, so the captured Branch* is current at the
-    // time the lambda runs.
+    // its pointer events. The captured Branch* stays valid for the
+    // Border's whole life: a Branch's address is stable (move-
+    // disabled, unique_ptr-held), and SyncChildrenFromTree drops the
+    // Border when its branch leaves the tree.
     winrt::Microsoft::UI::Xaml::Controls::Border MakeSplitter(Branch* splitBranch);
 
     // Find the Border previously created for `splitBranch`, or nullptr.
@@ -169,6 +169,14 @@ private:
         winrt::Microsoft::UI::Xaml::Controls::Border element{ nullptr };
         Branch* branch{ nullptr };  // always a Branch holding a Split
     };
+
+    // Depth-first traversal of `branch`: every leaf's content and
+    // one splitter Border per Split node, in the order Children()
+    // should hold them. A Split that survived the mutation keeps
+    // its Border (looked up in the previous sync's m_splitters).
+    void CollectChildrenOf(Branch& branch,
+                           std::vector<winrt::Microsoft::UI::Xaml::UIElement>& desired,
+                           std::vector<SplitterEntry>& splitters);
 
     // Refresh Visibility on every child so the zoom state matches
     // Tree().Zoomed().


### PR DESCRIPTION
## Why

Fixes #192: splitting in a nested layout lands focus on the wrong pane — the last one in depth-first order — instead of the pane the split just created.

Every tree mutation rebuilt the panel with `Children().Clear()` + re-append, so the focused element left the visual tree for a moment. XAML then moves focus on its own, asynchronously; that move can land *after* the handler's programmatic `Focus` on the new pane, and whichever control receives it fires `GotFocus` → `NotifySurfaceFocused` → `SetActivePane`, overwriting both the focus and the active pane.

<details><summary>日本語</summary>

#192 の修正: 入れ子 layout で split すると、いま作った pane ではなく DFS 順の最後の pane にフォーカスが行ってしまう問題。

tree の変更のたびに `Children().Clear()` + 再 append で panel を作り直していたため、フォーカスを持つ element が一瞬 visual tree から外れます。すると XAML が自前の非同期フォーカス移動を行い、それが handler の programmatic `Focus` の**後に**着弾しうる — 受け取った control の `GotFocus` → `NotifySurfaceFocused` → `SetActivePane` がフォーカスと active pane を両方上書きしていました。

</details>

## What

`SyncChildrenFromTree` reconciles by diff instead of Clear + re-append:

1. Collect what `Children()` should become (panes and splitters, depth-first).
2. Remove the elements that left the tree.
3. Insert the new ones at their positions.

An element that merely stays is never detached, so XAML never fires a recovery focus — the cause is gone, and per-mutation churn shrinks too. Splitter Borders ride along: a Split that survived the mutation keeps its Border (safe because a `Branch`'s address is stable — move-disabled, `unique_ptr`-held), so its captured `Branch*` handlers stay valid. No current mutation reorders surviving elements; the move branch in the reconcile is a safety net.

<details><summary>日本語</summary>

`SyncChildrenFromTree` を Clear + 再 append から差分更新に:

1. `Children()` があるべき姿 (pane と splitter の DFS 順) を収集
2. tree から消えた element を除去
3. 新しい element をあるべき位置に挿入

「残るだけ」の element は一度も detach されないので、XAML の復旧フォーカスが発火せず、原因ごと消えます (mutation ごとの churn も減少)。splitter Border も同行: 変更を生き延びた Split は自分の Border を保持します (`Branch` のアドレスは move 禁止 + `unique_ptr` 保持で安定なので、キャプチャ済み `Branch*` の handler は有効なまま)。現状の mutation は残存 element の順序を変えないため、reconcile 内の move 分岐は安全網です。

</details>

## Verification

- [x] The #192 repro: split top/bottom → split the bottom left/right → focus the top pane and split it top/bottom again — focus lands in the newly created pane (the top half's new bottom), not the bottom-right
- [x] Regression smoke over the sync paths: new split in all four directions (focus follows the new pane), close a pane (collapse; focus per existing behaviour), toggle zoom on/off, drag a splitter after several mutations (reused Borders still resize the right split), close a tab with splits and undo it
- [x] Tests still green (no Core change in this PR)

<details><summary>日本語</summary>

- [x] #192 の再現手順: 上下 split → 下半分を左右 split → 上の pane にフォーカスしてもう一度上下 split — フォーカスが**いま作った pane** (上半分の新しい下側) に行き、下右に行かないこと
- [x] sync 経路の回帰 smoke: 4 方向の new split (フォーカスが新 pane に付く)、pane close (collapse、フォーカスは従来挙動)、zoom の on/off、数回 mutation した後の splitter ドラッグ (再利用 Border が正しい split を resize すること)、split 入り tab の close → undo
- [x] Tests が green のまま (この PR に Core 変更は無し)

</details>

