### PR TITLE
State the config-ownership intent at the clone and the free

### DIFF
--- a/Core/Ghostty/Actions/Actions.cpp
+++ b/Core/Ghostty/Actions/Actions.cpp
@@ -569,9 +569,11 @@ bool Actions::OnReloadConfig(bool soft) {
 }
 
 bool Actions::OnConfigChange(ghostty_config_t newCfg) {
-    // Clone here because ghostty owns the incoming pointer.
-    // The view takes ownership of the clone and either swaps it
-    // in or frees it on the UI thread.
+    // Take ownership by cloning: ghostty's pointer is only
+    // guaranteed alive during this callback, while the host both
+    // crosses to the UI thread asynchronously and keeps reading
+    // the config until the next reload. The view holds the clone
+    // from here on and frees it when the one after replaces it.
     if (!newCfg) return true;
     auto cloned = ghostty_config_clone(newCfg);
     if (!cloned) return true;

--- a/Core/Ghostty/App.h
+++ b/Core/Ghostty/App.h
@@ -84,7 +84,9 @@ public:
         if (m_app) ghostty_app_set_color_scheme(m_app, scheme);
     }
 
-    // Replace the owned config with newConfig and free the old one.
+    // Replace the owned config with newConfig and free the old one
+    // — the freeing half of the ownership taken at the clone in
+    // Actions::OnConfigChange.
     // Used by the reload_config path: the worker thread parses a fresh
     // config off-thread, then the UI thread hands the result here AFTER
     // ghostty_app_update_config has applied it to the app — at which


### PR DESCRIPTION
## Why

The config lifetime contract (the host owns a clone from CONFIG_CHANGE and frees it on the next replace) was implicit — spread across a clone in `Actions::OnConfigChange` and a free in `App::ReplaceConfig` with no comment tying them together. The value_c use-after-free investigation (i999rri/ghostty#48) made the pairing worth naming.

<details><summary>日本語</summary>

config の寿命契約 (host は CONFIG_CHANGE で clone を所有し、次の replace で解放する) が暗黙のままで、`Actions::OnConfigChange` の clone と `App::ReplaceConfig` の free に散らばっていて対応関係を示すコメントがありませんでした。value_c の use-after-free 調査 (i999rri/ghostty#48) でこの対に名前を付ける価値が確認できたため明文化します。

</details>

## What

Comments only, no behavior change: the clone site states why ownership is taken (callback-scoped pointer, async thread hop, reads until the next reload); the free site names itself as the owning half's duty and cross-references the clone.

<details><summary>日本語</summary>

コメントのみで挙動変更なし: clone 側に所有権を取る理由 (コールバック限定のポインタ / 非同期スレッド跨ぎ / 次の reload まで読み続ける) を、free 側に「clone で取った所有の返済側」であることと相互参照を記載。

</details>