### PR TITLE
Build the release branch as main plus one squash of dev

### DIFF
--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -105,7 +105,7 @@ merge → 自動 tag v0.3.1 → 公開
 - 各バージョンが「その時点で released な内容」と 1:1 で対応 (バージョン番号で何が入ってるか辿れる)
 - 「PR 開いた後に dev が動いて branch を更新する」みたいな複雑な運用が発生しない
 
-なお release PR open 中も **dev は普通に動かして OK**。release branch は dev の snapshot を取った時点で固定されるので、後から dev に入った修正の影響を受けない。次の patch bump (例: 0.3.1) のための fix を dev に積んだり、`v0.3.1-rc1` タグを並行で切ったりも自由。リリースサイクル間に depend がないので、v0.3.0 リリース直後に v0.3.1 をすぐ出せる構成にできる。
+なお release PR open 中も **dev は普通に動かして OK**。release branch は作成時点の dev の内容を 1 commit に畳んだもの (main + squash) で固定されるので、後から dev に入った修正の影響を受けない。次の patch bump (例: 0.3.1) のための fix を dev に積んだり、`v0.3.1-rc1` タグを並行で切ったりも自由。リリースサイクル間に depend がないので、v0.3.0 リリース直後に v0.3.1 をすぐ出せる構成にできる。
 
 ### semver の bump 指針
 

--- a/.github/workflows/open-release-pr.yml
+++ b/.github/workflows/open-release-pr.yml
@@ -1,8 +1,15 @@
 name: Open release PR
 
-# Cuts a "release/vX.Y.Z" branch from `dev` HEAD and opens a PR against
-# `main`. Triggered manually from the Actions tab when ready to ship a
-# production release.
+# Builds a "release/vX.Y.Z" branch as `main` plus one squash commit of
+# `dev` and opens a PR against `main`. Triggered manually from the
+# Actions tab when ready to ship a production release.
+#
+# The branch is deliberately NOT a snapshot of dev HEAD: main only ever
+# receives squash commits, so dev's individual commits are never its
+# ancestors and a snapshot branch drags the whole accumulated dev
+# history into the PR's commit list (every release PR showed 100+
+# commits). Squashing here keeps the PR at main + 1 commit while the
+# tree stays identical to dev HEAD.
 #
 # RC tags (vX.Y.Z-rcN) are intentionally NOT supported here — they're
 # created with `git tag` directly on `dev` per the model in
@@ -69,10 +76,20 @@ jobs:
             exit 1
           fi
 
-          # Push current dev HEAD as the release branch. From this point
-          # the branch is a frozen snapshot — dev can keep moving.
-          git push origin "HEAD:refs/heads/$BRANCH"
-          echo "Pushed branch $BRANCH at $(git rev-parse --short HEAD)"
+          # Build the branch as main + one squash commit of dev (see the
+          # header comment for why). The post-release sync keeps dev a
+          # superset of main, so the squash merge is conflict-free; if
+          # main ever gains a commit dev doesn't have, this step fails
+          # loudly and the operator reconciles first. From this point
+          # the branch is frozen — dev can keep moving.
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git fetch origin main
+          git checkout -b "$BRANCH" origin/main
+          git merge --squash origin/dev
+          git commit -m "Release v$VERSION"
+          git push origin "$BRANCH"
+          echo "Pushed branch $BRANCH at $(git rev-parse --short HEAD) (tree of dev $(git rev-parse --short origin/dev))"
 
       - name: Generate change list
         id: changes
@@ -105,9 +122,11 @@ jobs:
           fi
 
           if [[ -n "$prev_head" ]]; then
-            echo "Enumerating PRs in $prev_head..HEAD (since $prev_tag)"
+            # Walk dev, not the release branch: the branch is main + one
+            # squash commit, so the per-PR history only exists on dev.
+            echo "Enumerating PRs in $prev_head..origin/dev (since $prev_tag)"
             notes="## What's Changed"
-            for n in $(git log --first-parent --format='%s' "$prev_head..HEAD" \
+            for n in $(git log --first-parent --format='%s' "$prev_head..origin/dev" \
                 | grep -oE '\(#[0-9]+\)$' | tr -d '(#)' | sort -n || true); do
               notes+=$'\n'"$(gh pr view "$n" --json number,title,author --jq \
                 '"* \(.title) by @\(.author.login) in https://github.com/'"${GITHUB_REPOSITORY}"'/pull/\(.number)"')"
@@ -149,7 +168,7 @@ jobs:
 
           ---
 
-          このブランチは \`dev\` の HEAD をスナップショットしたもの。マージで自動的に
+          このブランチは \`main\` に \`dev\` との差分を 1 commit に畳んで載せたもの (tree は \`dev\` HEAD と同一)。マージで自動的に
           \`v$VERSION\` タグが \`main\` に打たれて \`release.yml\` が走る。
 
           See [.github/RELEASING.md](.github/RELEASING.md) for the full release procedure.


### PR DESCRIPTION
## Why

Every release PR's commit list shows the entire accumulated dev history (100+ commits, capped by the UI). main only receives squash commits, so dev's individual commits are never its ancestors — a release branch cut as a dev snapshot brings all of them along, every time, and the list keeps growing with each release.

<details><summary>日本語</summary>

リリース PR のコミット一覧に、積もった dev の全履歴 (100+ commit、UI 上限で切られる) が毎回表示される問題。main は squash コミットしか受け取らないため dev の個々のコミットは main の祖先に永遠にならず、dev スナップショットで切った release ブランチは毎回それを全部引き連れてくる (リリースごとに増え続ける)。

</details>

## What

`open-release-pr.yml` builds the release branch as **main + one squash commit of dev** instead of a dev snapshot:

- The PR shows 1 commit and the exact content diff; the tree is identical to dev HEAD, so the squash-merge result on main is unchanged.
- The change-list step now walks `$prev_head..origin/dev` instead of `..HEAD` — the per-PR history only exists on dev, so walking the new 1-commit branch would have produced empty notes.
- The post-release sync keeps dev a superset of main, so the squash merge is conflict-free; if main ever gains a commit dev lacks, the step fails loudly for the operator to reconcile.
- RELEASING.md wording updated to match.
- Bonus (own commit): `release.yml`'s Installation paragraph was column-wrapped in the YAML, and GitHub renders newlines in release bodies as line breaks — mid-sentence breaks on every release page. Unwrapped to one line per paragraph.

Verification plan: close the current release PR, delete its branch, and re-run the workflow for v0.8.1 — the regenerated PR should show 1 commit, the same file diff, and the same 19-entry change list.

<details><summary>日本語</summary>

`open-release-pr.yml` が release ブランチを dev スナップショットではなく **main + dev の squash 1 commit** で作るように:

- PR は 1 commit + 正確な内容差分の表示になる。tree は dev HEAD と同一なので、main への squash マージ結果は従来と不変
- change list の列挙を `$prev_head..HEAD` → `$prev_head..origin/dev` に変更 — PR 単位の履歴は dev にしか無いため、新しい 1 commit ブランチを歩くとノートが空になるのを回避
- post-release sync が dev ⊇ main を保つので squash は無衝突。main が dev に無いコミットを持った場合はこのステップが明示的に失敗し、オペレータが先に整合させる
- RELEASING.md の文言も実態に合わせて更新
- おまけ (別 commit): `release.yml` の Installation 段落が YAML 内で桁折り返されていて、GitHub の release 本文は改行を line break として描画するため文中で不自然に折れていた。段落 1 行に展開。

検証計画: 現行のリリース PR をクローズしてブランチを削除し、v0.8.1 で workflow を再実行 — 再生成された PR が「1 commit + 同じファイル差分 + 同じ 19 件の change list」になることを確認。

</details>
