### PR TITLE
Unwrap the hard-wrapped installation paragraph in release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -273,15 +273,10 @@ jobs:
 
             ## Installation
 
-            Signed only with a self-signed publisher certificate (`CN=i999rri`)
-            — an established CA / OSS Foundation signature isn't in place yet
-            (see [#46](https://github.com/${{ github.repository }}/issues/46)),
-            so Windows requires the certificate to be trusted before the MSIX
-            will install. Manual install is the only supported path:
+            Signed only with a self-signed publisher certificate (`CN=i999rri`) — an established CA / OSS Foundation signature isn't in place yet (see [#46](https://github.com/${{ github.repository }}/issues/46)), so Windows requires the certificate to be trusted before the MSIX will install. Manual install is the only supported path:
 
             1. Download `Ghostty.cer` and the `.msix` from the assets above
             2. Trust the certificate (Local Machine → Trusted People store)
             3. Double-click the `.msix` to install
 
-            📖 Detailed steps + troubleshooting:
-            [docs/INSTALL.md](https://github.com/${{ github.repository }}/blob/main/docs/INSTALL.md)
+            📖 Detailed steps + troubleshooting: [docs/INSTALL.md](https://github.com/${{ github.repository }}/blob/main/docs/INSTALL.md)


### PR DESCRIPTION
## Why

GitHub renders newlines in release bodies as line breaks, so the column-wrapped YAML text in `release.yml`'s Installation section showed up with mid-sentence breaks on every release page.

<details><summary>日本語</summary>

GitHub は release 本文の改行を line break として描画するため、`release.yml` の Installation 節の桁折り返しがそのまま文中の不自然な折れとして毎リリース表示されていました。

</details>

## What

One line per paragraph — content unchanged. (This was meant to ride #202 but the merge won the race.)

<details><summary>日本語</summary>

段落 1 行に展開 — 内容は不変。(#202 に載せる予定だったのがマージと入れ違いになった分です。)

</details>