### PR TITLE
Replace the tab-title latches with a TitleSource priority value

### DIFF
--- a/App/Tabs/Tab.h
+++ b/App/Tabs/Tab.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "Host/TitleSource.h"
 #include "Tabs/Panes/Tree.h"
 #include "Tabs/SplitPanel.h"
 #include "Terminal/TerminalControl.xaml.h"
@@ -89,27 +90,14 @@ public:
 
     Microsoft::UI::Xaml::Controls::TabViewItem const& Item() const noexcept { return m_item; }
 
-    // True once the shell has set an explicit title via SET_TITLE /
-    // SET_TAB_TITLE (OSC 0/2 or `set_title` action). The foreground-
-    // pid poll uses this to decide whether the tab header is theirs
-    // to overwrite: shell-supplied titles win, auto-computed process
-    // names only fill in when the shell has said nothing.
-    bool HasExplicitTitle() const noexcept { return m_hasExplicitTitle; }
-    void MarkExplicitTitle() noexcept { m_hasExplicitTitle = true; }
-
-    // True once the USER named this tab via the rename prompt
-    // (PROMPT_TITLE). One level stronger than the shell latch above:
-    // upstream documents that a prompt-set title "overrides any
-    // title set by the terminal", so SET_TITLE / SET_TAB_TITLE must
-    // skip a user-titled tab (the shell keeps re-asserting its OSC
-    // title on every prompt, which would instantly undo the rename).
-    // Marking a user title implies the explicit latch too, so the
-    // pid poll stays out without callers having to set both.
-    bool HasUserTitle() const noexcept { return m_hasUserTitle; }
-    void MarkUserTitle() noexcept {
-        m_hasUserTitle = true;
-        m_hasExplicitTitle = true;
-    }
+    // Who last named this tab. Every header write site asks this
+    // before touching Item().Header() — see Host/TitleSource.h for
+    // the priority rule between the foreground-pid poll, shell
+    // SET_TITLE / SET_TAB_TITLE, and the rename prompt.
+    // (Qualified return type: the method name shadows the type
+    // inside this class.)
+    core::host::TitleSource TitleSource() const noexcept { return m_titleSource; }
+    void SetTitleSource(core::host::TitleSource source) noexcept { m_titleSource = source; }
 
     // Last PID resolved for this tab's active pane's foreground
     // process, and the basename cached from it. The poll updates both
@@ -210,13 +198,9 @@ private:
     // pane is destroyed.
     Pane* m_activePane{ nullptr };
 
-    // See HasUserTitle. Sticky for the tab's lifetime — there is no
-    // inverse yet (the rename prompt treats empty input as cancel
-    // for exactly this reason).
-    bool m_hasUserTitle{ false };
-    // See HasExplicitTitle. Sticky: once the shell sets a title the
-    // poll leaves it alone for the rest of the tab's life.
-    bool m_hasExplicitTitle{ false };
+    // See TitleSource(). Starts Automatic: nobody has spoken yet, so
+    // the foreground-pid poll owns the header.
+    core::host::TitleSource m_titleSource{ core::host::TitleSource::Automatic() };
 
     // Foreground-pid poll cache. Zero means "not yet resolved".
     uint32_t         m_lastForegroundPid{ 0 };

--- a/App/Windows/MainWindow.xaml.cpp
+++ b/App/Windows/MainWindow.xaml.cpp
@@ -1510,18 +1510,27 @@ namespace winrt::GhosttyWin32::implementation
 
     void MainWindow::SetTabTitleForSurface(ghostty_surface_t surface, std::wstring title)
     {
-        if (auto* t = m_tabs.FindBySurface(surface)) {
-            // A user-chosen name (rename prompt) outranks the shell:
-            // upstream documents the prompt title as overriding any
-            // terminal-set title, and shells re-assert their OSC
-            // title on every prompt — honouring it here would undo
-            // the rename within seconds.
-            if (t->TitleSource().Outranks(core::host::TitleSource::Shell())) return;
-            t->Item().Header(box_value(winrt::hstring(title)));
-            // Once the shell has spoken, the foreground-pid poll
-            // stops overwriting the header for this tab.
-            t->SetTitleSource(core::host::TitleSource::Shell());
+        auto* t = m_tabs.FindBySurface(surface);
+        if (!t) {
+            DEBUG_TRACE(L"Title: SET_TITLE \"%s\" — no tab for surface\n", title.c_str());
+            return;
         }
+
+        // A user-chosen name (rename prompt) outranks the shell:
+        // upstream documents the prompt title as overriding any
+        // terminal-set title, and shells re-assert their OSC
+        // title on every prompt — honouring it here would undo
+        // the rename within seconds.
+        if (t->TitleSource().Outranks(core::host::TitleSource::Shell())) {
+            DEBUG_TRACE(L"Title: SET_TITLE \"%s\" — blocked by user title\n", title.c_str());
+            return;
+        }
+
+        DEBUG_TRACE(L"Title: SET_TITLE \"%s\" — applied\n", title.c_str());
+        t->Item().Header(box_value(winrt::hstring(title)));
+        // Once the shell has spoken, the foreground-pid poll
+        // stops overwriting the header for this tab.
+        t->SetTitleSource(core::host::TitleSource::Shell());
     }
 
     namespace {
@@ -1597,6 +1606,7 @@ namespace winrt::GhosttyWin32::implementation
             auto name = PidToBasename(pid);
             if (name.empty()) continue;
             tab->SetForegroundCache(pid, name);
+            DEBUG_TRACE(L"Title: poll applied \"%s\" (pid %u)\n", name.c_str(), pid);
             try {
                 tab->Item().Header(winrt::box_value(name));
             } catch (winrt::hresult_error const&) {
@@ -1995,7 +2005,10 @@ namespace winrt::GhosttyWin32::implementation
                 // its cache so the next tick rewrites the header
                 // even when the foreground PID hasn't changed.
                 if (self) {
-                    if (auto* tab = self->m_tabs.FindByItem(item)) {
+                    auto* tab = self->m_tabs.FindByItem(item);
+                    DEBUG_TRACE(L"Title: rename empty — reset to automatic (tab %s)\n",
+                                tab ? L"found" : L"NOT found");
+                    if (tab) {
                         tab->SetTitleSource(core::host::TitleSource::Automatic());
                         tab->SetForegroundCache(0, {});
                     }
@@ -2004,7 +2017,10 @@ namespace winrt::GhosttyWin32::implementation
             }
             item.Header(box_value(text));
             if (self) {
-                if (auto* tab = self->m_tabs.FindByItem(item)) {
+                auto* tab = self->m_tabs.FindByItem(item);
+                DEBUG_TRACE(L"Title: rename to \"%s\" (tab %s)\n",
+                            text.c_str(), tab ? L"found" : L"NOT found");
+                if (tab) {
                     // A user title outranks both the foreground-pid
                     // poll AND shell SET_TITLE — shells re-assert
                     // their OSC title constantly, so anything weaker

--- a/App/Windows/MainWindow.xaml.cpp
+++ b/App/Windows/MainWindow.xaml.cpp
@@ -1988,7 +1988,20 @@ namespace winrt::GhosttyWin32::implementation
             if (self) self->m_renamePromptOpen = false;
             if (sender.GetResults() != muxc::ContentDialogResult::Primary) return;
             auto text = input.Text();
-            if (text.empty()) return;
+            if (text.empty()) {
+                // Empty input resets to the automatic title —
+                // upstream's documented prompt behaviour. Hand the
+                // header back to the foreground-pid poll and clear
+                // its cache so the next tick rewrites the header
+                // even when the foreground PID hasn't changed.
+                if (self) {
+                    if (auto* tab = self->m_tabs.FindByItem(item)) {
+                        tab->SetTitleSource(core::host::TitleSource::Automatic());
+                        tab->SetForegroundCache(0, {});
+                    }
+                }
+                return;
+            }
             item.Header(box_value(text));
             if (self) {
                 if (auto* tab = self->m_tabs.FindByItem(item)) {

--- a/App/Windows/MainWindow.xaml.cpp
+++ b/App/Windows/MainWindow.xaml.cpp
@@ -6,6 +6,7 @@
 #include "Windows/TearOut.h"
 #include "Windows/TransparentBackdrop.h"
 #include "Host/KeyModifiers.h"
+#include "Host/TitleSource.h"
 #include "Interop/Encoding.h"
 #include "Display/PhysicalPixels.h"
 #include "Display/PhysicalSizeFactory.h"
@@ -1515,11 +1516,11 @@ namespace winrt::GhosttyWin32::implementation
             // terminal-set title, and shells re-assert their OSC
             // title on every prompt — honouring it here would undo
             // the rename within seconds.
-            if (t->HasUserTitle()) return;
+            if (t->TitleSource().Outranks(core::host::TitleSource::Shell())) return;
             t->Item().Header(box_value(winrt::hstring(title)));
             // Once the shell has spoken, the foreground-pid poll
             // stops overwriting the header for this tab.
-            t->MarkExplicitTitle();
+            t->SetTitleSource(core::host::TitleSource::Shell());
         }
     }
 
@@ -1584,8 +1585,8 @@ namespace winrt::GhosttyWin32::implementation
     {
         for (auto& tab : m_tabs) {
             if (!tab) continue;
-            // Shell-supplied titles are sticky — leave them alone.
-            if (tab->HasExplicitTitle()) continue;
+            // A shell- or user-set title outranks the automatic one.
+            if (tab->TitleSource().Outranks(core::host::TitleSource::Automatic())) continue;
             auto* tc = tab->ActiveControl();
             if (!tc) continue;
             uint32_t pid = tc->Surface().ForegroundPid();
@@ -1987,18 +1988,15 @@ namespace winrt::GhosttyWin32::implementation
             if (self) self->m_renamePromptOpen = false;
             if (sender.GetResults() != muxc::ContentDialogResult::Primary) return;
             auto text = input.Text();
-            // Empty input is treated as cancel: this port has no
-            // inverse of MarkExplicitTitle yet, so "reset to the
-            // automatic title" can't be honoured truthfully.
             if (text.empty()) return;
             item.Header(box_value(text));
             if (self) {
                 if (auto* tab = self->m_tabs.FindByItem(item)) {
-                    // User latch: outranks both the foreground-pid
-                    // poll AND shell SET_TITLE (see HasUserTitle) —
-                    // shells re-assert their OSC title constantly,
-                    // so anything weaker gets undone in seconds.
-                    tab->MarkUserTitle();
+                    // A user title outranks both the foreground-pid
+                    // poll AND shell SET_TITLE — shells re-assert
+                    // their OSC title constantly, so anything weaker
+                    // gets undone in seconds.
+                    tab->SetTitleSource(core::host::TitleSource::User());
                 }
             }
         });

--- a/Core/Core.vcxproj
+++ b/Core/Core.vcxproj
@@ -103,6 +103,7 @@
     <ClInclude Include="Host\EngagementState.h" />
     <ClInclude Include="Host\ImeBuffer.h" />
     <ClInclude Include="Host\KeyModifiers.h" />
+    <ClInclude Include="Host\TitleSource.h" />
     <ClInclude Include="Input\KeyEventTranslator.h" />
     <ClInclude Include="Interop\Encoding.h" />
     <ClInclude Include="Win32\Clipboard.h" />

--- a/Core/Core.vcxproj.filters
+++ b/Core/Core.vcxproj.filters
@@ -72,6 +72,9 @@
     <ClInclude Include="Host\KeyModifiers.h">
       <Filter>Host</Filter>
     </ClInclude>
+    <ClInclude Include="Host\TitleSource.h">
+      <Filter>Host</Filter>
+    </ClInclude>
     <ClInclude Include="Input\KeyEventTranslator.h">
       <Filter>Input</Filter>
     </ClInclude>

--- a/Core/Host/TitleSource.h
+++ b/Core/Host/TitleSource.h
@@ -1,0 +1,48 @@
+#pragma once
+
+namespace core::host {
+
+// Who last named a tab — and therefore who may rename it now.
+//
+// Three writers compete for a tab's header: the foreground-pid poll
+// (automatic process names), the shell (SET_TITLE / SET_TAB_TITLE,
+// i.e. OSC 0/2 or the `set_title` action), and the user (the rename
+// prompt, PROMPT_TITLE). Upstream documents a prompt-set title as
+// overriding any title set by the terminal, and a shell title as
+// winning over the computed one — a strict priority:
+//
+//   Automatic < Shell < User
+//
+// which collapses to one rule at every write site: a writer may set
+// the header only when the current source does not outrank it. Equal
+// rank re-asserts freely (the shell re-sends its OSC title on every
+// prompt, the poll refreshes its own name on process changes) — that
+// is what lets a title ever change at all.
+class TitleSource {
+public:
+    static constexpr TitleSource Automatic() noexcept { return TitleSource(Kind::Automatic); }
+    static constexpr TitleSource Shell() noexcept { return TitleSource(Kind::Shell); }
+    static constexpr TitleSource User() noexcept { return TitleSource(Kind::User); }
+
+    constexpr bool IsAutomatic() const noexcept { return m_kind == Kind::Automatic; }
+    constexpr bool IsShell() const noexcept { return m_kind == Kind::Shell; }
+    constexpr bool IsUser() const noexcept { return m_kind == Kind::User; }
+
+    // The write rule above: true when a title from this source must
+    // not be overwritten by `writer`.
+    constexpr bool Outranks(TitleSource writer) const noexcept {
+        return static_cast<int>(m_kind) > static_cast<int>(writer.m_kind);
+    }
+
+    constexpr bool operator==(TitleSource const&) const noexcept = default;
+
+private:
+    // Enumerator order is the priority order — Outranks compares it.
+    enum class Kind { Automatic, Shell, User };
+
+    constexpr explicit TitleSource(Kind kind) noexcept : m_kind(kind) {}
+
+    Kind m_kind;
+};
+
+}  // namespace core::host

--- a/Tests/Tests.vcxproj
+++ b/Tests/Tests.vcxproj
@@ -161,6 +161,7 @@
     <ClCompile Include="test_ime_buffer.cpp" />
     <ClCompile Include="test_ime_session.cpp" />
     <ClCompile Include="test_engagement_state.cpp" />
+    <ClCompile Include="test_title_source.cpp" />
     <ClCompile Include="test_key_modifiers.cpp" />
     <ClCompile Include="test_encoding.cpp" />
     <ClCompile Include="test_ghostty_config.cpp" />

--- a/Tests/test_title_source.cpp
+++ b/Tests/test_title_source.cpp
@@ -1,0 +1,35 @@
+#include "pch.h"
+#include "../Core/Host/TitleSource.h"
+
+using core::host::TitleSource;
+
+TEST(TitleSourceTest, RanksUserOverShellOverAutomatic) {
+    EXPECT_TRUE(TitleSource::User().Outranks(TitleSource::Shell()));
+    EXPECT_TRUE(TitleSource::User().Outranks(TitleSource::Automatic()));
+    EXPECT_TRUE(TitleSource::Shell().Outranks(TitleSource::Automatic()));
+
+    EXPECT_FALSE(TitleSource::Automatic().Outranks(TitleSource::Shell()));
+    EXPECT_FALSE(TitleSource::Automatic().Outranks(TitleSource::User()));
+    EXPECT_FALSE(TitleSource::Shell().Outranks(TitleSource::User()));
+}
+
+TEST(TitleSourceTest, EqualRankMayReassert) {
+    // The shell re-sends its OSC title on every prompt and the poll
+    // refreshes its own automatic name — an equal writer never blocks.
+    EXPECT_FALSE(TitleSource::Automatic().Outranks(TitleSource::Automatic()));
+    EXPECT_FALSE(TitleSource::Shell().Outranks(TitleSource::Shell()));
+    EXPECT_FALSE(TitleSource::User().Outranks(TitleSource::User()));
+}
+
+TEST(TitleSourceTest, AnswersItsIdentity) {
+    EXPECT_TRUE(TitleSource::Automatic().IsAutomatic());
+    EXPECT_TRUE(TitleSource::Shell().IsShell());
+    EXPECT_TRUE(TitleSource::User().IsUser());
+
+    EXPECT_FALSE(TitleSource::Automatic().IsShell());
+    EXPECT_FALSE(TitleSource::Automatic().IsUser());
+    EXPECT_FALSE(TitleSource::Shell().IsAutomatic());
+
+    EXPECT_EQ(TitleSource::Shell(), TitleSource::Shell());
+    EXPECT_NE(TitleSource::Shell(), TitleSource::User());
+}


### PR DESCRIPTION
## Why

Tab held two sticky bools for its title state — `m_hasUserTitle` and `m_hasExplicitTitle` — that could only latch on. Each write site re-derived the priority between the foreground-pid poll, shell SET_TITLE, and the rename prompt from those bools, `MarkUserTitle` had to know to set both, and "reset to the automatic title" was inexpressible: the rename prompt treated empty input as cancel because the latches had no inverse.

<details><summary>日本語</summary>

Tab はタイトル状態を 2 つの sticky bool (`m_hasUserTitle` / `m_hasExplicitTitle`) で持っていて、一度立つと戻せませんでした。foreground-pid poll・shell SET_TITLE・rename prompt の優先順位を各 write site がこの bool から再構成し、`MarkUserTitle` は両方立てる責務を知っている必要があり、「automatic title へのリセット」は表現不能でした (latch に逆操作が無いため、rename prompt は空入力を cancel 扱い)。

</details>

## What

**`core::host::TitleSource`** (new, with tests): who last named the tab — `Automatic` / `Shell` / `User` factories, `Is*()` predicates, and the one rule every write site asks: `Outranks(writer)`. The priority is upstream's — a prompt-set title overrides any terminal-set title, a shell title overrides the computed one (`Automatic < Shell < User`). Equal rank re-asserts freely, which is what lets a title ever change.

**Tab**: the two bools become one `TitleSource` value (`TitleSource()` / `SetTitleSource()`). Call sites now read as the rule itself:

- SET_TITLE handler: `if (t->TitleSource().Outranks(TitleSource::Shell())) return;` then marks `Shell`.
- pid poll: skips a tab whose source `Outranks(TitleSource::Automatic())`.
- rename prompt: marks `User` — no more "and also set the other latch".

**Rename prompt, empty input = reset** (own commit): with the reset now expressible, match upstream — an empty rename sets the source back to `Automatic` and clears the foreground cache so the next poll tick rewrites the header even when the PID hasn't changed.

<details><summary>日本語</summary>

**`core::host::TitleSource`** (新規、テスト付き): タブを最後に命名したのが誰か — `Automatic` / `Shell` / `User` の factory、`Is*()` 述語、そして全 write site が問う唯一のルール `Outranks(writer)`。優先順位は upstream 準拠 (prompt title は terminal-set title に勝ち、shell title は自動計算に勝つ = `Automatic < Shell < User`)。同順位は自由に上書きでき、これがタイトルが変わりうる理由そのものです。

**Tab**: bool 2 つが `TitleSource` 値 1 つに (`TitleSource()` / `SetTitleSource()`)。call site がルールそのままの読みになります:

- SET_TITLE handler: `Outranks(Shell())` なら skip、書いたら `Shell` をセット
- pid poll: `Outranks(Automatic())` なタブは skip
- rename prompt: `User` をセット — 「もう片方の latch も立てる」が消滅

**rename prompt の空入力 = リセット** (別コミット): リセットが表現可能になったので upstream に合わせ、空リネームで source を `Automatic` に戻し、foreground cache をクリアして PID が変わっていなくても次の poll tick でヘッダを書き直させます。

</details>

## Verification

- [x] Tests green (TitleSourceTest ×3 added)
- [x] Rename still wins over the shell: rename a tab (`prompt_tab_title`) → shell prompt activity does not undo it
- [x] **New**: empty rename hands the title back — rename again, clear the text, confirm with Rename, then press Enter once at the shell prompt → the header returns to the shell's OSC title. (Previously empty input was cancel, so a user title stuck forever.)

**Note found during verification:** the automatic (process-name) writer never fires on Windows today — libghostty's `WindowsPty.getProcessInfo` is a stub returning `null` (`src/pty.zig`), so `ghostty_surface_foreground_pid` is always 0 and the foreground-pid poll skips every tab. Same family as the PWD report stub. The reset is therefore observed through the shell reclaiming the title, not through a process name appearing; the poll path stays wired for the day the stub is implemented.

<details><summary>日本語</summary>

- [ ] Tests が green (TitleSourceTest ×3 追加)
- [ ] rename が shell に勝つのは従来通り: リネーム後、shell のプロンプト活動で戻らない
- [ ] **新規**: 空リネームでタイトルを返す — もう一度リネームして空欄で確定、shell のプロンプトで Enter を 1 回 → ヘッダが shell の OSC title に戻る (旧挙動は空=cancel で user title が永遠に残った)

**検証中の発見:** 自動 (プロセス名) の writer は現状 Windows では一度も発火しない — libghostty の `WindowsPty.getProcessInfo` が `null` を返す stub (`src/pty.zig`) のため `ghostty_surface_foreground_pid` が常に 0 で、foreground-pid poll は全タブを skip する。PWD 報告の stub と同族。よってリセットの観測は「shell が title を取り直す」形で行う。poll 経路は stub 実装の日のために配線を維持。

</details>
