### PR TITLE
Recover the missing scan code so Tab reaches the terminal

### DIFF
--- a/App/Input/TerminalKeyDown.h
+++ b/App/Input/TerminalKeyDown.h
@@ -111,11 +111,11 @@ inline core::input::RawKeyPress TerminalKeyDown::toRawKeyPress(
 {
     auto vk_code   = static_cast<uint32_t>(vk());
     auto scan_code = static_cast<uint32_t>(m_args.KeyStatus().ScanCode);
-    // KeyRoutedEventArgs can arrive with KeyStatus().ScanCode == 0
-    // (observed for Tab, issue #190). ghostty resolves the physical
-    // key from the scan code, so an empty one turns the event into
-    // .unidentified and it encodes nothing — recover the code from
-    // the virtual key instead.
+    // A tunneling PreviewKeyDown delivers its args with
+    // KeyStatus().ScanCode == 0 (observed for Tab, issue #190).
+    // ghostty resolves the physical key from the scan code, so an
+    // empty one turns the event into .unidentified and it encodes
+    // nothing — recover the code from the virtual key instead.
     if (scan_code == 0) {
         scan_code = MapVirtualKeyW(vk_code, MAPVK_VK_TO_VSC);
     }

--- a/App/Input/TerminalKeyDown.h
+++ b/App/Input/TerminalKeyDown.h
@@ -111,11 +111,11 @@ inline core::input::RawKeyPress TerminalKeyDown::toRawKeyPress(
 {
     auto vk_code   = static_cast<uint32_t>(vk());
     auto scan_code = static_cast<uint32_t>(m_args.KeyStatus().ScanCode);
-    // A tunneling PreviewKeyDown delivers its args with
-    // KeyStatus().ScanCode == 0 (observed for Tab, issue #190).
-    // ghostty resolves the physical key from the scan code, so an
-    // empty one turns the event into .unidentified and it encodes
-    // nothing — recover the code from the virtual key instead.
+    // KeyRoutedEventArgs can arrive with KeyStatus().ScanCode == 0
+    // (observed for Tab, issue #190). ghostty resolves the physical
+    // key from the scan code, so an empty one turns the event into
+    // .unidentified and it encodes nothing — recover the code from
+    // the virtual key instead.
     if (scan_code == 0) {
         scan_code = MapVirtualKeyW(vk_code, MAPVK_VK_TO_VSC);
     }

--- a/App/Input/TerminalKeyDown.h
+++ b/App/Input/TerminalKeyDown.h
@@ -111,6 +111,14 @@ inline core::input::RawKeyPress TerminalKeyDown::toRawKeyPress(
 {
     auto vk_code   = static_cast<uint32_t>(vk());
     auto scan_code = static_cast<uint32_t>(m_args.KeyStatus().ScanCode);
+    // A tunneling PreviewKeyDown delivers its args with
+    // KeyStatus().ScanCode == 0 (observed for Tab, issue #190).
+    // ghostty resolves the physical key from the scan code, so an
+    // empty one turns the event into .unidentified and it encodes
+    // nothing — recover the code from the virtual key instead.
+    if (scan_code == 0) {
+        scan_code = MapVirtualKeyW(vk_code, MAPVK_VK_TO_VSC);
+    }
 
     BYTE plain_state[256] = {};
     wchar_t unshifted_chars[4] = {};

--- a/App/Input/TerminalKeyUp.h
+++ b/App/Input/TerminalKeyUp.h
@@ -34,9 +34,15 @@ public:
     {}
 
     core::input::RawKeyRelease toRawKeyRelease() const noexcept {
+        auto scan_code = static_cast<uint32_t>(m_args.KeyStatus().ScanCode);
+        // Tunneling Preview events carry no scan code — same
+        // recovery as TerminalKeyDown::toRawKeyPress (issue #190).
+        if (scan_code == 0) {
+            scan_code = MapVirtualKeyW(static_cast<uint32_t>(vk()), MAPVK_VK_TO_VSC);
+        }
         return core::input::RawKeyRelease{
             .vk_code     = static_cast<uint32_t>(vk()),
-            .scan_code   = static_cast<uint32_t>(m_args.KeyStatus().ScanCode),
+            .scan_code   = scan_code,
             .is_extended = m_args.KeyStatus().IsExtendedKey,
             .shift       = m_shift,
             .ctrl        = m_ctrl,

--- a/App/Input/TerminalKeyUp.h
+++ b/App/Input/TerminalKeyUp.h
@@ -35,8 +35,8 @@ public:
 
     core::input::RawKeyRelease toRawKeyRelease() const noexcept {
         auto scan_code = static_cast<uint32_t>(m_args.KeyStatus().ScanCode);
-        // Same scan-code recovery as TerminalKeyDown::toRawKeyPress
-        // (issue #190).
+        // Tunneling Preview events carry no scan code — same
+        // recovery as TerminalKeyDown::toRawKeyPress (issue #190).
         if (scan_code == 0) {
             scan_code = MapVirtualKeyW(static_cast<uint32_t>(vk()), MAPVK_VK_TO_VSC);
         }

--- a/App/Input/TerminalKeyUp.h
+++ b/App/Input/TerminalKeyUp.h
@@ -35,8 +35,8 @@ public:
 
     core::input::RawKeyRelease toRawKeyRelease() const noexcept {
         auto scan_code = static_cast<uint32_t>(m_args.KeyStatus().ScanCode);
-        // Tunneling Preview events carry no scan code — same
-        // recovery as TerminalKeyDown::toRawKeyPress (issue #190).
+        // Same scan-code recovery as TerminalKeyDown::toRawKeyPress
+        // (issue #190).
         if (scan_code == 0) {
             scan_code = MapVirtualKeyW(static_cast<uint32_t>(vk()), MAPVK_VK_TO_VSC);
         }

--- a/App/Terminal/Overlays/SearchOverlay.xaml.cpp
+++ b/App/Terminal/Overlays/SearchOverlay.xaml.cpp
@@ -115,9 +115,18 @@ namespace winrt::GhosttyWin32::implementation
     bool SearchOverlay::HoldsKeyboardFocus()
     {
         if (!m_open) return false;
-        auto input = Input();
-        if (!input) return false;
-        return input.FocusState() != mux::FocusState::Unfocused;
+
+        // Focus anywhere inside the overlay counts, not just the
+        // input box: Tab navigation moves focus onto the prev /
+        // next / close buttons, and if only the box counted the
+        // terminal would reclaim Tab the moment a button holds
+        // focus — freezing the navigation there (found verifying
+        // #190).
+        auto const holds = [](mux::Controls::Control const& c) {
+            return c && c.FocusState() != mux::FocusState::Unfocused;
+        };
+        return holds(Input()) || holds(PrevButton())
+            || holds(NextButton()) || holds(CloseButton());
     }
 
     bool SearchOverlay::FocusInput()

--- a/App/Terminal/SurfaceHost.cpp
+++ b/App/Terminal/SurfaceHost.cpp
@@ -7,6 +7,7 @@
 #include "Input/TerminalKeyUp.h"
 #include "Display/PhysicalPixels.h"
 #include "Win32/Clipboard.h"
+#include "Win32/DebugTrace.h"
 #include <microsoft.ui.xaml.media.dxinterop.h>
 #include <dxgi1_3.h>
 
@@ -325,6 +326,11 @@ namespace winrt::GhosttyWin32::implementation
     void SurfaceHost::OnKeyDown(muxi::KeyRoutedEventArgs const& args)
     {
         if (!m_surface) return;
+        if (args.Key() == winrt::Windows::System::VirtualKey::Tab) {
+            DEBUG_TRACE(L"Key: Tab in OnKeyDown owns=%d handled=%d\n",
+                        TerminalOwnsInput() ? 1 : 0,
+                        args.Handled() ? 1 : 0);
+        }
         // While a sibling overlay owns the keyboard (the search box),
         // never forward to the pty — its keystrokes bubble up through
         // the composite to here as well (#171 review). Left unhandled

--- a/App/Terminal/SurfaceHost.cpp
+++ b/App/Terminal/SurfaceHost.cpp
@@ -372,7 +372,14 @@ namespace winrt::GhosttyWin32::implementation
         char textBuf[16] = {};
         auto raw = key.toRawKeyPress(textBuf, sizeof(textBuf));
         auto keyEvent = core::input::Translate(raw);
-        m_surface.Key(keyEvent);
+        bool consumed = m_surface.Key(keyEvent);
+        if (args.Key() == winrt::Windows::System::VirtualKey::Tab) {
+            DEBUG_TRACE(L"Key: Tab sent keycode=0x%X mods=0x%X text=%d -> consumed=%d\n",
+                        keyEvent.keycode,
+                        static_cast<unsigned>(keyEvent.mods),
+                        keyEvent.text ? 1 : 0,
+                        consumed ? 1 : 0);
+        }
 
         Tick();
         args.Handled(true);

--- a/App/Terminal/TerminalControl.xaml.cpp
+++ b/App/Terminal/TerminalControl.xaml.cpp
@@ -2,6 +2,7 @@
 #include "Terminal/TerminalControl.xaml.h"
 #include "resource.h"
 #include "Interop/Encoding.h"
+#include "Win32/DebugTrace.h"
 #include <algorithm>
 #if __has_include("TerminalControl.g.cpp")
 #include "TerminalControl.g.cpp"
@@ -102,13 +103,28 @@ namespace winrt::GhosttyWin32::implementation
         // while focus is inside us, so they feed the host directly
         // without an ActiveControl() lookup. The host marks handled
         // keys, which in particular prevents the TabView's built-in
-        // keybindings from also acting on the already-routed key —
-        // and, for Tab, cancels XAML's focus navigation so the key
-        // stays a terminal keystroke (issue #190).
+        // keybindings from also acting on the already-routed key.
         KeyDown([weakSelf](auto&&, muxi::KeyRoutedEventArgs const& args) {
             if (auto self = weakSelf.get()) self->m_host->OnKeyDown(args);
         });
         KeyUp([weakSelf](auto&&, muxi::KeyRoutedEventArgs const& args) {
+            if (auto self = weakSelf.get()) self->m_host->OnKeyUp(args);
+        });
+
+        // Tab alone rides the tunneling Preview events: XAML claims
+        // Tab for focus navigation, so by the bubbling KeyDown above
+        // it can already be gone (issue #190). PreviewKeyDown fires
+        // before that processing; the host marks the key handled,
+        // which cancels the focus move and keeps Tab a terminal
+        // keystroke. Every other key stays on the plain path so the
+        // framework keeps its accelerators and navigation.
+        PreviewKeyDown([weakSelf](auto&&, muxi::KeyRoutedEventArgs const& args) {
+            if (args.Key() != winrt::Windows::System::VirtualKey::Tab) return;
+            DEBUG_TRACE(L"Key: Tab preview down\n");
+            if (auto self = weakSelf.get()) self->m_host->OnKeyDown(args);
+        });
+        PreviewKeyUp([weakSelf](auto&&, muxi::KeyRoutedEventArgs const& args) {
+            if (args.Key() != winrt::Windows::System::VirtualKey::Tab) return;
             if (auto self = weakSelf.get()) self->m_host->OnKeyUp(args);
         });
 

--- a/App/Terminal/TerminalControl.xaml.cpp
+++ b/App/Terminal/TerminalControl.xaml.cpp
@@ -2,6 +2,7 @@
 #include "Terminal/TerminalControl.xaml.h"
 #include "resource.h"
 #include "Interop/Encoding.h"
+#include "Win32/DebugTrace.h"
 #include <algorithm>
 #if __has_include("TerminalControl.g.cpp")
 #include "TerminalControl.g.cpp"
@@ -107,6 +108,23 @@ namespace winrt::GhosttyWin32::implementation
             if (auto self = weakSelf.get()) self->m_host->OnKeyDown(args);
         });
         KeyUp([weakSelf](auto&&, muxi::KeyRoutedEventArgs const& args) {
+            if (auto self = weakSelf.get()) self->m_host->OnKeyUp(args);
+        });
+
+        // Tab alone rides the tunneling Preview events: XAML claims
+        // Tab for focus navigation, so by the bubbling KeyDown above
+        // it can already be gone (issue #190). PreviewKeyDown fires
+        // before that processing; the host marks the key handled,
+        // which cancels the focus move and keeps Tab a terminal
+        // keystroke. Every other key stays on the plain path so the
+        // framework keeps its accelerators and navigation.
+        PreviewKeyDown([weakSelf](auto&&, muxi::KeyRoutedEventArgs const& args) {
+            if (args.Key() != winrt::Windows::System::VirtualKey::Tab) return;
+            DEBUG_TRACE(L"Key: Tab preview down\n");
+            if (auto self = weakSelf.get()) self->m_host->OnKeyDown(args);
+        });
+        PreviewKeyUp([weakSelf](auto&&, muxi::KeyRoutedEventArgs const& args) {
+            if (args.Key() != winrt::Windows::System::VirtualKey::Tab) return;
             if (auto self = weakSelf.get()) self->m_host->OnKeyUp(args);
         });
 

--- a/App/Terminal/TerminalControl.xaml.cpp
+++ b/App/Terminal/TerminalControl.xaml.cpp
@@ -2,7 +2,6 @@
 #include "Terminal/TerminalControl.xaml.h"
 #include "resource.h"
 #include "Interop/Encoding.h"
-#include "Win32/DebugTrace.h"
 #include <algorithm>
 #if __has_include("TerminalControl.g.cpp")
 #include "TerminalControl.g.cpp"
@@ -103,28 +102,13 @@ namespace winrt::GhosttyWin32::implementation
         // while focus is inside us, so they feed the host directly
         // without an ActiveControl() lookup. The host marks handled
         // keys, which in particular prevents the TabView's built-in
-        // keybindings from also acting on the already-routed key.
+        // keybindings from also acting on the already-routed key —
+        // and, for Tab, cancels XAML's focus navigation so the key
+        // stays a terminal keystroke (issue #190).
         KeyDown([weakSelf](auto&&, muxi::KeyRoutedEventArgs const& args) {
             if (auto self = weakSelf.get()) self->m_host->OnKeyDown(args);
         });
         KeyUp([weakSelf](auto&&, muxi::KeyRoutedEventArgs const& args) {
-            if (auto self = weakSelf.get()) self->m_host->OnKeyUp(args);
-        });
-
-        // Tab alone rides the tunneling Preview events: XAML claims
-        // Tab for focus navigation, so by the bubbling KeyDown above
-        // it can already be gone (issue #190). PreviewKeyDown fires
-        // before that processing; the host marks the key handled,
-        // which cancels the focus move and keeps Tab a terminal
-        // keystroke. Every other key stays on the plain path so the
-        // framework keeps its accelerators and navigation.
-        PreviewKeyDown([weakSelf](auto&&, muxi::KeyRoutedEventArgs const& args) {
-            if (args.Key() != winrt::Windows::System::VirtualKey::Tab) return;
-            DEBUG_TRACE(L"Key: Tab preview down\n");
-            if (auto self = weakSelf.get()) self->m_host->OnKeyDown(args);
-        });
-        PreviewKeyUp([weakSelf](auto&&, muxi::KeyRoutedEventArgs const& args) {
-            if (args.Key() != winrt::Windows::System::VirtualKey::Tab) return;
             if (auto self = weakSelf.get()) self->m_host->OnKeyUp(args);
         });
 


### PR DESCRIPTION
## Why

Fixes #190: the Tab key never reaches the terminal, on every build.

The delivery chain was never the problem — the bubbling `KeyDown` receives Tab and the host marks it handled. What was broken is the event itself: WinUI delivers Tab's `KeyRoutedEventArgs` with `KeyStatus().ScanCode == 0`. ghostty resolves the physical key from the scan code, so the event became `.unidentified` with no text, encoded nothing, and was silently dropped — the debug trace showed `keycode=0x0 → consumed=0`.

<details><summary>日本語</summary>

#190 の修正: Tab キーがどのビルドでも terminal に届かない問題。

配達経路は最初から無実でした — bubbling `KeyDown` は Tab を受け取っていて、host は handled も立てています。壊れていたのはイベントの中身: WinUI は Tab の `KeyRoutedEventArgs` を `KeyStatus().ScanCode == 0` で寄越します。ghostty は scan code から物理キーを解決するため、イベントは text 無しの `.unidentified` になり、何もエンコードされず黙って捨てられていました (debug trace で `keycode=0x0 → consumed=0` を確認)。

</details>

## What

- **Scan-code recovery**: when `KeyStatus()` carries no scan code, `TerminalKeyDown` / `TerminalKeyUp` recover it with `MapVirtualKeyW(vk, MAPVK_VK_TO_VSC)`. That is the whole fix — after it, the trace reads `keycode=0xF → consumed=1` and Tab types, completes, and indents everywhere. `ctrl+tab` / `ctrl+shift+tab` also flow through this path into ghostty's default `next_tab` / `previous_tab` keybinds.
- **Search overlay keyboard ownership** (found verifying this): `HoldsKeyboardFocus` only counted the input box, so the moment Tab navigation moved focus onto the overlay's prev / next / close buttons the terminal reclaimed Tab and navigation froze on the first button. Any focused control inside the overlay now counts.
- **`Key:` debug traces** on the key path (Tab arrival, the `ghostty_surface_key` verdict), following the `Title:` precedent — this bug was invisible without them.

A tunneling `PreviewKeyDown` delivery layer was tried first and removed again once the scan-code recovery proved sufficient on its own (the intermediate commits tell that story; squash hides it).

<details><summary>日本語</summary>

- **scan code 復元**: `KeyStatus()` が scan code を持たないとき、`TerminalKeyDown` / `TerminalKeyUp` が `MapVirtualKeyW(vk, MAPVK_VK_TO_VSC)` で復元します。修正はこれが全てで、適用後は trace が `keycode=0xF → consumed=1` になり、Tab は補完・インデントとも全所で動きます。`ctrl+tab` / `ctrl+shift+tab` も同じ経路で ghostty デフォルトの `next_tab` / `previous_tab` keybind に流れます。
- **検索オーバーレイのキーボード所有判定** (本検証中に発見): `HoldsKeyboardFocus` が入力ボックスしか見ておらず、Tab ナビでフォーカスが prev / next / close ボタンに移った瞬間に terminal が Tab を取り返し、ナビが最初のボタンで凍っていました。オーバーレイ内のどのコントロールがフォーカスを持っていても所有扱いに。
- **`Key:` debug trace** をキー経路に追加 (Tab の到達、`ghostty_surface_key` の判定)。`Title:` の前例に倣ったもので、このバグはこれ無しでは不可視でした。

tunneling `PreviewKeyDown` による配達層を先に試しましたが、scan code 復元だけで十分と実証されたため撤去しています (経緯は中間 commit に残り、squash で畳まれます)。

</details>

## Verification

- [x] pwsh: `cd ` + Tab → completion fires, repeated Tab cycles
- [x] Shift+Tab → backwards completion
- [x] nvim **insert mode**: Tab inserts indentation (normal-mode Tab has no visible effect — that false negative cost us a round trip)
- [x] ctrl+tab / ctrl+shift+tab switch tabs via ghostty keybinds (`mods=0x2 / 0x3, consumed=1` in the trace)
- [x] Search bar focused: Tab cycles Input → Prev → Next → Close inside the overlay, never reaching the pty (`owns=0` traces)
- [x] Split panes: Tab types only into the focused pane

<details><summary>日本語</summary>

- [x] pwsh: `cd ` + Tab で補完、連打でサイクル
- [x] Shift+Tab で逆方向補完
- [x] nvim の **insert mode** で Tab がインデント (normal mode の Tab は見た目の効果が無い — この誤観測で 1 往復無駄にした教訓を記録)
- [x] ctrl+tab / ctrl+shift+tab が ghostty keybind 経由でタブ切替 (trace で `mods=0x2 / 0x3, consumed=1`)
- [x] 検索バーにフォーカス中: Tab がオーバーレイ内 (Input → Prev → Next → Close) を巡回し、pty に漏れない (`owns=0` trace)
- [x] split 時、Tab はフォーカス中の pane にだけ入る

</details>
